### PR TITLE
fix: replace hardcoded English strings with i18n t() calls

### DIFF
--- a/frontend/src/components/ChatPage.tsx
+++ b/frontend/src/components/ChatPage.tsx
@@ -698,7 +698,7 @@ export function ChatPage() {
           addMessage({
             type: "chat",
             role: "assistant",
-            content: "Error: Failed to get response",
+            content: t("chat.errorFailedResponse"),
             timestamp: Date.now(),
           });
         }
@@ -1242,7 +1242,7 @@ export function ChatPage() {
               <button
                 onClick={isHistoryView ? handleBackToChat : handleBackToHistory}
                 className="p-1.5 rounded-lg bg-white/80 dark:bg-slate-800/80 border border-slate-200 dark:border-slate-700 hover:bg-white dark:hover:bg-slate-800 transition-all duration-200 backdrop-blur-sm shadow-sm hover:shadow-md"
-                aria-label={isHistoryView ? "Back to chat" : "Back to history"}
+                aria-label={isHistoryView ? t("chat.backToChat") : t("chat.backToHistory")}
               >
                 <ChevronLeftIcon className="w-4 h-4 text-slate-600 dark:text-slate-400" />
               </button>
@@ -1252,7 +1252,7 @@ export function ChatPage() {
                 <div className="flex items-center">
                   {isHistoryView ? (
                     <h1 className="text-slate-800 dark:text-slate-100 text-lg sm:text-xl font-bold tracking-tight">
-                      Conversation History
+                      {t("chat.conversationHistory")}
                     </h1>
                   ) : isRemoteWorkspace ? (
                     <button
@@ -1261,7 +1261,7 @@ export function ChatPage() {
                       aria-label={t("chat.backToProjects")}
                       title={t("chat.backToProjects")}
                     >
-                      {workingDirectory || "Chat"}
+                      {workingDirectory || t("chat.chat")}
                     </button>
                   ) : sessionId ? (
                     <>
@@ -1281,7 +1281,7 @@ export function ChatPage() {
                       aria-label={t("chat.backToProjects")}
                       title={t("chat.backToProjects")}
                     >
-                      {workingDirectory || "Chat"}
+                      {workingDirectory || t("chat.chat")}
                     </button>
                   )}
                 </div>
@@ -1358,7 +1358,7 @@ export function ChatPage() {
             <div className="text-center">
               <div className="w-8 h-8 border-2 border-slate-300 border-t-slate-600 rounded-full animate-spin mx-auto mb-4"></div>
               <p className="text-slate-600 dark:text-slate-400">
-                Loading conversation history...
+                {t("chat.loadingHistory")}
               </p>
             </div>
           </div>
@@ -1382,7 +1382,7 @@ export function ChatPage() {
                 </svg>
               </div>
               <h2 className="text-slate-800 dark:text-slate-100 text-xl font-semibold mb-2">
-                Error Loading Conversation
+                {t("chat.errorLoadingConversation")}
               </h2>
               <p className="text-slate-600 dark:text-slate-400 text-sm mb-4">
                 {historyError}
@@ -1391,7 +1391,7 @@ export function ChatPage() {
                 onClick={() => navigate({ search: "" })}
                 className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
               >
-                Start New Conversation
+                {t("chat.startNewConversation")}
               </button>
             </div>
           </div>
@@ -1548,7 +1548,7 @@ export function ChatPage() {
                 <button
                   onClick={handleCommandLoopAbort}
                   className="text-amber-500 hover:text-amber-700 dark:text-amber-400 dark:hover:text-amber-200 flex-shrink-0"
-                  aria-label="Dismiss"
+                  aria-label={t("chat.dismiss")}
                 >
                   <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
@@ -1602,7 +1602,7 @@ export function ChatPage() {
                 <button
                   onClick={() => setThinkingTimeoutInfo(null)}
                   className="text-blue-500 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-200 flex-shrink-0"
-                  aria-label="Dismiss"
+                  aria-label={t("chat.dismiss")}
                 >
                   <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />

--- a/frontend/src/components/HistoryView.tsx
+++ b/frontend/src/components/HistoryView.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
+import { useTranslation } from "react-i18next";
 import type { ConversationSummary } from "../../../shared/types";
 import { getHistoriesUrl } from "../config/api";
 
@@ -11,6 +12,7 @@ interface HistoryViewProps {
 
 export function HistoryView({ encodedName }: HistoryViewProps) {
   const navigate = useNavigate();
+  const { t } = useTranslation();
   const [conversations, setConversations] = useState<ConversationSummary[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -35,7 +37,7 @@ export function HistoryView({ encodedName }: HistoryViewProps) {
         setConversations(data.conversations || []);
       } catch (err) {
         setError(
-          err instanceof Error ? err.message : "Failed to load conversations",
+          err instanceof Error ? err.message : t("history.failedToLoad"),
         );
       } finally {
         setLoading(false);
@@ -57,7 +59,7 @@ export function HistoryView({ encodedName }: HistoryViewProps) {
         <div className="text-center">
           <div className="w-8 h-8 border-2 border-slate-300 border-t-slate-600 rounded-full animate-spin mx-auto mb-4"></div>
           <p className="text-slate-600 dark:text-slate-400">
-            {!encodedName ? "Loading project..." : "Loading conversations..."}
+            {!encodedName ? t("history.loadingProject") : t("history.loadingConversations")}
           </p>
         </div>
       </div>
@@ -84,7 +86,7 @@ export function HistoryView({ encodedName }: HistoryViewProps) {
             </svg>
           </div>
           <h2 className="text-slate-800 dark:text-slate-100 text-xl font-semibold mb-2">
-            Error Loading History
+            {t("history.errorLoadingHistory")}
           </h2>
           <p className="text-slate-600 dark:text-slate-400 text-sm mb-4">
             {error}
@@ -114,10 +116,10 @@ export function HistoryView({ encodedName }: HistoryViewProps) {
             </svg>
           </div>
           <h2 className="text-slate-800 dark:text-slate-100 text-xl font-semibold mb-2">
-            No Conversations Yet
+            {t("history.noConversations")}
           </h2>
           <p className="text-slate-600 dark:text-slate-400 text-sm max-w-sm">
-            Start chatting to see your conversation history here.
+            {t("history.startChatting")}
           </p>
         </div>
       </div>
@@ -137,11 +139,11 @@ export function HistoryView({ encodedName }: HistoryViewProps) {
               <div className="flex items-start justify-between">
                 <div className="flex-1 min-w-0">
                   <h3 className="text-sm font-medium text-slate-900 dark:text-slate-100 truncate">
-                    Session: {conversation.sessionId.substring(0, 8)}...
+                    {t("history.session")}{conversation.sessionId.substring(0, 8)}...
                   </h3>
                   <p className="text-xs text-slate-500 dark:text-slate-400 mt-1">
                     {new Date(conversation.startTime).toLocaleString()} •{" "}
-                    {conversation.messageCount} messages
+                    {conversation.messageCount} {t("history.messages")}
                   </p>
                   <p className="text-sm text-slate-600 dark:text-slate-300 mt-2 line-clamp-2">
                     {conversation.lastMessagePreview}

--- a/frontend/src/components/RemoteDirectoryBrowser.tsx
+++ b/frontend/src/components/RemoteDirectoryBrowser.tsx
@@ -55,7 +55,7 @@ export function RemoteDirectoryBrowser({
         }
       } catch (err) {
         setError(
-          err instanceof Error ? err.message : "Failed to browse remote directory"
+          err instanceof Error ? err.message : t("remoteDirectory.failedToBrowse")
         );
       } finally {
         setLoading(false);
@@ -120,7 +120,7 @@ export function RemoteDirectoryBrowser({
           />
         </svg>
         <span className="text-slate-600 dark:text-slate-400">
-          Loading remote directory...
+          {t("remoteDirectory.loadingRemote")}
         </span>
       </div>
     );
@@ -145,7 +145,7 @@ export function RemoteDirectoryBrowser({
       {/* Header with close button */}
       <div className="flex items-center justify-between px-3 py-2 bg-slate-100 dark:bg-slate-700/50 rounded-t-lg border-b border-slate-200 dark:border-slate-600">
         <span className="text-xs font-medium text-slate-500 dark:text-slate-400 uppercase tracking-wide">
-          Remote Machine
+          {t("remoteDirectory.remoteMachine")}
         </span>
         <button
           onClick={onClose}
@@ -210,7 +210,7 @@ export function RemoteDirectoryBrowser({
         {directories.length === 0 ? (
           <div className="flex flex-col items-center justify-center h-full text-slate-500 dark:text-slate-400">
             <FolderIcon className="h-12 w-12 mb-2 opacity-50" />
-            <p className="text-sm">No subdirectories found</p>
+            <p className="text-sm">{t("remoteDirectory.noSubdirectories")}</p>
           </div>
         ) : (
           <div className="space-y-1">
@@ -235,11 +235,11 @@ export function RemoteDirectoryBrowser({
                       }}
                       className="px-2 py-1 text-xs bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 rounded hover:bg-blue-200 dark:hover:bg-blue-900/50"
                     >
-                      Select
+                      {t("common.select")}
                     </button>
                   )}
                   <span className="text-xs text-slate-400 dark:text-slate-500">
-                    {dir.isWritable ? "Writable" : "Read-only"}
+                    {dir.isWritable ? t("directoryBrowser.writable") : t("directoryBrowser.readOnly")}
                   </span>
                 </div>
               </button>
@@ -254,7 +254,7 @@ export function RemoteDirectoryBrowser({
           onClick={handleSelectCurrent}
           className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 text-sm font-medium"
         >
-          Select This Folder
+          {t("directoryBrowser.selectThisFolder")}
         </button>
       </div>
     </div>

--- a/frontend/src/components/RemoteMachineSelector.tsx
+++ b/frontend/src/components/RemoteMachineSelector.tsx
@@ -44,18 +44,16 @@ function getStatusDotColor(status: RemoteMachine["status"]): string {
   }
 }
 
-function getStatusLabel(status: RemoteMachine["status"]): string {
-  // This function is used in a non-component context for the title attribute
-  // For the visible status label, we use inline translated text
+function getStatusLabel(status: RemoteMachine["status"], t: (key: string) => string): string {
   switch (status) {
     case "online":
-      return "Online";
+      return t("chat.statusOnline");
     case "busy":
-      return "Busy";
+      return t("chat.statusBusy");
     case "offline":
-      return "Offline";
+      return t("chat.statusOffline");
     case "error":
-      return "Error";
+      return t("chat.statusError");
     default:
       return status;
   }
@@ -77,7 +75,7 @@ export function RemoteMachineSelector({
       const response = await fetchRemoteMachines();
       setMachines(response.machines || []);
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to load remote machines");
+      setError(err instanceof Error ? err.message : t("remoteMachine.failedToLoad"));
     } finally {
       setLoading(false);
     }
@@ -115,7 +113,7 @@ export function RemoteMachineSelector({
           />
         </svg>
         <span className="text-slate-600 dark:text-slate-400">
-          Loading remote machines...
+          {t("remoteMachine.loading")}
         </span>
       </div>
     );
@@ -130,7 +128,7 @@ export function RemoteMachineSelector({
           className="flex items-center gap-2 px-3 py-1.5 text-sm bg-slate-100 dark:bg-slate-700 rounded-lg hover:bg-slate-200 dark:hover:bg-slate-600 text-slate-700 dark:text-slate-300"
         >
           <ArrowPathIcon className="h-4 w-4" />
-          Retry
+          {t("common.retry")}
         </button>
       </div>
     );
@@ -141,14 +139,14 @@ export function RemoteMachineSelector({
       <div className="flex flex-col items-center justify-center p-8">
         <ComputerDesktopIcon className="h-12 w-12 text-slate-300 dark:text-slate-600 mb-3" />
         <p className="text-slate-500 dark:text-slate-400 text-sm mb-3">
-          No remote machines available
+          {t("remoteMachine.noMachines")}
         </p>
         <button
           onClick={loadMachines}
           className="flex items-center gap-2 px-3 py-1.5 text-sm bg-slate-100 dark:bg-slate-700 rounded-lg hover:bg-slate-200 dark:hover:bg-slate-600 text-slate-700 dark:text-slate-300"
         >
           <ArrowPathIcon className="h-4 w-4" />
-          Refresh
+          {t("chat.refreshMachines")}
         </button>
       </div>
     );
@@ -159,7 +157,7 @@ export function RemoteMachineSelector({
       {/* Header with refresh */}
       <div className="flex items-center justify-between">
         <h3 className="text-sm font-medium text-slate-700 dark:text-slate-300">
-          Remote Machines
+          {t("remoteMachine.title")}
         </h3>
         <button
           onClick={loadMachines}
@@ -190,7 +188,7 @@ export function RemoteMachineSelector({
                 {/* Status dot */}
                 <span
                   className={`inline-block w-2.5 h-2.5 rounded-full flex-shrink-0 ${getStatusDotColor(machine.status)}`}
-                  title={getStatusLabel(machine.status)}
+                  title={getStatusLabel(machine.status, t)}
                 />
 
                 {/* OS icon */}
@@ -232,12 +230,12 @@ export function RemoteMachineSelector({
       {selectedMachine && (
         <div className="mt-2 p-3 bg-slate-50 dark:bg-slate-700/30 rounded-lg border border-slate-200 dark:border-slate-600">
           <h4 className="text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wide mb-2">
-            Machine Details
+            {t("remoteMachine.machineDetails")}
           </h4>
           <div className="space-y-1.5 text-sm text-slate-700 dark:text-slate-300">
             {selectedMachine.os_type && (
               <div className="flex justify-between">
-                <span className="text-slate-500 dark:text-slate-400">OS</span>
+                <span className="text-slate-500 dark:text-slate-400">{t("remoteMachine.os")}</span>
                 <span className="font-mono">
                   {selectedMachine.os_type}
                   {selectedMachine.os_version ? ` ${selectedMachine.os_version}` : ""}
@@ -246,15 +244,15 @@ export function RemoteMachineSelector({
             )}
             {selectedMachine.capabilities?.cpu_count != null && (
               <div className="flex justify-between">
-                <span className="text-slate-500 dark:text-slate-400">CPU</span>
+                <span className="text-slate-500 dark:text-slate-400">{t("remoteMachine.cpu")}</span>
                 <span className="font-mono">
-                  {selectedMachine.capabilities.cpu_count} cores
+                  {selectedMachine.capabilities.cpu_count} {t("remoteMachine.cores")}
                 </span>
               </div>
             )}
             {selectedMachine.capabilities?.memory_gb != null && (
               <div className="flex justify-between">
-                <span className="text-slate-500 dark:text-slate-400">Memory</span>
+                <span className="text-slate-500 dark:text-slate-400">{t("remoteMachine.memory")}</span>
                 <span className="font-mono">
                   {selectedMachine.capabilities.memory_gb} GB
                 </span>
@@ -262,13 +260,13 @@ export function RemoteMachineSelector({
             )}
             {selectedMachine.capabilities?.gpu && (
               <div className="flex justify-between">
-                <span className="text-slate-500 dark:text-slate-400">GPU</span>
+                <span className="text-slate-500 dark:text-slate-400">{t("remoteMachine.gpu")}</span>
                 <span className="font-mono">{selectedMachine.capabilities.gpu}</span>
               </div>
             )}
             {selectedMachine.capabilities?.disk_gb != null && (
               <div className="flex justify-between">
-                <span className="text-slate-500 dark:text-slate-400">Disk</span>
+                <span className="text-slate-500 dark:text-slate-400">{t("remoteMachine.disk")}</span>
                 <span className="font-mono">
                   {selectedMachine.capabilities.disk_gb} GB
                 </span>
@@ -276,7 +274,7 @@ export function RemoteMachineSelector({
             )}
             {selectedMachine.last_heartbeat && (
               <div className="flex justify-between">
-                <span className="text-slate-500 dark:text-slate-400">Last heartbeat</span>
+                <span className="text-slate-500 dark:text-slate-400">{t("remoteMachine.lastHeartbeat")}</span>
                 <span className="font-mono text-xs">
                   {new Date(selectedMachine.last_heartbeat).toLocaleString()}
                 </span>

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -86,7 +86,16 @@
     "statusOnline": "Online",
     "statusBusy": "Busy",
     "statusOffline": "Offline",
-    "statusError": "Error"
+    "statusError": "Error",
+    "errorFailedResponse": "Error: Failed to get response",
+    "backToChat": "Back to chat",
+    "backToHistory": "Back to history",
+    "conversationHistory": "Conversation History",
+    "chat": "Chat",
+    "loadingHistory": "Loading conversation history...",
+    "errorLoadingConversation": "Error Loading Conversation",
+    "startNewConversation": "Start New Conversation",
+    "dismiss": "Dismiss"
   },
   "permission": {
     "title": "Permission Required",
@@ -156,5 +165,35 @@
     "estimatedInfo": "Sub-categories are proportionally estimated from visible messages. Actual distribution may vary.",
     "cacheInfo": "Overhead is based on API cache data (more accurate). Sub-categories are proportionally scaled to match.",
     "autoCompressInfo": "Auto-compress triggers at 70%"
+  },
+  "remoteMachine": {
+    "loading": "Loading remote machines...",
+    "failedToLoad": "Failed to load remote machines",
+    "noMachines": "No remote machines available",
+    "title": "Remote Machines",
+    "machineDetails": "Machine Details",
+    "lastHeartbeat": "Last heartbeat",
+    "os": "OS",
+    "cpu": "CPU",
+    "cores": "cores",
+    "memory": "Memory",
+    "gpu": "GPU",
+    "disk": "Disk"
+  },
+  "remoteDirectory": {
+    "loadingRemote": "Loading remote directory...",
+    "failedToBrowse": "Failed to browse remote directory",
+    "remoteMachine": "Remote Machine",
+    "noSubdirectories": "No subdirectories found"
+  },
+  "history": {
+    "loadingProject": "Loading project...",
+    "loadingConversations": "Loading conversations...",
+    "errorLoadingHistory": "Error Loading History",
+    "noConversations": "No Conversations Yet",
+    "startChatting": "Start chatting to see your conversation history here.",
+    "session": "Session: ",
+    "messages": "messages",
+    "failedToLoad": "Failed to load conversations"
   }
 }

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -86,7 +86,16 @@
     "statusOnline": "在线",
     "statusBusy": "忙碌",
     "statusOffline": "离线",
-    "statusError": "错误"
+    "statusError": "错误",
+    "errorFailedResponse": "错误：未能获取回复",
+    "backToChat": "返回对话",
+    "backToHistory": "返回历史记录",
+    "conversationHistory": "对话历史",
+    "chat": "对话",
+    "loadingHistory": "正在加载对话历史...",
+    "errorLoadingConversation": "加载对话失败",
+    "startNewConversation": "开始新对话",
+    "dismiss": "关闭"
   },
   "permission": {
     "title": "需要权限确认",
@@ -156,5 +165,35 @@
     "estimatedInfo": "子分类基于可见消息按比例估算，实际分布可能不同。",
     "cacheInfo": "系统开销基于 API 缓存数据（更准确）。子分类已按比例缩放。",
     "autoCompressInfo": "自动压缩在 70% 时触发"
+  },
+  "remoteMachine": {
+    "loading": "正在加载远程机器...",
+    "failedToLoad": "加载远程机器失败",
+    "noMachines": "没有可用的远程机器",
+    "title": "远程机器",
+    "machineDetails": "机器详情",
+    "lastHeartbeat": "最近心跳",
+    "os": "操作系统",
+    "cpu": "CPU",
+    "cores": "核心",
+    "memory": "内存",
+    "gpu": "GPU",
+    "disk": "磁盘"
+  },
+  "remoteDirectory": {
+    "loadingRemote": "正在加载远程目录...",
+    "failedToBrowse": "浏览远程目录失败",
+    "remoteMachine": "远程机器",
+    "noSubdirectories": "未找到子目录"
+  },
+  "history": {
+    "loadingProject": "正在加载项目...",
+    "loadingConversations": "正在加载对话...",
+    "errorLoadingHistory": "加载历史记录失败",
+    "noConversations": "暂无对话记录",
+    "startChatting": "开始对话以在此处查看对话历史。",
+    "session": "会话：",
+    "messages": "条消息",
+    "failedToLoad": "加载对话失败"
   }
 }


### PR DESCRIPTION
Components affected:
- RemoteMachineSelector: loading/error/machine details labels
- RemoteDirectoryBrowser: loading/error/header/footer labels
- HistoryView: add useTranslation, replace all 7 hardcoded strings
- ChatPage: error messages, history view, aria-labels

Adds remoteMachine, remoteDirectory, history sections to translation files and extends the chat section with missing keys.

Ref: open-ace/open-ace#228