### PR TITLE
fix: SSE connection error recovery

### DIFF
--- a/frontend/src/components/ChatPage.tsx
+++ b/frontend/src/components/ChatPage.tsx
@@ -616,6 +616,16 @@ export function ChatPage() {
           } catch { /* ignore parse error */ }
         }
 
+        // Handle non-200 responses (409, 401, 500, etc.)
+        if (!response.ok) {
+          let errorMsg = `Server error: ${response.status}`;
+          try {
+            const errorData = await response.json();
+            if (errorData.error) errorMsg = String(errorData.error);
+          } catch { /* use default message */ }
+          throw new Error(errorMsg);
+        }
+
         if (!response.body) throw new Error("No response body");
 
         const reader = response.body.getReader();
@@ -705,6 +715,9 @@ export function ChatPage() {
             timestamp: Date.now(),
           });
         }
+        // Clear stale sessionId so next request creates a fresh session
+        // instead of trying to resume a dead one (e.g. after server restart)
+        setCurrentSessionId(null);
       } finally {
         clearAbortRef.current = false;
 
@@ -830,9 +843,11 @@ export function ChatPage() {
         });
         if (!resp.ok) {
           console.warn("Permission response failed:", resp.status);
+          abortRequest(currentRequestId, true, resetRequestState);
         }
       } catch (error) {
         console.error("Failed to send permission response:", error);
+        abortRequest(currentRequestId, true, resetRequestState);
       }
       closePermissionRequest();
       return;
@@ -860,6 +875,9 @@ export function ChatPage() {
     clearNotification,
     isRemoteWorkspace,
     remoteChat,
+    abortRequest,
+    currentRequestId,
+    resetRequestState,
   ]);
 
   const handlePermissionAllowPermanent = useCallback(async () => {
@@ -894,9 +912,11 @@ export function ChatPage() {
         });
         if (!resp.ok) {
           console.warn("Permission response failed:", resp.status);
+          abortRequest(currentRequestId, true, resetRequestState);
         }
       } catch (error) {
         console.error("Failed to send permission response:", error);
+        abortRequest(currentRequestId, true, resetRequestState);
       }
       closePermissionRequest();
       return;
@@ -924,6 +944,9 @@ export function ChatPage() {
     clearNotification,
     isRemoteWorkspace,
     remoteChat,
+    abortRequest,
+    currentRequestId,
+    resetRequestState,
   ]);
 
   // "Allow all run_shell_command" — persist bare tool name for broad approval
@@ -943,9 +966,11 @@ export function ChatPage() {
         });
         if (!resp.ok) {
           console.warn("Permission response failed:", resp.status);
+          abortRequest(currentRequestId, true, resetRequestState);
         }
       } catch (error) {
         console.error("Failed to send permission response:", error);
+        abortRequest(currentRequestId, true, resetRequestState);
       }
       closePermissionRequest();
       return;
@@ -966,6 +991,9 @@ export function ChatPage() {
     closePermissionRequest,
     resetDenialCounter,
     clearNotification,
+    abortRequest,
+    currentRequestId,
+    resetRequestState,
   ]);
 
   const handlePermissionDeny = useCallback(async () => {
@@ -1002,9 +1030,11 @@ export function ChatPage() {
         });
         if (!resp.ok) {
           console.warn("Permission response failed:", resp.status);
+          abortRequest(currentRequestId, true, resetRequestState);
         }
       } catch (error) {
         console.error("Failed to send permission response:", error);
+        abortRequest(currentRequestId, true, resetRequestState);
       }
       closePermissionRequest();
       return;
@@ -1034,6 +1064,9 @@ export function ChatPage() {
     clearNotification,
     isRemoteWorkspace,
     remoteChat,
+    abortRequest,
+    currentRequestId,
+    resetRequestState,
   ]);
 
   // Plan mode request handlers

--- a/frontend/src/components/ChatPage.tsx
+++ b/frontend/src/components/ChatPage.tsx
@@ -714,10 +714,10 @@ export function ChatPage() {
             content: t("chat.errorFailedResponse"),
             timestamp: Date.now(),
           });
+          // Clear stale sessionId so next request creates a fresh session
+          // instead of trying to resume a dead one (e.g. after server restart)
+          setCurrentSessionId(null);
         }
-        // Clear stale sessionId so next request creates a fresh session
-        // instead of trying to resume a dead one (e.g. after server restart)
-        setCurrentSessionId(null);
       } finally {
         clearAbortRef.current = false;
 
@@ -806,6 +806,12 @@ export function ChatPage() {
   }, [setMessages, setCurrentSessionId, setHasShownInitMessage, setHasReceivedInit, addMessage, t, navigate, abortRequest, currentRequestId, isLoading, resetRequestState, isRemoteWorkspace, remoteChat.abortCurrentRequest, remoteChat.session]);
 
   // Permission request handlers
