### PR TITLE
fix: handle SSE error events in remote chat hook

### DIFF
--- a/frontend/src/hooks/useRemoteChat.ts
+++ b/frontend/src/hooks/useRemoteChat.ts
@@ -70,6 +70,13 @@ export function useRemoteChat(options?: RemoteChatOptions) {
       if (parsed.type === "claude_json" && parsed.data?.type === "result") {
         setIsLoading(false);
       }
+
+      // Handle error events from the remote agent (e.g. CLI crash, send failure)
+      if (parsed.type === "error") {
+        setIsLoading(false);
+        setError(parsed.data || "Unknown remote error");
+        return; // Don't forward to onStreamLine
+      }
     } catch { /* not JSON, ignore */ }
 
     // Forward to stream processor


### PR DESCRIPTION
## Summary

- Add error event handling in `useRemoteChat`'s `handleSSELine` callback
- When the remote agent sends `{"type": "error", "data": ...}` events (e.g. CLI crash, send_message failure), the frontend now displays the error message and clears the loading state
- Previously, these events were silently ignored, leaving the UI stuck in "thinking" indefinitely

## Context

This fix works together with the server-side fix ([open-ace#314](https://github.com/open-ace/open-ace/pull/314)) that forwards stderr output as error events from the SSE stream.

## Test plan

- [x] Frontend builds successfully with the change
- [ ] Verify: when a remote CLI crashes, the error message appears in the chat instead of infinite "thinking"

🤖 Generated with [Claude Code](https://claude.com/claude-code)