### PR TITLE
fix: project deletion and clear conversation fixes

### DIFF
--- a/backend/app.ts
+++ b/backend/app.ts
@@ -49,11 +49,12 @@ export function createApp(
   const pendingPermissions = new Map<string, PendingPermission>();
 
   // CORS middleware
+  // allowMethods intentionally omitted to use Hono defaults
+  // (GET, HEAD, PUT, POST, DELETE, PATCH, OPTIONS)
   app.use(
     "*",
     cors({
       origin: "*",
-      allowMethods: ["GET", "POST", "OPTIONS"],
       allowHeaders: ["Content-Type"],
     }),
   );

--- a/backend/handlers/projects.test.ts
+++ b/backend/handlers/projects.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { handleDeleteProjectRequest } from "./projects.ts";
+
+// Mock fs utilities
+const mockStat = vi.fn();
+const mockRemove = vi.fn();
+
+vi.mock("../utils/fs.ts", () => ({
+  readDir: vi.fn(),
+  stat: (...args: unknown[]) => mockStat(...args),
+  remove: (...args: unknown[]) => mockRemove(...args),
+}));
+
+// Mock os utilities
+vi.mock("../utils/os.ts", () => ({
+  getHomeDir: () => "/home/testuser",
+}));
+
+// Mock logger
+vi.mock("../utils/logger.ts", () => ({
+  logger: {
+    api: {
+      info: vi.fn(),
+      error: vi.fn(),
+    },
+  },
+}));
+
+// Mock projectMapping
+vi.mock("../utils/projectMapping.ts", () => ({
+  decodeProjectPath: vi.fn(),
+}));
+
+function createMockContext(param: string) {
+  return {
+    req: {
+      param: (name: string) => (name === "encodedProjectName" ? param : undefined),
+    },
+    json: vi.fn((data: unknown, status?: number) => ({ data, status })),
+  } as unknown as Parameters<typeof handleDeleteProjectRequest>[0];
+}
+
+describe("handleDeleteProjectRequest", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockStat.mockResolvedValue({ isDirectory: true });
+    mockRemove.mockResolvedValue(undefined);
+  });
+
+  it("should reject path traversal with ..", async () => {
+    const c = createMockContext("..");
+    const result = await handleDeleteProjectRequest(c);
+    const response = result as { data: { error: string }; status?: number };
+    expect(response.data.error).toBe("Invalid project name");
+  });
+
+  it("should allow ..-prefix names that resolve inside projectsDir", async () => {
+    // "..other" resolves to projectsDir/..other which stays inside projectsDir
+    // This is NOT a traversal — it's a valid (though unusual) directory name
+    const c = createMockContext("..other");
+    const result = await handleDeleteProjectRequest(c);
+    const response = result as { data: { success: boolean } };
+    // Stat mock returns isDirectory: true, so it succeeds
+    expect(response.data.success).toBe(true);
+  });
+
+  it("should verify ..-prefix name resolves inside projectsDir", async () => {
+    // Confirm that "..other" resolves within projectsDir, not its parent
+    const path = await import("node:path");
+    const resolved = path.resolve("/home/testuser/.qwen/projects", "..other");
+    expect(resolved.startsWith("/home/testuser/.qwen/projects" + path.sep)).toBe(true);
+  });
+
+  it("should reject pure parent directory traversal", async () => {
+    const c = createMockContext("..");
+    const result = await handleDeleteProjectRequest(c);
+    const response = result as { data: { error: string }; status?: number };
+    expect(response.data.error).toBe("Invalid project name");
+  });
+
+  it("should reject empty project name", async () => {
+    const c = createMockContext("");
+    const result = await handleDeleteProjectRequest(c);
+    const response = result as { data: { error: string }; status?: number };
+    expect(response.data.error).toBe("Project name is required");
+  });
+
+  it("should reject project name with slashes", async () => {
+    const c = createMockContext("foo/bar");
+    const result = await handleDeleteProjectRequest(c);
+    const response = result as { data: { error: string }; status?: number };
+    expect(response.data.error).toBe("Invalid project name");
+  });
+
+  it("should reject project name with backslashes", async () => {
+    const c = createMockContext("foo\\bar");
+    const result = await handleDeleteProjectRequest(c);
+    const response = result as { data: { error: string }; status?: number };
+    expect(response.data.error).toBe("Invalid project name");
+  });
+
+  it("should allow and successfully delete a valid project", async () => {
+    const c = createMockContext("-home-testuser-my-project");
+    const result = await handleDeleteProjectRequest(c);
+    const response = result as { data: { success: boolean; message: string } };
+    expect(response.data.success).toBe(true);
+    expect(mockRemove).toHaveBeenCalledWith(
+      "/home/testuser/.qwen/projects/-home-testuser-my-project",
+    );
+  });
+
+  it("should return 404 when project directory does not exist", async () => {
+    mockStat.mockRejectedValue(new Error("not found"));
+    const c = createMockContext("-home-testuser-nonexistent");
+    const result = await handleDeleteProjectRequest(c);
+    const response = result as { data: { error: string }; status?: number };
+    expect(response.data.error).toBe("Project not found");
+  });
+});