+  // Abort backend request when permission response HTTP POST fails,
+  // preventing stuck canUseTool promises that block the stream forever.
+  const handlePermissionAbort = useCallback(async () => {
+    await abortRequest(currentRequestId, isLoading, resetRequestState);
+  }, [abortRequest, currentRequestId, isLoading, resetRequestState]);
+
   const handlePermissionAllow = useCallback(async () => {
     if (!permissionRequest) return;
 
@@ -843,11 +849,11 @@ export function ChatPage() {
         });
         if (!resp.ok) {
           console.warn("Permission response failed:", resp.status);
-          abortRequest(currentRequestId, true, resetRequestState);
+          await handlePermissionAbort();
         }
       } catch (error) {
         console.error("Failed to send permission response:", error);
-        abortRequest(currentRequestId, true, resetRequestState);
+        await handlePermissionAbort();
       }
       closePermissionRequest();
       return;
@@ -875,9 +881,7 @@ export function ChatPage() {
     clearNotification,
     isRemoteWorkspace,
     remoteChat,
-    abortRequest,
-    currentRequestId,
-    resetRequestState,
+    handlePermissionAbort,
   ]);
 
   const handlePermissionAllowPermanent = useCallback(async () => {
@@ -912,11 +916,11 @@ export function ChatPage() {
         });
         if (!resp.ok) {
           console.warn("Permission response failed:", resp.status);
-          abortRequest(currentRequestId, true, resetRequestState);
+          await handlePermissionAbort();
         }
       } catch (error) {
         console.error("Failed to send permission response:", error);
-        abortRequest(currentRequestId, true, resetRequestState);
+        await handlePermissionAbort();
       }
       closePermissionRequest();
       return;
@@ -944,9 +948,7 @@ export function ChatPage() {
     clearNotification,
     isRemoteWorkspace,
     remoteChat,
-    abortRequest,
-    currentRequestId,
-    resetRequestState,
+    handlePermissionAbort,
   ]);
 
   // "Allow all run_shell_command" — persist bare tool name for broad approval
@@ -966,11 +968,11 @@ export function ChatPage() {
         });
         if (!resp.ok) {
           console.warn("Permission response failed:", resp.status);
-          abortRequest(currentRequestId, true, resetRequestState);
+          await handlePermissionAbort();
         }
       } catch (error) {
         console.error("Failed to send permission response:", error);
-        abortRequest(currentRequestId, true, resetRequestState);
+        await handlePermissionAbort();
       }
       closePermissionRequest();
       return;
@@ -991,9 +993,7 @@ export function ChatPage() {
     closePermissionRequest,
     resetDenialCounter,
     clearNotification,
-    abortRequest,
-    currentRequestId,
-    resetRequestState,
+    handlePermissionAbort,
   ]);
 
   const handlePermissionDeny = useCallback(async () => {
@@ -1030,11 +1030,11 @@ export function ChatPage() {
         });
         if (!resp.ok) {
           console.warn("Permission response failed:", resp.status);
-          abortRequest(currentRequestId, true, resetRequestState);
+          await handlePermissionAbort();
         }
       } catch (error) {
         console.error("Failed to send permission response:", error);
-        abortRequest(currentRequestId, true, resetRequestState);
+        await handlePermissionAbort();
       }
       closePermissionRequest();
       return;
@@ -1064,9 +1064,7 @@ export function ChatPage() {
     clearNotification,
     isRemoteWorkspace,
     remoteChat,
-    abortRequest,
-    currentRequestId,
-    resetRequestState,
+    handlePermissionAbort,
   ]);
 
   // Plan mode request handlers


### PR DESCRIPTION
## Summary

Fix 3 issues related to SSE connection error handling:

1. **Stale sessionId after server restart** — Clear `currentSessionId` in catch block so next request creates a fresh session instead of trying to resume a dead one
2. **Non-200 responses silently swallowed** — Add `response.ok` check to show meaningful errors for 409/401/500 instead of silently failing
3. **Permission response failure leaves backend stuck** — Abort backend request when `sendPermissionResponse` HTTP POST fails, preventing stuck `canUseTool` promises

## Test plan

- [ ] Send message → restart backend → send again → should auto-recover with fresh session
- [ ] Stop backend → send message → should show meaningful error message
- [ ] Disconnect network during permission dialog → click allow → should abort and recover
- [ ] `tsc --noEmit` zero errors (frontend)

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)