### PR TITLE
fix: detect stream stall when frontend reader hangs indefinitely

### DIFF
--- a/frontend/src/components/ChatPage.tsx
+++ b/frontend/src/components/ChatPage.tsx
@@ -593,10 +593,35 @@ export function ChatPage() {
       let shouldAbort = false;
       let reader: ReadableStreamDefaultReader<Uint8Array> | null = null;
 
+      // Stream stall detection: abort fetch if no data received for 60s.
+      // Backend sends keepalive \n every 15s, so 60s = 4 missed keepalives.
+      const STREAM_STALL_TIMEOUT_MS = 60_000;
+      const fetchAbortController = new AbortController();
+      let stallTimerId: ReturnType<typeof setTimeout> | null = null;
+
+      const resetStallTimer = () => {
+        if (stallTimerId) clearTimeout(stallTimerId);
+        stallTimerId = setTimeout(() => {
+          if (document.hidden) {
+            resetStallTimer();
+            return;
+          }
+          console.warn("[Stream stall] No data for 60s, aborting fetch");
+          fetchAbortController.abort();
+        }, STREAM_STALL_TIMEOUT_MS);
+      };
+      resetStallTimer();
+
+      const onVisibilityChange = () => {
+        if (!document.hidden) resetStallTimer();
+      };
+      document.addEventListener("visibilitychange", onVisibilityChange);
+
       try {
         const response = await fetch(getChatUrl(), {
           method: "POST",
           headers: { "Content-Type": "application/json" },
+          signal: fetchAbortController.signal,
           body: JSON.stringify({
             message: content,
             requestId,
@@ -698,6 +723,8 @@ export function ChatPage() {
           const { done, value } = await reader.read();
           if (done || shouldAbort) break;
 
+          resetStallTimer();
+
           lineBuffer += decoder.decode(value, { stream: true });
           const lines = lineBuffer.split("\n");
           lineBuffer = lines.pop() || "";
@@ -716,8 +743,19 @@ export function ChatPage() {
           processStreamLine(lineBuffer.trim(), streamingContext);
         }
       } catch (error) {
-        // Skip error message when abort was triggered by /clear
-        if (!clearAbortRef.current) {
+        // Stall timeout abort → show friendly message
+        if (
+          error instanceof DOMException && error.name === "AbortError"
+          && fetchAbortController.signal.aborted
+        ) {
+          addMessage({
+            type: "chat",
+            role: "assistant",
+            content: t("chat.errorStreamStall"),
+            timestamp: Date.now(),
+          });
+          setCurrentSessionId(null);
+        } else if (!clearAbortRef.current) {
           console.error("Failed to send message:", error);
           const errorText = error instanceof Error
             ? error.message
@@ -733,6 +771,12 @@ export function ChatPage() {
           setCurrentSessionId(null);
         }
       } finally {
+        if (stallTimerId) {
+          clearTimeout(stallTimerId);
+          stallTimerId = null;
+        }
+        document.removeEventListener("visibilitychange", onVisibilityChange);
+
         // Release the reader to free the HTTP connection.
         // Without this, the browser keeps connections open and eventually
         // hits its per-host connection limit (6 for HTTP/1.1), causing

--- a/frontend/src/components/ChatPage.tsx
+++ b/frontend/src/components/ChatPage.tsx
@@ -25,6 +25,7 @@ import { useOpenAceSessionTracker } from "../hooks/useOpenAceSessionTracker";
 import { useTabNotification } from "../hooks/useTabNotification";
 import { calculateTokenUsage, calculateContextBreakdown } from "../utils/tokenUsage";
 import type { ContextUsageData } from "../utils/tokenUsage";
+import { createStallDetector } from "../utils/streamStallDetector";
 import { ContextUsagePanel } from "./chat/ContextUsagePanel";
 import { SettingsButton } from "./SettingsButton";
 import { SettingsModal } from "./SettingsModal";
@@ -595,27 +596,8 @@ export function ChatPage() {
 
       // Stream stall detection: abort fetch if no data received for 60s.
       // Backend sends keepalive \n every 15s, so 60s = 4 missed keepalives.
-      const STREAM_STALL_TIMEOUT_MS = 60_000;
       const fetchAbortController = new AbortController();
-      let stallTimerId: ReturnType<typeof setTimeout> | null = null;
-
-      const resetStallTimer = () => {
-        if (stallTimerId) clearTimeout(stallTimerId);
-        stallTimerId = setTimeout(() => {
-          if (document.hidden) {
-            resetStallTimer();
-            return;
-          }
-          console.warn("[Stream stall] No data for 60s, aborting fetch");
-          fetchAbortController.abort();
-        }, STREAM_STALL_TIMEOUT_MS);
-      };
-      resetStallTimer();
-
-      const onVisibilityChange = () => {
-        if (!document.hidden) resetStallTimer();
-      };
-      document.addEventListener("visibilitychange", onVisibilityChange);
+      const stallDetector = createStallDetector(fetchAbortController);
 
       try {
         const response = await fetch(getChatUrl(), {
@@ -723,7 +705,7 @@ export function ChatPage() {
           const { done, value } = await reader.read();
           if (done || shouldAbort) break;
 
-          resetStallTimer();
+          stallDetector.onData();
 
           lineBuffer += decoder.decode(value, { stream: true });
           const lines = lineBuffer.split("\n");
@@ -743,7 +725,9 @@ export function ChatPage() {
           processStreamLine(lineBuffer.trim(), streamingContext);
         }
       } catch (error) {
-        // Stall timeout abort → show friendly message
+        // Distinguish stall abort from other abort sources (e.g. /clear uses
+        // a separate AbortController via createAbortHandler). Check
+        // fetchAbortController.signal.aborted to identify our stall timeout.
         if (
           error instanceof DOMException && error.name === "AbortError"
           && fetchAbortController.signal.aborted
@@ -771,11 +755,7 @@ export function ChatPage() {
           setCurrentSessionId(null);
         }
       } finally {
-        if (stallTimerId) {
-          clearTimeout(stallTimerId);
-          stallTimerId = null;
-        }
-        document.removeEventListener("visibilitychange", onVisibilityChange);
+        stallDetector.dispose();
 
         // Release the reader to free the HTTP connection.
         // Without this, the browser keeps connections open and eventually

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -94,6 +94,7 @@
     "statusOffline": "Offline",
     "statusError": "Error",
     "errorFailedResponse": "Error: Failed to get response",
+    "errorStreamStall": "Connection lost. You can send a new message to continue.",
     "backToChat": "Back to chat",
     "backToHistory": "Back to history",
     "conversationHistory": "Conversation History",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -94,6 +94,7 @@
     "statusOffline": "离线",
     "statusError": "错误",
     "errorFailedResponse": "错误：未能获取回复",
+    "errorStreamStall": "连接已断开，你可以发送新消息继续对话。",
     "backToChat": "返回对话",
     "backToHistory": "返回历史记录",
     "conversationHistory": "对话历史",

--- a/frontend/src/utils/streamStallDetector.test.ts
+++ b/frontend/src/utils/streamStallDetector.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createStallDetector } from "./streamStallDetector";
+
+describe("createStallDetector", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    Object.defineProperty(document, "hidden", {
+      value: false,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("aborts after timeout when no data is received", () => {
+    const abortController = new AbortController();
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    createStallDetector(abortController, 60_000);
+
+    expect(abortController.signal.aborted).toBe(false);
+
+    vi.advanceTimersByTime(60_000);
+
+    expect(abortController.signal.aborted).toBe(true);
+    expect(warnSpy).toHaveBeenCalledWith(
+      "[Stream stall] No data for 60s, aborting fetch",
+    );
+    warnSpy.mockRestore();
+  });
+
+  it("resets timer when onData is called", () => {
+    const abortController = new AbortController();
+    const detector = createStallDetector(abortController, 60_000);
+
+    // Advance 30s, then receive data
+    vi.advanceTimersByTime(30_000);
+    expect(abortController.signal.aborted).toBe(false);
+
+    detector.onData();
+
+    // Advance another 30s (60s since data, but only 30s since last reset)
+    vi.advanceTimersByTime(30_000);
+    expect(abortController.signal.aborted).toBe(false);
+
+    // Advance another 30s = 60s since last onData
+    vi.advanceTimersByTime(30_000);
+    expect(abortController.signal.aborted).toBe(true);
+
+    detector.dispose();
+  });
+
+  it("does not abort when tab is hidden", () => {
+    const abortController = new AbortController();
+    const detector = createStallDetector(abortController, 60_000);
+
+    // Tab goes hidden before timeout
+    vi.advanceTimersByTime(50_000);
+    Object.defineProperty(document, "hidden", { value: true, writable: true, configurable: true });
+    vi.advanceTimersByTime(10_000); // 60s total — timer fires while hidden
+
+    expect(abortController.signal.aborted).toBe(false);
+
+    // Tab becomes visible again — timer should restart from now
+    Object.defineProperty(document, "hidden", { value: false, writable: true, configurable: true });
+    document.dispatchEvent(new Event("visibilitychange"));
+
+    // Should abort 60s after visibility change (because lastDataTime is old)
+    vi.advanceTimersByTime(60_000);
+    expect(abortController.signal.aborted).toBe(true);
+
+    detector.dispose();
+  });
+
+  it("cleans up timers and listeners on dispose", () => {
+    const abortController = new AbortController();
+    const detector = createStallDetector(abortController, 60_000);
+    const removeSpy = vi.spyOn(document, "removeEventListener");
+
+    detector.dispose();
+
+    expect(removeSpy).toHaveBeenCalledWith("visibilitychange", expect.any(Function));
+
+    // Should NOT abort after timeout if already disposed
+    vi.advanceTimersByTime(120_000);
+    expect(abortController.signal.aborted).toBe(false);
+
+    removeSpy.mockRestore();
+  });
+
+  it("does not abort if data keeps arriving within timeout", () => {
+    const abortController = new AbortController();
+    const detector = createStallDetector(abortController, 60_000);
+
+    // Simulate keepalive every 15s for 3 minutes
+    for (let i = 0; i < 12; i++) {
+      vi.advanceTimersByTime(14_000);
+      detector.onData();
+    }
+
+    expect(abortController.signal.aborted).toBe(false);
+    detector.dispose();
+  });
+});

--- a/frontend/src/utils/streamStallDetector.ts
+++ b/frontend/src/utils/streamStallDetector.ts
@@ -1,0 +1,67 @@
+/**
+ * Stream stall detector — aborts a fetch when no data arrives for a configurable
+ * timeout. Handles browser background-tab throttling and system sleep/wake by
+ * tracking `lastDataTime` and only aborting when the tab is visible.
+ */
+
+export interface StallDetector {
+  /** Call every time data is received (including keepalive bytes). */
+  onData: () => void;
+  /** Clean up timers and event listeners. */
+  dispose: () => void;
+}
+
+export function createStallDetector(
+  abortController: AbortController,
+  timeoutMs: number = 60_000,
+): StallDetector {
+  let stallTimerId: ReturnType<typeof setTimeout> | null = null;
+  let lastDataTime = Date.now();
+
+  const scheduleCheck = () => {
+    if (stallTimerId) clearTimeout(stallTimerId);
+    stallTimerId = setTimeout(onTimeout, timeoutMs);
+  };
+
+  const onTimeout = () => {
+    // Tab hidden → browser throttles reader.read() delivery; re-schedule.
+    if (document.hidden) {
+      stallTimerId = setTimeout(onTimeout, timeoutMs);
+      return;
+    }
+    // Tab visible but not enough time has actually elapsed (e.g. woke from
+    // sleep during a re-scheduled check) — wait the remaining time.
+    const elapsed = Date.now() - lastDataTime;
+    if (elapsed < timeoutMs) {
+      stallTimerId = setTimeout(onTimeout, timeoutMs - elapsed);
+      return;
+    }
+    console.warn(`[Stream stall] No data for ${timeoutMs / 1000}s, aborting fetch`);
+    abortController.abort();
+  };
+
+  const onData = () => {
+    lastDataTime = Date.now();
+    scheduleCheck();
+  };
+
+  const onVisibilityChange = () => {
+    if (!document.hidden) onData();
+  };
+
+  document.addEventListener("visibilitychange", onVisibilityChange);
+
+  // Start the initial timer.
+  scheduleCheck();
+
+  return {
+    onData,
+    dispose: () => {
+      if (stallTimerId) {
+        clearTimeout(stallTimerId);
+        stallTimerId = null;
+      }
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- When the backend completes a request but the frontend's `reader.read()` never returns `{ done: true }`, the UI stays stuck in "Thinking..." indefinitely
- Adds a 60s stall timer with `AbortController` on the fetch to break the blocked `reader.read()` call
- Protects against false positives from background tab throttling (`document.hidden` check) and system sleep/wake (`visibilitychange` listener)

## Root cause
Backend logs confirmed the request completed normally (COMPLETE + FINALLY), but the browser's `ReadableStream` reader never delivered the done signal. The `while(true)` loop with `await reader.read()` blocked forever, preventing `resetRequestState()` from running.

## Test plan
- [ ] Start WebUI, send a message to trigger a request
- [ ] Kill the CLI process or disconnect network during the request
- [ ] Verify UI auto-recovers after ~60s with "Connection lost" message
- [ ] Verify `isLoading` resets and new messages can be sent
- [ ] Verify normal requests are unaffected (keepalive resets the timer every 15s)
- [ ] Test background tab: start a request, switch tabs for 2+ minutes, switch back — verify no false abort

🤖 Generated with [Claude Code](https://claude.com/claude-code)