### PR TITLE
fix: translate hardcoded Local/Remote strings in AddProjectModal

### DIFF
--- a/frontend/src/components/AddProjectModal.tsx
+++ b/frontend/src/components/AddProjectModal.tsx
@@ -216,7 +216,7 @@ export function AddProjectModal({
                     {/* Workspace Type Toggle */}
                     <div className="flex items-center gap-4 mb-4">
                       <span className="text-sm font-medium text-slate-700 dark:text-slate-300">
-                        Workspace:
+                        {t("project.workspaceType")}
                       </span>
                       <div className="flex rounded-lg border border-slate-300 dark:border-slate-600 overflow-hidden">
                         <button
@@ -229,7 +229,7 @@ export function AddProjectModal({
                           }`}
                         >
                           <ComputerDesktopIcon className="h-4 w-4" />
-                          Local
+                          {t("project.local")}
                         </button>
                         <button
                           type="button"
@@ -241,7 +241,7 @@ export function AddProjectModal({
                           }`}
                         >
                           <ServerIcon className="h-4 w-4" />
-                          Remote
+                          {t("project.remote")}
                         </button>
                       </div>
                     </div>
@@ -262,7 +262,7 @@ export function AddProjectModal({
                         <div className="space-y-4">
                           <div>
                             <label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">
-                              Select Remote Machine
+                              {t("project.selectRemoteMachine")}
                             </label>
                             <RemoteMachineSelector
                               onSelect={(machine) => setSelectedMachine(machine)}
@@ -272,7 +272,7 @@ export function AddProjectModal({
                           {selectedMachine && (
                             <div>
                               <label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">
-                                Select Directory on {selectedMachine.machine_name}
+                                {t("project.selectDirectoryOnMachine", { machine: selectedMachine.machine_name })}
                               </label>
                               <RemoteDirectoryBrowser
                                 machineId={selectedMachine.machine_id}
@@ -294,7 +294,7 @@ export function AddProjectModal({
                       <div className="flex items-center gap-2 p-3 bg-purple-50 dark:bg-purple-900/20 rounded-lg border border-purple-200 dark:border-purple-800">
                         <ServerIcon className="h-5 w-5 text-purple-500" />
                         <span className="text-sm text-purple-700 dark:text-purple-300">
-                          Remote workspace on <strong>{selectedMachine.machine_name}</strong>
+                          {t("project.remoteWorkspaceOn", { machine: selectedMachine.machine_name })}
                           {selectedMachine.hostname && ` (${selectedMachine.hostname})`}
                         </span>
                       </div>

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -25,7 +25,13 @@
     "created": "Project Created!",
     "failedToCreate": "Failed to create project",
     "tryAgain": "Try Again",
-    "invalidPath": "Invalid path"
+    "invalidPath": "Invalid path",
+    "workspaceType": "Workspace:",
+    "local": "Local",
+    "remote": "Remote",
+    "selectRemoteMachine": "Select Remote Machine",
+    "selectDirectoryOnMachine": "Select Directory on {{machine}}",
+    "remoteWorkspaceOn": "Remote workspace on {{machine}}"
   },
   "directoryBrowser": {
     "home": "Home",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -25,7 +25,13 @@
     "created": "项目创建成功！",
     "failedToCreate": "创建项目失败",
     "tryAgain": "重试",
-    "invalidPath": "路径无效"
+    "invalidPath": "路径无效",
+    "workspaceType": "工作区：",
+    "local": "本地",
+    "remote": "远程",
+    "selectRemoteMachine": "选择远程机器",
+    "selectDirectoryOnMachine": "选择 {{machine}} 上的目录",
+    "remoteWorkspaceOn": "{{machine}} 上的远程工作区"
   },
   "directoryBrowser": {
     "home": "主目录",


### PR DESCRIPTION
## Summary
- 替换 AddProjectModal 中 6 处硬编码英文字符串为 `t()` 翻译函数调用
- 新增 `project.workspaceType`、`project.local`、`project.remote`、`project.selectRemoteMachine`、`project.selectDirectoryOnMachine`、`project.remoteWorkspaceOn` 翻译 key

## Test plan
- [x] TypeScript 编译通过
- [ ] `?lang=zh` 下添加项目弹窗显示"本地"/"远程"而非"Local"/"Remote"

Ref: open-ace/open-ace#227

🤖 Generated with [Claude Code](https://claude.com/claude-code)