### PR TITLE
fix: refine auto-approve to read-only tools only + proactive deny detection

### DIFF
--- a/backend/handlers/chat.ts
+++ b/backend/handlers/chat.ts
@@ -38,6 +38,9 @@ async function executeQwenCommand(
 ): Promise<void> {
   let abortController: AbortController;
   const localPendingIds = new Set<string>();
+  // Remember tools the user already approved during this request — avoids
+  // repeated permission dialogs for the same tool within one streaming session.
+  const localAllowedTools = new Set<string>();
 
   try {
     // Process commands that start with '/'
@@ -68,6 +71,12 @@ async function executeQwenCommand(
       // Defense 1: check main query abort (not SDK's per-request signal)
       if (abortController.signal.aborted) {
         return { behavior: "deny", message: "Request aborted" };
+      }
+
+      // Auto-approve if user already allowed this tool during this request
+      if (localAllowedTools.has(toolName)) {
+        logger.chat.debug("canUseTool: auto-approving previously allowed tool {toolName}", { toolName });
+        return { behavior: "allow", updatedInput: input };
       }
 
       const permissionId = crypto.randomUUID();
@@ -113,6 +122,10 @@ async function executeQwenCommand(
           resolve: (result) => {
             abortController.signal.removeEventListener("abort", onAbort);
             localPendingIds.delete(permissionId);
+            // Remember approval so subsequent calls to the same tool are auto-approved
+            if (result.behavior === "allow") {
+              localAllowedTools.add(toolName);
+            }
             resolve(result);
           },
           abortSignal: abortController.signal,

--- a/backend/handlers/chat.ts
+++ b/backend/handlers/chat.ts
@@ -19,6 +19,16 @@ function mapPermissionMode(mode?: string): PermissionMode | undefined {
 }
 
 /**
+ * Read-only tools that are safe to auto-approve within a single request after
+ * the user approves them once. High-risk tools (write_file, edit, run_shell_command)
+ * always require per-call confirmation for safety.
+ *
+ * Tool names use snake_case to match the SDK's canUseTool callback format.
+ * See qwen-code-cli/packages/core/src/tools/tool-names.ts for the canonical list.
+ */
+const READ_ONLY_TOOLS = new Set(["read_file", "glob", "grep_search", "list_directory"]);
+
+/**
  * Executes a Qwen command and sends StreamResponse objects via the provided enqueue callback.
  * Supports canUseTool callback for proactive permission handling.
  */
@@ -38,8 +48,14 @@ async function executeQwenCommand(
 ): Promise<void> {
   let abortController: AbortController;
   const localPendingIds = new Set<string>();
-  // Remember tools the user already approved during this request — avoids
-  // repeated permission dialogs for the same tool within one streaming session.
+  // Read-only tools approved by the user during this request — auto-approved on
+  // subsequent calls within the same streaming session. Scope is limited to a
+  // single executeQwenCommand invocation; the Set is discarded on request end.
+  //
+  // This is independent of the frontend's `allowedTools` (ChatRequest.allowedTools →
+  // SDK allowedTools option), which persists across requests and handles the legacy
+  // reactive permission flow. When a tool is in SDK `allowedTools`, the `canUseTool`
+  // callback is not invoked at all, so the two mechanisms never conflict.
   const localAllowedTools = new Set<string>();
 
   try {
@@ -73,7 +89,9 @@ async function executeQwenCommand(
         return { behavior: "deny", message: "Request aborted" };
       }
 
-      // Auto-approve if user already allowed this tool during this request
+      // Auto-approve read-only tools the user already allowed during this request.
+      // High-risk tools (write_file, edit, run_shell_command, etc.) always require
+      // per-call confirmation regardless of prior approval.
       if (localAllowedTools.has(toolName)) {
         logger.chat.debug("canUseTool: auto-approving previously allowed tool {toolName}", { toolName });
         return { behavior: "allow", updatedInput: input };
@@ -122,8 +140,9 @@ async function executeQwenCommand(
           resolve: (result) => {
             abortController.signal.removeEventListener("abort", onAbort);
             localPendingIds.delete(permissionId);
-            // Remember approval so subsequent calls to the same tool are auto-approved
-            if (result.behavior === "allow") {
+            // Only remember read-only tools for auto-approve; high-risk tools
+            // always require per-call user confirmation.
+            if (result.behavior === "allow" && READ_ONLY_TOOLS.has(toolName)) {
               localAllowedTools.add(toolName);
             }
             resolve(result);
@@ -184,6 +203,13 @@ async function executeQwenCommand(
     if (ac) {
       ac.abort();
       requestAbortControllers.delete(requestId);
+    }
+    // Audit log: record which tools were auto-approved during this request
+    if (localAllowedTools.size > 0) {
+      logger.chat.debug("Request {requestId} auto-approved tools: {tools}", {
+        requestId,
+        tools: [...localAllowedTools],
+      });
     }
     // Clean up unresolved pending permissions for this request
     for (const id of localPendingIds) {

--- a/backend/utils/loopDetector.ts
+++ b/backend/utils/loopDetector.ts
@@ -15,6 +15,7 @@ const LOOP_ERROR_PATTERNS: [string, RegExp][] = [
   ["input_closed", /input\s+closed/i],
   ["input_closed", /operation\s+cancelled/i],
   ["permission_denied", /permission denied/i],
+  ["proactive_denied", /denied this tool call.*proactive/i],
   ["stdin_closed", /stdin.*closed/i],
 ];
 


### PR DESCRIPTION
## Summary

Refines the auto-approve mechanism introduced in PR #95 (now merged) based on a 4-round security review on Issue #96.

## Changes from PR #95

PR #95 auto-approved **all** tools after first user approval. This PR narrows the scope:

### Security improvements

- **Only auto-approve read-only tools** (`read_file`, `glob`, `grep_search`, `list_directory`) after first user approval. High-risk tools (`write_file`, `edit`, `run_shell_command`) always require per-call confirmation, preventing AI from exploiting an approved tool name to execute different operations.
- **`localAllowedTools.add()` now filters by `READ_ONLY_TOOLS`** — the Set only contains tools that will actually be auto-approved, avoiding semantic confusion for future maintainers.

### Reliability improvements

- **`READ_ONLY_TOOLS` defined as module-level constant** with JSDoc explaining the design decision, snake_case naming convention, and reference to canonical source (`qwen-code-cli/packages/core/src/tools/tool-names.ts`).
- **`LOOP_ERROR_PATTERNS` gains `proactive_denied` pattern** — backend `checkLoop` can now detect proactive canUseTool deny loops (`User denied this tool call [proactive]`), providing a backend failsafe if frontend loop detection fails.
- **Audit log in `finally` block** — records which tools were auto-approved during the request (debug level), for post-incident security review.
- **Comments explaining `localAllowedTools` vs frontend `allowedTools`** relationship and scope differences.

## Commits

| Commit | Description |
|--------|-------------|
| `a4ed97e` | Initial fix: auto-approve previously allowed tools (from PR #95) |
| `fd54386` | Refine: read-only tools only, proactive deny detection, audit log |

## Related

- Issue #96: Security review with 4 rounds of adversarial analysis
- Issue #97: Discovered frontend snake_case/PascalCase tool name mismatch (separate bug)
