### PR TITLE
fix: thinking timeout fires even when AI is actively producing output

### DIFF
--- a/frontend/src/components/ChatPage.tsx
+++ b/frontend/src/components/ChatPage.tsx
@@ -302,7 +302,7 @@ export function ChatPage() {
             },
             // Thinking timeout
             thinkingTimeout: {
-              onThinkingTimeout: (content) => thinkingTimeoutRef.current?.(content),
+              onThinkingTimeout: (content, info) => thinkingTimeoutRef.current?.(content, info),
             },
           },
           onPermissionRequest: (event) => {
@@ -471,7 +471,7 @@ export function ChatPage() {
 
   // Ref for thinking timeout handler — same pattern as permissionErrorRef
   const thinkingTimeoutRef = useRef<
-    ((accumulatedContent: string, info?: { reason: "idle" | "absolute"; elapsedSeconds: number }) => void) | null
+    ((accumulatedContent: string, info: { reason: "idle" | "absolute"; elapsedSeconds: number }) => void) | null
   >(null);
 
   // Ref to track previous isLoading state for detecting when AI finishes responding
@@ -1046,7 +1046,7 @@ export function ChatPage() {
   const handleThinkingTimeout = useCallback(
     (
       accumulatedContent: string,
-      info?: { reason: "idle" | "absolute"; elapsedSeconds: number },
+      info: { reason: "idle" | "absolute"; elapsedSeconds: number },
     ) => {
       // Abort the request
       if (isLoading && currentRequestId) {
@@ -1056,12 +1056,10 @@ export function ChatPage() {
       }
 
       // Show timeout notification with thinking content
-      const reason = info?.reason ?? "idle";
-      const elapsed = info?.elapsedSeconds ?? 5 * 60;
       setThinkingTimeoutInfo({
         content: accumulatedContent,
-        elapsed,
-        reason,
+        elapsed: info.elapsedSeconds,
+        reason: info.reason,
       });
     },
     [isLoading, currentRequestId, abortRequest, resetRequestState, isRemoteWorkspace, remoteChat],

--- a/frontend/src/components/ChatPage.tsx
+++ b/frontend/src/components/ChatPage.tsx
@@ -14,6 +14,7 @@ import { usePermissions, type CommandLoopRequest } from "../hooks/chat/usePermis
 import { usePermissionMode } from "../hooks/chat/usePermissionMode";
 import { useAbortController } from "../hooks/chat/useAbortController";
 import { sendPermissionResponse } from "../hooks/chat/useAbortController";
+import type { ThinkingTimeoutContext } from "../hooks/streaming/useMessageProcessor";
 import { extractToolInfo, generateToolPatterns } from "../utils/toolUtils";
 import { useAutoHistoryLoader } from "../hooks/useHistoryLoader";
 import { useSettings } from "../hooks/useSettings";
@@ -471,7 +472,7 @@ export function ChatPage() {
 
   // Ref for thinking timeout handler — same pattern as permissionErrorRef
   const thinkingTimeoutRef = useRef<
-    ((accumulatedContent: string, info: { reason: "idle" | "absolute"; elapsedSeconds: number }) => void) | null
+    ((accumulatedContent: string, info: ThinkingTimeoutContext) => void) | null
   >(null);
 
   // Ref to track previous isLoading state for detecting when AI finishes responding
@@ -1046,7 +1047,7 @@ export function ChatPage() {
   const handleThinkingTimeout = useCallback(
     (
       accumulatedContent: string,
-      info: { reason: "idle" | "absolute"; elapsedSeconds: number },
+      info: ThinkingTimeoutContext,
     ) => {
       // Abort the request
       if (isLoading && currentRequestId) {

--- a/frontend/src/components/ChatPage.tsx
+++ b/frontend/src/components/ChatPage.tsx
@@ -471,7 +471,7 @@ export function ChatPage() {
 
   // Ref for thinking timeout handler — same pattern as permissionErrorRef
   const thinkingTimeoutRef = useRef<
-    ((accumulatedContent: string) => void) | null
+    ((accumulatedContent: string, info?: { reason: "idle" | "absolute"; elapsedSeconds: number }) => void) | null
   >(null);
 
   // Ref to track previous isLoading state for detecting when AI finishes responding
@@ -1040,10 +1040,14 @@ export function ChatPage() {
   const [thinkingTimeoutInfo, setThinkingTimeoutInfo] = useState<{
     content: string;
     elapsed: number;
+    reason: "idle" | "absolute";
   } | null>(null);
 
   const handleThinkingTimeout = useCallback(
-    (accumulatedContent: string) => {
+    (
+      accumulatedContent: string,
+      info?: { reason: "idle" | "absolute"; elapsedSeconds: number },
+    ) => {
       // Abort the request
       if (isLoading && currentRequestId) {
         abortRequest(currentRequestId, isLoading, resetRequestState);
@@ -1052,9 +1056,12 @@ export function ChatPage() {
       }
 
       // Show timeout notification with thinking content
+      const reason = info?.reason ?? "idle";
+      const elapsed = info?.elapsedSeconds ?? 5 * 60;
       setThinkingTimeoutInfo({
         content: accumulatedContent,
-        elapsed: 5 * 60, // 5 minutes
+        elapsed,
+        reason,
       });
     },
     [isLoading, currentRequestId, abortRequest, resetRequestState, isRemoteWorkspace, remoteChat],
@@ -1573,10 +1580,14 @@ export function ChatPage() {
                 </svg>
                 <div className="flex-1 min-w-0">
                   <p className="text-sm font-medium text-blue-800 dark:text-blue-300">
-                    {t("thinkingTimeout.title", "Thinking timeout — auto-aborted")}
+                    {thinkingTimeoutInfo.reason === "idle"
+                      ? t("thinkingTimeout.stalledTitle", "Thinking stalled — auto-aborted")
+                      : t("thinkingTimeout.title", "Thinking timeout — auto-aborted")}
                   </p>
                   <p className="text-xs text-blue-700 dark:text-blue-400 mt-1">
-                    {t("thinkingTimeout.description", "AI thinking exceeded {{minutes}} minutes and was auto-aborted. Here's what the AI was thinking about:", { minutes: thinkingTimeoutInfo.elapsed / 60 })}
+                    {thinkingTimeoutInfo.reason === "idle"
+                      ? t("thinkingTimeout.stalledDescription", "AI produced no new output for {{minutes}} minutes and was auto-aborted. Here's what the AI was thinking about:", { minutes: Math.round(thinkingTimeoutInfo.elapsed / 60) })
+                      : t("thinkingTimeout.description", "AI thinking exceeded {{minutes}} minutes total and was auto-aborted. Here's what the AI was thinking about:", { minutes: Math.round(thinkingTimeoutInfo.elapsed / 60) })}
                   </p>
                   {thinkingTimeoutInfo.content && (
                     <details className="mt-2">

--- a/frontend/src/hooks/streaming/useMessageProcessor.ts
+++ b/frontend/src/hooks/streaming/useMessageProcessor.ts
@@ -2,9 +2,17 @@ import type { AllMessage, ChatMessage, ThinkingMessage } from "../../types";
 import { useMessageConverter } from "../useMessageConverter";
 import type { CommandLoopRequest } from "../chat/usePermissions";
 
+/** Context data provided when a thinking timeout fires */
+export interface ThinkingTimeoutContext {
+  /** Whether the timeout was caused by idle (no new output) or absolute (total time exceeded) */
+  reason: "idle" | "absolute";
+  /** Seconds since the relevant threshold was crossed */
+  elapsedSeconds: number;
+}
+
 export interface ThinkingTimeoutInfo {
   /** Triggered when thinking exceeds the timeout */
-  onThinkingTimeout: (accumulatedContent: string) => void;
+  onThinkingTimeout: (accumulatedContent: string, info: ThinkingTimeoutContext) => void;
 }
 
 export interface StreamingContext {

--- a/frontend/src/hooks/streaming/useStreamParser.test.ts
+++ b/frontend/src/hooks/streaming/useStreamParser.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { renderHook } from "@testing-library/react";
 import { useStreamParser } from "./useStreamParser";
 import type { StreamingContext } from "./useMessageProcessor";
@@ -632,6 +632,188 @@ describe("useStreamParser", () => {
           type: "tool",
           content: expect.stringContaining("grep_search"),
         }),
+      );
+    });
+  });
+
+
+  describe("Thinking Timeout", () => {
+    let onThinkingTimeout: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+      onThinkingTimeout = vi.fn();
+      // Use mock functions that also update currentThinkingMessage state
+      // so the UnifiedMessageProcessor can track thinking state properly
+      mockContext.currentThinkingMessage = null;
+      mockContext.setCurrentThinkingMessage = vi.fn((msg) => {
+        mockContext.currentThinkingMessage = msg;
+      });
+      mockContext.updateThinkingMessage = vi.fn((content) => {
+        if (mockContext.currentThinkingMessage) {
+          mockContext.currentThinkingMessage = { ...mockContext.currentThinkingMessage, content };
+        }
+      });
+      mockContext.thinkingTimeout = { onThinkingTimeout };
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    /** Helper: create an assistant message with thinking content */
+    function makeThinkingAssistantMessage(text: string) {
+      return {
+        type: "assistant" as const,
+        session_id: "test-session",
+        uuid: generateId(),
+        parent_tool_use_id: null,
+        message: {
+          id: "msg_" + generateId(),
+          type: "message" as const,
+          role: "assistant" as const,
+          model: "qwen3-coder-plus",
+          content: [{ type: "thinking" as const, thinking: text }],
+          stop_reason: "tool_use" as const,
+          usage: { input_tokens: 10, output_tokens: 5 },
+        },
+      };
+    }
+
+    it("should fire idle timeout after 5 minutes with no new output", () => {
+      const { result } = renderHook(() => useStreamParser());
+
+      result.current.processStreamLine(
+        JSON.stringify({
+          type: "claude_json",
+          data: makeThinkingAssistantMessage("Analyzing the problem..."),
+        }),
+        mockContext,
+      );
+
+      // Thinking message should trigger setCurrentThinkingMessage
+      expect(mockContext.setCurrentThinkingMessage).toHaveBeenCalled();
+      expect(onThinkingTimeout).not.toHaveBeenCalled();
+
+      // Advance past 5 minutes idle timeout
+      vi.advanceTimersByTime(5 * 60 * 1000);
+
+      expect(onThinkingTimeout).toHaveBeenCalledTimes(1);
+      expect(onThinkingTimeout).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ reason: "idle" }),
+      );
+    });
+
+    it("should not fire timeout when thinking ends normally before 5 minutes", () => {
+      const { result } = renderHook(() => useStreamParser());
+
+      // Send thinking message using Claude content format
+      result.current.processStreamLine(
+        JSON.stringify({
+          type: "claude_json",
+          data: makeThinkingAssistantMessage("Quick thought..."),
+        }),
+        mockContext,
+      );
+
+      // Send a result message which clears thinking state
+      const resultMessage = {
+        type: "result" as const,
+        session_id: "test-session",
+        uuid: generateId(),
+        parent_tool_use_id: null,
+        message: {
+          id: "msg_" + generateId(),
+          type: "message" as const,
+          role: "assistant" as const,
+          model: "qwen3-coder-plus",
+          content: [{ type: "text" as const, text: "Done thinking" }],
+          stop_reason: "end_turn" as const,
+          usage: { input_tokens: 10, output_tokens: 5 },
+        },
+        result: "Task completed",
+        duration_ms: 1000,
+        duration_api_ms: 800,
+        cost_usd: 0.001,
+      };
+      result.current.processStreamLine(
+        JSON.stringify({
+          type: "claude_json",
+          data: resultMessage,
+        }),
+        mockContext,
+      );
+
+      // Advance past 5 minutes — should NOT fire because thinking ended
+      vi.advanceTimersByTime(5 * 60 * 1000 + 1000);
+      expect(onThinkingTimeout).not.toHaveBeenCalled();
+    });
+
+    it("should not restart timer when thinking was not started (ref is null)", () => {
+      const { result } = renderHook(() => useStreamParser());
+
+      // Send a message that does NOT contain thinking content
+      const textAssistantMessage = {
+        type: "assistant" as const,
+        session_id: "test-session",
+        uuid: generateId(),
+        parent_tool_use_id: null,
+        message: {
+          id: "msg_" + generateId(),
+          type: "message" as const,
+          role: "assistant" as const,
+          model: "qwen3-coder-plus",
+          content: [{ type: "text" as const, text: "No thinking here" }],
+          stop_reason: "end_turn" as const,
+          usage: { input_tokens: 10, output_tokens: 5 },
+        },
+      };
+      result.current.processStreamLine(
+        JSON.stringify({
+          type: "claude_json",
+          data: textAssistantMessage,
+        }),
+        mockContext,
+      );
+
+      // No thinking timeout should be set up
+      vi.advanceTimersByTime(15 * 60 * 1000);
+      expect(onThinkingTimeout).not.toHaveBeenCalled();
+    });
+
+    it("should fire absolute timeout after 15 minutes even with active output", () => {
+      const { result } = renderHook(() => useStreamParser());
+
+      // Start thinking
+      result.current.processStreamLine(
+        JSON.stringify({
+          type: "claude_json",
+          data: makeThinkingAssistantMessage("Start"),
+        }),
+        mockContext,
+      );
+
+      // Simulate continuous output: every 4 min 50 sec a new chunk arrives
+      // This keeps the idle timer from firing but absolute should still hit at 15 min
+      for (let i = 0; i < 3; i++) {
+        vi.advanceTimersByTime(4 * 60 * 1000 + 50 * 1000);
+        result.current.processStreamLine(
+          JSON.stringify({
+            type: "claude_json",
+            data: makeThinkingAssistantMessage(`Start\nchunk ${i}`),
+          }),
+          mockContext,
+        );
+      }
+
+      // Total elapsed ~14.5 min. Advance to cross 15 min absolute threshold
+      vi.advanceTimersByTime(30 * 1000);
+
+      expect(onThinkingTimeout).toHaveBeenCalledTimes(1);
+      expect(onThinkingTimeout).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ reason: "absolute" }),
       );
     });
   });

--- a/frontend/src/hooks/streaming/useStreamParser.test.ts
+++ b/frontend/src/hooks/streaming/useStreamParser.test.ts
@@ -699,10 +699,10 @@ describe("useStreamParser", () => {
       vi.advanceTimersByTime(5 * 60 * 1000);
 
       expect(onThinkingTimeout).toHaveBeenCalledTimes(1);
-      expect(onThinkingTimeout).toHaveBeenCalledWith(
-        expect.any(String),
-        expect.objectContaining({ reason: "idle" }),
-      );
+      const [_content, info] = onThinkingTimeout.mock.calls[0];
+      expect(info.reason).toBe("idle");
+      expect(info.elapsedSeconds).toBeGreaterThanOrEqual(300);
+      expect(info.elapsedSeconds).toBeLessThanOrEqual(310);
     });
 
     it("should not fire timeout when thinking ends normally before 5 minutes", () => {
@@ -811,10 +811,40 @@ describe("useStreamParser", () => {
       vi.advanceTimersByTime(30 * 1000);
 
       expect(onThinkingTimeout).toHaveBeenCalledTimes(1);
-      expect(onThinkingTimeout).toHaveBeenCalledWith(
-        expect.any(String),
-        expect.objectContaining({ reason: "absolute" }),
+      const [_content, info] = onThinkingTimeout.mock.calls[0];
+      expect(info.reason).toBe("absolute");
+      expect(info.elapsedSeconds).toBeGreaterThanOrEqual(870);
+      expect(info.elapsedSeconds).toBeLessThanOrEqual(920);
+    });
+
+    it("should not restart timer after timeout abort when buffered chunk arrives", () => {
+      const { result } = renderHook(() => useStreamParser());
+
+      // Start thinking
+      result.current.processStreamLine(
+        JSON.stringify({
+          type: "claude_json",
+          data: makeThinkingAssistantMessage("Thinking..."),
+        }),
+        mockContext,
       );
+
+      // Trigger idle timeout
+      vi.advanceTimersByTime(5 * 60 * 1000);
+      expect(onThinkingTimeout).toHaveBeenCalledTimes(1);
+
+      // Simulate buffered chunk arriving after abort — should NOT restart timer
+      result.current.processStreamLine(
+        JSON.stringify({
+          type: "claude_json",
+          data: makeThinkingAssistantMessage("Late chunk"),
+        }),
+        mockContext,
+      );
+
+      // Advance another 5 minutes — no second timeout
+      vi.advanceTimersByTime(5 * 60 * 1000);
+      expect(onThinkingTimeout).toHaveBeenCalledTimes(1); // still 1, not 2
     });
   });
 });

--- a/frontend/src/hooks/streaming/useStreamParser.test.ts
+++ b/frontend/src/hooks/streaming/useStreamParser.test.ts
@@ -643,8 +643,6 @@ describe("useStreamParser", () => {
     beforeEach(() => {
       vi.useFakeTimers();
       onThinkingTimeout = vi.fn();
-      // Use mock functions that also update currentThinkingMessage state
-      // so the UnifiedMessageProcessor can track thinking state properly
       mockContext.currentThinkingMessage = null;
       mockContext.setCurrentThinkingMessage = vi.fn((msg) => {
         mockContext.currentThinkingMessage = msg;
@@ -661,8 +659,7 @@ describe("useStreamParser", () => {
       vi.useRealTimers();
     });
 
-    /** Helper: create an assistant message with thinking content */
-    function makeThinkingAssistantMessage(text: string) {
+    function makeThinkingMessage(text: string) {
       return {
         type: "assistant" as const,
         session_id: "test-session",
@@ -680,22 +677,32 @@ describe("useStreamParser", () => {
       };
     }
 
+    function makeTextMessage(text: string) {
+      return {
+        type: "assistant" as const,
+        session_id: "test-session",
+        uuid: generateId(),
+        parent_tool_use_id: null,
+        message: {
+          id: "msg_" + generateId(),
+          type: "message" as const,
+          role: "assistant" as const,
+          model: "qwen3-coder-plus",
+          content: [{ type: "text" as const, text }],
+          stop_reason: "end_turn" as const,
+          usage: { input_tokens: 10, output_tokens: 5 },
+        },
+      };
+    }
+
     it("should fire idle timeout after 5 minutes with no new output", () => {
       const { result } = renderHook(() => useStreamParser());
 
       result.current.processStreamLine(
-        JSON.stringify({
-          type: "claude_json",
-          data: makeThinkingAssistantMessage("Analyzing the problem..."),
-        }),
+        JSON.stringify({ type: "claude_json", data: makeThinkingMessage("Analyzing...") }),
         mockContext,
       );
 
-      // Thinking message should trigger setCurrentThinkingMessage
-      expect(mockContext.setCurrentThinkingMessage).toHaveBeenCalled();
-      expect(onThinkingTimeout).not.toHaveBeenCalled();
-
-      // Advance past 5 minutes idle timeout
       vi.advanceTimersByTime(5 * 60 * 1000);
 
       expect(onThinkingTimeout).toHaveBeenCalledTimes(1);
@@ -708,44 +715,17 @@ describe("useStreamParser", () => {
     it("should not fire timeout when thinking ends normally before 5 minutes", () => {
       const { result } = renderHook(() => useStreamParser());
 
-      // Send thinking message using Claude content format
       result.current.processStreamLine(
-        JSON.stringify({
-          type: "claude_json",
-          data: makeThinkingAssistantMessage("Quick thought..."),
-        }),
+        JSON.stringify({ type: "claude_json", data: makeThinkingMessage("Quick thought...") }),
         mockContext,
       );
 
-      // Send a result message which clears thinking state
-      const resultMessage = {
-        type: "result" as const,
-        session_id: "test-session",
-        uuid: generateId(),
-        parent_tool_use_id: null,
-        message: {
-          id: "msg_" + generateId(),
-          type: "message" as const,
-          role: "assistant" as const,
-          model: "qwen3-coder-plus",
-          content: [{ type: "text" as const, text: "Done thinking" }],
-          stop_reason: "end_turn" as const,
-          usage: { input_tokens: 10, output_tokens: 5 },
-        },
-        result: "Task completed",
-        duration_ms: 1000,
-        duration_api_ms: 800,
-        cost_usd: 0.001,
-      };
+      // End thinking by sending text content
       result.current.processStreamLine(
-        JSON.stringify({
-          type: "claude_json",
-          data: resultMessage,
-        }),
+        JSON.stringify({ type: "claude_json", data: makeTextMessage("Done thinking") }),
         mockContext,
       );
 
-      // Advance past 5 minutes — should NOT fire because thinking ended
       vi.advanceTimersByTime(5 * 60 * 1000 + 1000);
       expect(onThinkingTimeout).not.toHaveBeenCalled();
     });
@@ -753,31 +733,11 @@ describe("useStreamParser", () => {
     it("should not restart timer when thinking was not started (ref is null)", () => {
       const { result } = renderHook(() => useStreamParser());
 
-      // Send a message that does NOT contain thinking content
-      const textAssistantMessage = {
-        type: "assistant" as const,
-        session_id: "test-session",
-        uuid: generateId(),
-        parent_tool_use_id: null,
-        message: {
-          id: "msg_" + generateId(),
-          type: "message" as const,
-          role: "assistant" as const,
-          model: "qwen3-coder-plus",
-          content: [{ type: "text" as const, text: "No thinking here" }],
-          stop_reason: "end_turn" as const,
-          usage: { input_tokens: 10, output_tokens: 5 },
-        },
-      };
       result.current.processStreamLine(
-        JSON.stringify({
-          type: "claude_json",
-          data: textAssistantMessage,
-        }),
+        JSON.stringify({ type: "claude_json", data: makeTextMessage("No thinking here") }),
         mockContext,
       );
 
-      // No thinking timeout should be set up
       vi.advanceTimersByTime(15 * 60 * 1000);
       expect(onThinkingTimeout).not.toHaveBeenCalled();
     });
@@ -785,47 +745,35 @@ describe("useStreamParser", () => {
     it("should fire absolute timeout after 15 minutes even with active output", () => {
       const { result } = renderHook(() => useStreamParser());
 
-      // Start thinking
       result.current.processStreamLine(
-        JSON.stringify({
-          type: "claude_json",
-          data: makeThinkingAssistantMessage("Start"),
-        }),
+        JSON.stringify({ type: "claude_json", data: makeThinkingMessage("Start") }),
         mockContext,
       );
 
-      // Simulate continuous output: every 4 min 50 sec a new chunk arrives
-      // This keeps the idle timer from firing but absolute should still hit at 15 min
+      // Keep sending content every 4 min 50 sec to prevent idle timeout
       for (let i = 0; i < 3; i++) {
         vi.advanceTimersByTime(4 * 60 * 1000 + 50 * 1000);
         result.current.processStreamLine(
-          JSON.stringify({
-            type: "claude_json",
-            data: makeThinkingAssistantMessage(`Start\nchunk ${i}`),
-          }),
+          JSON.stringify({ type: "claude_json", data: makeThinkingMessage(`Start\nchunk ${i}`) }),
           mockContext,
         );
       }
 
-      // Total elapsed ~14.5 min. Advance to cross 15 min absolute threshold
+      // Total ~14.5 min. Advance to cross 15 min absolute threshold
       vi.advanceTimersByTime(30 * 1000);
 
       expect(onThinkingTimeout).toHaveBeenCalledTimes(1);
       const [_content, info] = onThinkingTimeout.mock.calls[0];
       expect(info.reason).toBe("absolute");
       expect(info.elapsedSeconds).toBeGreaterThanOrEqual(870);
-      expect(info.elapsedSeconds).toBeLessThanOrEqual(920);
+      expect(info.elapsedSeconds).toBeLessThanOrEqual(910);
     });
 
     it("should not restart timer after timeout abort when buffered chunk arrives", () => {
       const { result } = renderHook(() => useStreamParser());
 
-      // Start thinking
       result.current.processStreamLine(
-        JSON.stringify({
-          type: "claude_json",
-          data: makeThinkingAssistantMessage("Thinking..."),
-        }),
+        JSON.stringify({ type: "claude_json", data: makeThinkingMessage("Thinking...") }),
         mockContext,
       );
 
@@ -833,18 +781,15 @@ describe("useStreamParser", () => {
       vi.advanceTimersByTime(5 * 60 * 1000);
       expect(onThinkingTimeout).toHaveBeenCalledTimes(1);
 
-      // Simulate buffered chunk arriving after abort — should NOT restart timer
+      // Simulate buffered chunk arriving after abort — thinkingAbortedRef prevents restart
       result.current.processStreamLine(
-        JSON.stringify({
-          type: "claude_json",
-          data: makeThinkingAssistantMessage("Late chunk"),
-        }),
+        JSON.stringify({ type: "claude_json", data: makeThinkingMessage("Late chunk") }),
         mockContext,
       );
 
-      // Advance another 5 minutes — no second timeout
+      // Advance another 5 minutes — should NOT fire again
       vi.advanceTimersByTime(5 * 60 * 1000);
-      expect(onThinkingTimeout).toHaveBeenCalledTimes(1); // still 1, not 2
+      expect(onThinkingTimeout).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/frontend/src/hooks/streaming/useStreamParser.ts
+++ b/frontend/src/hooks/streaming/useStreamParser.ts
@@ -18,7 +18,8 @@ import {
   type ProcessingContext,
 } from "../../utils/UnifiedMessageProcessor";
 
-const THINKING_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
+const THINKING_IDLE_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes — no new output
+const THINKING_ABSOLUTE_TIMEOUT_MS = 15 * 60 * 1000; // 15 minutes — total thinking time
 
 export function useStreamParser() {
   // Create a single unified processor instance
@@ -26,8 +27,10 @@ export function useStreamParser() {
 
   // Thinking timeout tracking
   const thinkingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const thinkingStartRef = useRef<number>(0);
+  const thinkingLastActivityRef = useRef<number>(0); // timestamp of last content chunk
+  const thinkingStartedAtRef = useRef<number>(0); // timestamp when thinking began
   const thinkingContentRef = useRef<string>("");
+  const thinkingAbortedRef = useRef(false); // prevents new timers after timeout abort
 
   const clearThinkingTimer = useCallback(() => {
     if (thinkingTimerRef.current) {
@@ -35,6 +38,40 @@ export function useStreamParser() {
       thinkingTimerRef.current = null;
     }
   }, []);
+
+  /** Compute the next deadline as the minimum of idle and absolute timeouts */
+  const scheduleThinkingTimer = useCallback(
+    (
+      onTimeout: (
+        content: string,
+        info: { reason: "idle" | "absolute"; elapsedSeconds: number },
+      ) => void,
+    ) => {
+      const idleDeadline =
+        thinkingLastActivityRef.current + THINKING_IDLE_TIMEOUT_MS;
+      const absoluteDeadline =
+        thinkingStartedAtRef.current + THINKING_ABSOLUTE_TIMEOUT_MS;
+      const nextDeadline = Math.min(idleDeadline, absoluteDeadline);
+      const delay = Math.max(0, nextDeadline - Date.now());
+
+      clearTimeout(thinkingTimerRef.current!);
+      thinkingTimerRef.current = setTimeout(() => {
+        const now = Date.now();
+        const isIdle = now >= idleDeadline;
+        const reason = isIdle ? ("idle" as const) : ("absolute" as const);
+        const elapsedSeconds = Math.round((now - thinkingStartedAtRef.current) / 1000);
+        console.warn(
+          `Thinking timeout (${reason}): ${isIdle ? "no new output for" : "total"} ${elapsedSeconds}s, auto-aborting`,
+        );
+        onTimeout(thinkingContentRef.current, { reason, elapsedSeconds });
+        // Mark as aborted and clear ref so buffered chunks after abort
+        // don't restart the timer
+        thinkingAbortedRef.current = true;
+        thinkingTimerRef.current = null;
+      }, delay);
+    },
+    [],
+  );
 
   // Convert StreamingContext to ProcessingContext
   const adaptContext = useCallback(
@@ -52,27 +89,36 @@ export function useStreamParser() {
         currentThinkingMessage: context.currentThinkingMessage,
         setCurrentThinkingMessage: (msg) => {
           context.setCurrentThinkingMessage?.(msg);
-          if (msg && context.thinkingTimeout) {
+          if (msg && context.thinkingTimeout && !thinkingAbortedRef.current) {
             // Start thinking timer when a new thinking message begins
             if (!thinkingTimerRef.current) {
-              thinkingStartRef.current = Date.now();
+              const now = Date.now();
+              thinkingStartedAtRef.current = now;
+              thinkingLastActivityRef.current = now;
               thinkingContentRef.current = msg.content;
-              thinkingTimerRef.current = setTimeout(() => {
-                const elapsed = Math.round((Date.now() - thinkingStartRef.current) / 1000);
-                const content = thinkingContentRef.current;
-                console.warn(`Thinking timeout after ${elapsed}s, auto-aborting`);
-                context.thinkingTimeout!.onThinkingTimeout(content);
-              }, THINKING_TIMEOUT_MS);
+              scheduleThinkingTimer(
+                context.thinkingTimeout.onThinkingTimeout,
+              );
             }
           } else if (!msg) {
-            // Thinking ended — clear timer
+            // Thinking ended — clear timer and reset refs
             clearThinkingTimer();
+            thinkingLastActivityRef.current = 0;
+            thinkingStartedAtRef.current = 0;
+            thinkingAbortedRef.current = false;
           }
         },
         updateThinkingMessage: (content: string) => {
           context.updateThinkingMessage?.(content);
-          // Track latest thinking content for timeout notification
           thinkingContentRef.current = content;
+          // Reset idle timer on each new content chunk so timeout only fires
+          // when there is truly no new output
+          if (thinkingTimerRef.current && context.thinkingTimeout && !thinkingAbortedRef.current) {
+            thinkingLastActivityRef.current = Date.now();
+            scheduleThinkingTimer(
+              context.thinkingTimeout.onThinkingTimeout,
+            );
+          }
         },
 
         // Session handling
@@ -99,7 +145,7 @@ export function useStreamParser() {
         onThinkingTimeout: context.thinkingTimeout?.onThinkingTimeout,
       };
     },
-    [clearThinkingTimer],
+    [clearThinkingTimer, scheduleThinkingTimer],
   );
 
   const processQwenData = useCallback(

--- a/frontend/src/hooks/streaming/useStreamParser.ts
+++ b/frontend/src/hooks/streaming/useStreamParser.ts
@@ -54,9 +54,12 @@ export function useStreamParser() {
       const nextDeadline = Math.min(idleDeadline, absoluteDeadline);
       const delay = Math.max(0, nextDeadline - Date.now());
 
-      clearTimeout(thinkingTimerRef.current!);
+      if (thinkingTimerRef.current) clearTimeout(thinkingTimerRef.current);
       thinkingTimerRef.current = setTimeout(() => {
         const now = Date.now();
+        // When absolute fires first: idleDeadline > now (since lastActivity was
+        // recently updated by content chunks), so isIdle is false and reason
+        // correctly resolves to "absolute".
         const isIdle = now >= idleDeadline;
         const reason = isIdle ? ("idle" as const) : ("absolute" as const);
         const elapsedSeconds = Math.round((now - thinkingStartedAtRef.current) / 1000);

--- a/frontend/src/utils/UnifiedMessageProcessor.ts
+++ b/frontend/src/utils/UnifiedMessageProcessor.ts
@@ -14,6 +14,7 @@ import {
   createTodoMessageFromInput,
 } from "./messageConversion";
 import { isThinkingContentItem } from "./messageTypes";
+import type { ThinkingTimeoutContext } from "../hooks/streaming/useMessageProcessor";
 import { extractToolInfo, generateToolPatterns } from "./toolUtils";
 import type { CommandLoopRequest } from "../hooks/chat/usePermissions";
 
@@ -75,10 +76,7 @@ export interface ProcessingContext {
   onShowCommandLoopRequest?: (request: CommandLoopRequest) => void;
 
   // Thinking timeout
-  onThinkingTimeout?: (
-    accumulatedContent: string,
-    info: { reason: "idle" | "absolute"; elapsedSeconds: number },
-  ) => void;
+  onThinkingTimeout?: (accumulatedContent: string, info: ThinkingTimeoutContext) => void;
 }
 
 /**

--- a/frontend/src/utils/UnifiedMessageProcessor.ts
+++ b/frontend/src/utils/UnifiedMessageProcessor.ts
@@ -75,7 +75,10 @@ export interface ProcessingContext {
   onShowCommandLoopRequest?: (request: CommandLoopRequest) => void;
 
   // Thinking timeout
-  onThinkingTimeout?: (accumulatedContent: string) => void;
+  onThinkingTimeout?: (
+    accumulatedContent: string,
+    info: { reason: "idle" | "absolute"; elapsedSeconds: number },
+  ) => void;
 }
 
 /**

--- a/frontend/src/utils/UnifiedMessageProcessor.ts
+++ b/frontend/src/utils/UnifiedMessageProcessor.ts
@@ -529,6 +529,10 @@ export class UnifiedMessageProcessor {
     else if (message.message?.content && Array.isArray(message.message.content)) {
       for (const item of message.message.content) {
         if (item.type === "text") {
+          // Regular text content — clear thinking state when text starts
+          if (options.isStreaming) {
+            context.setCurrentThinkingMessage?.(null);
+          }
           if (options.isStreaming) {
             this.handleAssistantText(item, context, options);
           } else {


### PR DESCRIPTION
## PR 描述更新

Supersedes the original description. This PR fixes the thinking timeout bug and includes an additional fix discovered during testing.

---

### 核心修复：Thinking Timeout 双 deadline 机制

**问题：** 思考超时计时器基于累计时间触发，即使 AI 正在活跃地产生输出，也会导致误报的"自动中止"通知。

**修复：** 实现双 deadline 单计时器机制：
- **空闲超时** (5 min): 最后一次内容输出后无新输出
- **绝对超时** (15 min): 总思考时间上限
- `thinkingAbortedRef` 防止超时后缓冲块重启计时器

### 附加修复：`UnifiedMessageProcessor` `text` 内容不清除 `thinking state`

在测试过程中发现：`message.content`（Claude 格式）的 `text` 内容分支缺少 `setCurrentThinkingMessage(null)` 调用，而 `parts`（Qwen SDK 格式）分支已有此调用。这导致 AI 从 `thinking` 转为 `text` 输出时 `timer` 不被清除，可能产生误触发。两处行为现已一致。

### 变更文件

| 文件 | 变更 |
|------|------|
| `useStreamParser.ts` | 核心：单 `timer` + 双 `deadline` + `thinkingAbortedRef` 竞态保护 |
| `useMessageProcessor.ts` | 新增 `ThinkingTimeoutContext` 接口，更新 `onThinkingTimeout` 签名 |
| `UnifiedMessageProcessor.ts` | 统一使用 `ThinkingTimeoutContext` 类型；`text` 内容清除 `thinking state` |
| `ChatPage.tsx` | 通知 UI 区分 `idle`/`absolute`；统一类型引用 |

### 测试

5 个测试用例覆盖：
1. `idle` 超时 (5 `min` 无新输出)
2. 正常结束不触发超时
3. 非 `thinking` 内容不启动 `timer`
4. `absolute` 超时 (15 `min` 持续输出)
5. 竞态条件：超时后缓冲 `chunk` 不重启 `timer`
