### PR TITLE
fix: "Error: Failed to get response" after /clear

### DIFF
--- a/frontend/src/components/ChatPage.tsx
+++ b/frontend/src/components/ChatPage.tsx
@@ -477,6 +477,9 @@ export function ChatPage() {
   // Ref to track previous isLoading state for detecting when AI finishes responding
   const wasLoadingRef = useRef(false);
 
+  // Ref to suppress error message when abort is triggered by /clear
+  const clearAbortRef = useRef(false);
+
   // Show input notification when AI finishes responding (isLoading changes from true to false)
   useEffect(() => {
     // Update the ref to track previous state
@@ -688,13 +691,18 @@ export function ChatPage() {
           if (shouldAbort) break;
         }
       } catch (error) {
-        console.error("Failed to send message:", error);
-        addMessage({
-          type: "chat",
-          role: "assistant",
-          content: "Error: Failed to get response",
-          timestamp: Date.now(),
-        });
+        // Skip error message when abort was triggered by /clear
+        if (clearAbortRef.current) {
+          clearAbortRef.current = false;
+        } else {
+          console.error("Failed to send message:", error);
+          addMessage({
+            type: "chat",
+            role: "assistant",
+            content: "Error: Failed to get response",
+            timestamp: Date.now(),
+          });
+        }
       } finally {
         // Note: Input notification will be shown via useEffect when isLoading becomes false.
         // Don't reset notificationTriggeredRef here - it's needed by useEffect to determine
@@ -759,11 +767,13 @@ export function ChatPage() {
   // Clear conversation handler
   const handleClearConversation = useCallback(() => {
     // Abort any in-flight request to prevent stale messages
+    clearAbortRef.current = true;
     if (isRemoteWorkspace && remoteChat.session) {
       remoteChat.abortCurrentRequest();
     } else {
       abortRequest(currentRequestId, isLoading, resetRequestState);
     }
+    resetRequestState();
     setMessages([]);
     setCurrentSessionId(null);
     setHasShownInitMessage(false);

--- a/frontend/src/components/ChatPage.tsx
+++ b/frontend/src/components/ChatPage.tsx
@@ -692,9 +692,7 @@ export function ChatPage() {
         }
       } catch (error) {
         // Skip error message when abort was triggered by /clear
-        if (clearAbortRef.current) {
-          clearAbortRef.current = false;
-        } else {
+        if (!clearAbortRef.current) {
           console.error("Failed to send message:", error);
           addMessage({
             type: "chat",
@@ -704,6 +702,8 @@ export function ChatPage() {
           });
         }
       } finally {
+        clearAbortRef.current = false;
+
         // Note: Input notification will be shown via useEffect when isLoading becomes false.
         // Don't reset notificationTriggeredRef here - it's needed by useEffect to determine
         // whether a permission/plan notification was triggered during this session.

--- a/frontend/src/components/ChatPage.tsx
+++ b/frontend/src/components/ChatPage.tsx
@@ -21,7 +21,6 @@ import { useExpandThinking } from "../hooks/useSettings";
 import { useModel } from "../hooks/useModel";
 import { useOpenAceSessionTracker } from "../hooks/useOpenAceSessionTracker";
 import { useTabNotification } from "../hooks/useTabNotification";
-import { generateId } from "../utils/id";
 import { calculateTokenUsage, calculateContextBreakdown } from "../utils/tokenUsage";
 import type { ContextUsageData } from "../utils/tokenUsage";
 import { ContextUsagePanel } from "./chat/ContextUsagePanel";
@@ -759,22 +758,25 @@ export function ChatPage() {
 
   // Clear conversation handler
   const handleClearConversation = useCallback(() => {
-    // Clear messages and generate a new session ID to start fresh
-    // The old history files remain on server but won't be loaded
+    // Abort any in-flight request to prevent stale messages
+    if (isRemoteWorkspace && remoteChat.session) {
+      remoteChat.abortCurrentRequest();
+    } else {
+      abortRequest(currentRequestId, isLoading, resetRequestState);
+    }
     setMessages([]);
-    setCurrentSessionId(generateId());
+    setCurrentSessionId(null);
     setHasShownInitMessage(false);
     setHasReceivedInit(false);
     setShowClearConfirm(false);
     navigate({ search: "" });
-    // Add a system message to indicate context was cleared
     addMessage({
       type: "chat",
       role: "assistant",
       content: t("slashCommands.contextCleared"),
       timestamp: Date.now(),
     });
-  }, [setMessages, setCurrentSessionId, setHasShownInitMessage, setHasReceivedInit, addMessage, t, navigate, generateId]);
+  }, [setMessages, setCurrentSessionId, setHasShownInitMessage, setHasReceivedInit, addMessage, t, navigate, abortRequest, currentRequestId, isLoading, resetRequestState, isRemoteWorkspace, remoteChat.abortCurrentRequest, remoteChat.session]);
 
   // Permission request handlers
   const handlePermissionAllow = useCallback(async () => {


### PR DESCRIPTION
## Summary

- Fix `/clear` generating a fake session ID (`generateId()`) that the backend mapped to `--resume`, causing CLI failure on non-existent session
- Abort in-flight requests during `/clear` to prevent stale messages
- Suppress error message when abort is triggered by `/clear` (avoids "Failed to get response" appearing after clear)
- Reset `clearAbortRef` in `finally` block to prevent swallowing future errors
- Call `resetRequestState()` unconditionally as a defensive fallback
- Remove unused `generateId` import from ChatPage.tsx

Closes #90

## Test plan

- [ ] Start dev server, send a message, confirm session establishes
- [ ] Execute `/clear`, confirm context cleared message appears
- [ ] Send another message, confirm normal response without error
- [ ] During a streaming response, execute `/clear`, confirm request is aborted and subsequent messages work
- [ ] After `/clear` + abort, trigger a real error and confirm error message is displayed (not swallowed)
- [ ] Run lint check — no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)