### PR TITLE
fix: skip permission dialog for tools already in allowed list

### DIFF
--- a/backend/handlers/chat.test.ts
+++ b/backend/handlers/chat.test.ts
@@ -656,6 +656,182 @@ describe("Chat Handler - Permission Mode Tests", () => {
     });
   });
 
+  describe("canUseTool - allowedTools matching", () => {
+    let capturedCanUseTool: ((toolName: string, input: Record<string, unknown>, options: { signal: AbortSignal }) => Promise<any>) | null = null;
+
+    async function setupWithCanUseTool(allowedTools?: string[]) {
+      const chatRequest: ChatRequest = {
+        message: "Test message",
+        requestId: "test-canusetool",
+        allowedTools,
+      };
+
+      mockContext.req.json = vi.fn().mockResolvedValue(chatRequest);
+
+      capturedCanUseTool = null;
+
+      mockQuery.mockImplementation(
+        (args: any) =>
+          ({
+            [Symbol.asyncIterator]: async function* () {
+              capturedCanUseTool = args.options.canUseTool;
+              yield {
+                type: "assistant",
+                message: { content: [{ type: "text", text: "Response" }] },
+                session_id: "test-session",
+                parent_tool_use_id: null,
+              } as any;
+            },
+            interrupt: vi.fn(),
+            next: vi.fn(),
+            return: vi.fn(),
+            throw: vi.fn(),
+          }) as any,
+      );
+
+      await handleChatRequest(mockContext, requestAbortControllers, pendingPermissions);
+      expect(capturedCanUseTool).not.toBeNull();
+    }
+
+    it("should auto-approve edit when in allowedTools", async () => {
+      await setupWithCanUseTool(["edit"]);
+
+      const result = await capturedCanUseTool!(
+        "edit",
+        { file_path: "/test.ts", old_string: "a", new_string: "b" },
+        { signal: new AbortController().signal },
+      );
+
+      expect(result).toEqual({ behavior: "allow", updatedInput: { file_path: "/test.ts", old_string: "a", new_string: "b" } });
+    });
+
+    it("should auto-approve read-only tools regardless of allowedTools", async () => {
+      await setupWithCanUseTool(undefined);
+
+      const result = await capturedCanUseTool!(
+        "read_file",
+        { file_path: "/test.ts" },
+        { signal: new AbortController().signal },
+      );
+
+      expect(result).toEqual({ behavior: "allow", updatedInput: { file_path: "/test.ts" } });
+    });
+
+    it("should auto-approve web_fetch as read-only", async () => {
+      await setupWithCanUseTool(undefined);
+
+      const result = await capturedCanUseTool!(
+        "web_fetch",
+        { url: "https://example.com" },
+        { signal: new AbortController().signal },
+      );
+
+      expect(result).toEqual({ behavior: "allow", updatedInput: { url: "https://example.com" } });
+    });
+
+    it("should auto-approve think as read-only", async () => {
+      await setupWithCanUseTool(undefined);
+
+      const result = await capturedCanUseTool!(
+        "think",
+        { thought: "thinking..." },
+        { signal: new AbortController().signal },
+      );
+
+      expect(result).toEqual({ behavior: "allow", updatedInput: { thought: "thinking..." } });
+    });
+
+    it("should auto-approve run_shell_command matching command prefix", async () => {
+      await setupWithCanUseTool(["run_shell_command(git:*)"]);
+
+      const result = await capturedCanUseTool!(
+        "run_shell_command",
+        { command: "git status" },
+        { signal: new AbortController().signal },
+      );
+
+      expect(result).toEqual({ behavior: "allow", updatedInput: { command: "git status" } });
+    });
+
+    it("should deny run_shell_command when command prefix does not match", async () => {
+      await setupWithCanUseTool(["run_shell_command(git:*)"]);
+
+      // Without a pending permission resolution, the callback will send a permission_request
+      // and wait forever. We abort to get a denial.
+      const abortController = new AbortController();
+      const promise = capturedCanUseTool!(
+        "run_shell_command",
+        { command: "rm -rf /" },
+        { signal: abortController.signal },
+      );
+
+      // Give it a tick to reach the pending state, then abort
+      await new Promise(resolve => setTimeout(resolve, 10));
+      abortController.abort();
+
+      const result = await promise;
+      expect(result.behavior).toBe("deny");
+    });
+
+    it("should auto-approve run_shell_command with bare tool name", async () => {
+      await setupWithCanUseTool(["run_shell_command"]);
+
+      const result = await capturedCanUseTool!(
+        "run_shell_command",
+        { command: "npm install" },
+        { signal: new AbortController().signal },
+      );
+
+      expect(result).toEqual({ behavior: "allow", updatedInput: { command: "npm install" } });
+    });
+
+    it("should auto-approve multi-word command prefixes", async () => {
+      await setupWithCanUseTool(["run_shell_command(npm run build:*)"]);
+
+      const result = await capturedCanUseTool!(
+        "run_shell_command",
+        { command: "npm run build --production" },
+        { signal: new AbortController().signal },
+      );
+
+      expect(result).toEqual({ behavior: "allow", updatedInput: { command: "npm run build --production" } });
+    });
+
+    it("should not auto-approve when allowedTools is empty", async () => {
+      await setupWithCanUseTool([]);
+
+      const abortController = new AbortController();
+      const promise = capturedCanUseTool!(
+        "edit",
+        { file_path: "/test.ts", old_string: "a", new_string: "b" },
+        { signal: abortController.signal },
+      );
+
+      await new Promise(resolve => setTimeout(resolve, 10));
+      abortController.abort();
+
+      const result = await promise;
+      expect(result.behavior).toBe("deny");
+    });
+
+    it("should not auto-approve when allowedTools is undefined", async () => {
+      await setupWithCanUseTool(undefined);
+
+      const abortController = new AbortController();
+      const promise = capturedCanUseTool!(
+        "edit",
+        { file_path: "/test.ts", old_string: "a", new_string: "b" },
+        { signal: abortController.signal },
+      );
+
+      await new Promise(resolve => setTimeout(resolve, 10));
+      abortController.abort();
+
+      const result = await promise;
+      expect(result.behavior).toBe("deny");
+    });
+  });
+
   describe("Abort Controller Management with Permission Mode", () => {
     it("should manage abort controller correctly with permissionMode", async () => {
       const chatRequest: ChatRequest = {

--- a/backend/handlers/chat.ts
+++ b/backend/handlers/chat.ts
@@ -136,7 +136,9 @@ async function executeQwenCommand(
         }
       }
 
-      // Defense: auto-approve tools in the session's allowedTools (passed from frontend).
+      // Defense: auto-approve tools in the session's allowedTools — the persistent set
+      // of tools the user has approved in Settings (unlike localAllowedTools which only
+      // tracks approvals within the current streaming request).
       // The SDK should handle this before calling canUseTool, but this provides
       // defense-in-depth in case the SDK's internal matching has edge cases.
       if (allowedTools && allowedTools.length > 0) {
@@ -148,7 +150,7 @@ async function executeQwenCommand(
             if (patternToolName !== toolName) return false;
             const inner = pattern.substring(openParen + 1, pattern.length - 1);
             const cmdPrefix = inner.replace(/:.*$/, '');
-            const actualCmd = extractBaseCommand(String(input?.command || ''));
+            const actualCmd = String(input?.command || '').trim();
             return actualCmd === cmdPrefix || actualCmd.startsWith(cmdPrefix + ' ');
           }
           return false;

--- a/backend/handlers/chat.ts
+++ b/backend/handlers/chat.ts
@@ -32,7 +32,7 @@ function mapPermissionMode(mode?: string): PermissionMode | undefined {
 // Tools that are safe to auto-approve without user confirmation.
 // Criteria: no side effects, no writes to filesystem or external systems.
 // Update this set when new read-only SDK tools are added.
-const READ_ONLY_TOOLS = new Set(["read_file", "glob", "grep_search", "list_directory"]);
+const READ_ONLY_TOOLS = new Set(["read_file", "glob", "grep_search", "list_directory", "web_fetch", "think"]);
 
 function extractBaseCommand(command: string): string {
   return command.trim().split(/\s+/)[0] || "";
@@ -132,6 +132,29 @@ async function executeQwenCommand(
         const baseCmd = extractBaseCommand(input.command as string);
         if (baseCmd && localAllowedTools.has(`${toolName}:${baseCmd}`)) {
           logger.chat.debug("canUseTool: auto-approving previously allowed command {toolName}:{baseCmd}", { toolName, baseCmd });
+          return { behavior: "allow", updatedInput: input };
+        }
+      }
+
+      // Defense: auto-approve tools in the session's allowedTools (passed from frontend).
+      // The SDK should handle this before calling canUseTool, but this provides
+      // defense-in-depth in case the SDK's internal matching has edge cases.
+      if (allowedTools && allowedTools.length > 0) {
+        const toolMatches = allowedTools.some(pattern => {
+          if (pattern === toolName) return true;
+          const openParen = pattern.indexOf('(');
+          if (openParen !== -1) {
+            const patternToolName = pattern.substring(0, openParen);
+            if (patternToolName !== toolName) return false;
+            const inner = pattern.substring(openParen + 1, pattern.length - 1);
+            const cmdPrefix = inner.replace(/:.*$/, '');
+            const actualCmd = extractBaseCommand(String(input?.command || ''));
+            return actualCmd === cmdPrefix || actualCmd.startsWith(cmdPrefix + ' ');
+          }
+          return false;
+        });
+        if (toolMatches) {
+          logger.chat.debug("canUseTool: auto-approving tool in session allowedTools: {toolName}", { toolName });
           return { behavior: "allow", updatedInput: input };
         }
       }


### PR DESCRIPTION
## Summary
- Add defense-in-depth check in `canUseTool` callback to auto-approve tools that are in the session's `allowedTools` array passed from the frontend
- Add `web_fetch` and `think` to `READ_ONLY_TOOLS` so they are auto-approved without confirmation
- Supports both simple tool name patterns (`"edit"`) and command-scoped patterns (`"run_shell_command(git:*)"`)

## Root Cause
The `canUseTool` callback in `backend/handlers/chat.ts` did not check the `allowedTools` parameter. It relied entirely on the SDK's internal matching to prevent the callback from being invoked. When the SDK failed to match, the callback sent `permission_request` to the frontend, causing the user to see a confirmation dialog for tools they had already allowed — and clicking "Allow Permanent" again created duplicate entries in Settings.

## Test plan
- [ ] Add `edit` to allowed tools in Settings → verify Edit tool no longer prompts
- [ ] Verify `web_fetch` and `think` are auto-approved without any configuration
- [ ] Test `run_shell_command(git:*)` pattern only approves git commands, not others

🤖 Generated with [Claude Code](https://claude.com/claude-code)