--- a/backend/handlers/projects.ts
+++ b/backend/handlers/projects.ts
@@ -1,9 +1,11 @@
 import { Context } from "hono";
+import { resolve, sep } from "node:path";
 import type { ProjectInfo, ProjectsResponse } from "../../shared/types.ts";
 import { logger } from "../utils/logger.ts";
 import { readDir, stat, remove } from "../utils/fs.ts";
 import { getHomeDir } from "../utils/os.ts";
 import { decodeProjectPath } from "../utils/projectMapping.ts";
+import { validateEncodedProjectName } from "../history/pathUtils.ts";
 
 /**
  * Handles GET /api/projects requests
@@ -154,17 +156,29 @@ export async function handleDeleteProjectRequest(c: Context) {
       return c.json({ error: "Project name is required" }, 400);
     }
 
+    // Validate encoded name against dangerous characters
+    if (!validateEncodedProjectName(encodedProjectName)) {
+      return c.json({ error: "Invalid project name" }, 400);
+    }
+
     const homeDir = getHomeDir();
     if (!homeDir) {
       return c.json({ error: "Home directory not found" }, 500);
     }
 
     const projectsDir = `${homeDir}/.qwen/projects`;
-    const projectPath = `${projectsDir}/${encodedProjectName}`;
+
+    // Resolve and verify the path stays within projectsDir.
+    // Note: resolve(projectsDir, "") returns projectsDir itself, which is safe
+    // but will fail the isDirectory check below.
+    const resolved = resolve(projectsDir, encodedProjectName);
+    if (!resolved.startsWith(projectsDir + sep)) {
+      return c.json({ error: "Invalid project name" }, 400);
+    }
 
     // Check if project directory exists
     try {
-      const dirInfo = await stat(projectPath);
+      const dirInfo = await stat(resolved);
       if (!dirInfo.isDirectory) {
         return c.json({ error: "Project not found" }, 404);
       }
@@ -173,7 +187,7 @@ export async function handleDeleteProjectRequest(c: Context) {
     }
 
     // Delete the project directory
-    await remove(projectPath);
+    await remove(resolved);
 
     logger.api.info("Deleted project: {encodedProjectName}", { encodedProjectName });
 

--- a/frontend/src/api/openace.ts
+++ b/frontend/src/api/openace.ts
@@ -162,10 +162,10 @@ export async function createOpenAceProject(
   });
   
   if (!response.ok) {
-    const error = await response.json();
+    const error = await response.json().catch(() => ({}));
     throw new Error(error.error || `Failed to create project: ${response.statusText}`);
   }
-  
+
   return response.json();
 }
 
@@ -174,16 +174,16 @@ export async function createOpenAceProject(
  */
 export async function deleteOpenAceProject(projectId: number): Promise<{ success: boolean }> {
   const url = buildOpenAceUrl(`/api/projects/${projectId}`);
-  
+
   const response = await fetch(url, {
     method: "DELETE",
     headers: {
       "Content-Type": "application/json",
     },
   });
-  
+
   if (!response.ok) {
-    const error = await response.json();
+    const error = await response.json().catch(() => ({}));
     throw new Error(error.error || `Failed to delete project: ${response.statusText}`);
   }
   
@@ -228,7 +228,7 @@ export async function checkPath(path: string): Promise<CheckPathResponse> {
   });
   
   if (!response.ok) {
-    const error = await response.json();
+    const error = await response.json().catch(() => ({}));
     return {
       valid: false,
       exists: false,
@@ -281,7 +281,7 @@ export async function deleteLocalProject(encodedProjectName: string): Promise<{ 
   });
 
   if (!response.ok) {
-    const error = await response.json();
+    const error = await response.json().catch(() => ({}));
     throw new Error(error.error || `Failed to delete project: ${response.statusText}`);
   }
 

--- a/frontend/src/components/ConfirmModal.tsx
+++ b/frontend/src/components/ConfirmModal.tsx
@@ -12,6 +12,7 @@ interface ConfirmModalProps {
   cancelText?: string;
   variant?: "danger" | "warning" | "info";
   isLoading?: boolean;
+  errorMessage?: string;
 }
 
 export function ConfirmModal({
@@ -24,6 +25,7 @@ export function ConfirmModal({
   cancelText = "Cancel",
   variant = "warning",
   isLoading = false,
+  errorMessage,
 }: ConfirmModalProps) {
   const confirmButtonRef = useRef<HTMLButtonElement>(null);
 
@@ -93,6 +95,11 @@ export function ConfirmModal({
                     <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">
                       {message}
                     </p>
+                    {errorMessage && (
+                      <p className="mt-2 text-sm text-red-600 dark:text-red-400">
+                        {errorMessage}
+                      </p>
+                    )}
                   </div>
                 </div>
 

--- a/frontend/src/components/ProjectSelector.tsx
+++ b/frontend/src/components/ProjectSelector.tsx
@@ -71,6 +71,7 @@ export function ProjectSelector() {
   const [isAddProjectOpen, setIsAddProjectOpen] = useState(false);
   const [deleteProject, setDeleteProject] = useState<OpenAceProject | ProjectInfo | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
   const navigate = useNavigate();
 
   // Ref for the project list container to enable keyboard focus
@@ -201,6 +202,7 @@ export function ProjectSelector() {
 
   const handleDeleteClick = (project: ProjectInfo | OpenAceProject, e: React.MouseEvent) => {
     e.stopPropagation();
+    setDeleteError(null);
     setDeleteProject(project);
   };
 
@@ -208,6 +210,7 @@ export function ProjectSelector() {
     if (!deleteProject) return;
 
     setIsDeleting(true);
+    setDeleteError(null);
     try {
       if (integrated) {
         // Open-ACE mode - use project id
@@ -222,8 +225,8 @@ export function ProjectSelector() {
       await loadProjects();
       setDeleteProject(null);
     } catch (err) {
-      console.error("Failed to delete project:", err);
-      // Show error - could add a toast notification here
+      const message = err instanceof Error ? err.message : "Failed to delete project";
+      setDeleteError(message);
     } finally {
       setIsDeleting(false);
     }
@@ -402,15 +405,16 @@ export function ProjectSelector() {
         {/* Delete Confirmation Modal */}
         <ConfirmModal
           isOpen={deleteProject !== null}
-          onClose={() => setDeleteProject(null)}
+          onClose={() => { setDeleteProject(null); setDeleteError(null); }}
           onConfirm={handleConfirmDelete}
           title={t("projectSelector.removeProject")}
-          message={t("projectSelector.removeConfirmMessage", { 
+          message={t("projectSelector.removeConfirmMessage", {
             name: deleteProject ? getDeleteConfirmName(deleteProject) : ''
           })}
           confirmText={t("projectSelector.remove")}
           variant="danger"
           isLoading={isDeleting}
+          errorMessage={deleteError ?? undefined}
         />
       </div>
     </div>

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -127,7 +127,7 @@
     "select": "Select",
     "removeProject": "Remove Project",
     "remove": "Remove",
-    "removeConfirmMessage": "Are you sure you want to remove \"{{name}}\"? This will delete the project's chat history but won't affect the actual directory on disk."
+    "removeConfirmMessage": "Are you sure you want to remove \"{{name}}\"? This will delete the project's configuration and conversation history but won't affect the actual directory on disk."
   },
   "slashCommands": {
     "skillsDescription": "Show available skills",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -127,7 +127,7 @@
     "select": "选择",
     "removeProject": "移除项目",
     "remove": "移除",
-    "removeConfirmMessage": "确定要移除 \"{{name}}\" 吗？这将删除项目的聊天历史，但不会影响磁盘上的实际目录。"
+    "removeConfirmMessage": "确定要移除 \"{{name}}\" 吗？这将删除项目的配置和会话历史，但不会影响磁盘上的实际目录。"
   },
   "slashCommands": {
     "skillsDescription": "显示可用技能",


### PR DESCRIPTION
## Summary

Bug fixes for project deletion and conversation clearing.

### Bug Fixes

- **Project deletion fails silently** (#92): Delete confirmation dialog now shows error messages on failure instead of silently closing
- **CORS missing DELETE method**: Removed explicit `allowMethods` restriction in CORS middleware, using Hono defaults (GET, HEAD, PUT, POST, DELETE, PATCH, OPTIONS)
- **Path traversal vulnerability**: Added `validateEncodedProjectName()` + `path.resolve` prefix check to prevent directory traversal in delete handler, with Windows `path.sep` compatibility
- **response.json() crash**: Added `.catch(() => ({}))` to all error handlers in `openace.ts` (4 locations) to prevent secondary exceptions on non-JSON responses
- **Clear conversation errors**: Fixed stale error messages and fake session ID generation on `/clear`
- **Abort error swallowing**: Reset `clearAbortRef` in finally block to prevent swallowing subsequent errors

### Changes

| File | Change |
|------|--------|
| `backend/app.ts` | CORS: remove `allowMethods` restriction |
| `backend/handlers/projects.ts` | Path traversal protection with `resolve` + `sep` |
| `backend/handlers/projects.test.ts` | 9 test cases for delete handler security |
| `frontend/src/components/ConfirmModal.tsx` | Add `errorMessage` prop |
| `frontend/src/components/ProjectSelector.tsx` | Show delete errors in dialog |
| `frontend/src/components/ChatPage.tsx` | Clear conversation fixes |
| `frontend/src/api/openace.ts` | 4× `.catch(() => ({}))` on error handlers |
| `frontend/src/i18n/locales/*.json` | Updated delete confirmation text |

Closes #92
HERODC