### PR TITLE
fix: enable Enter key to confirm ConfirmModal dialogs

### DIFF
--- a/frontend/src/components/ConfirmModal.tsx
+++ b/frontend/src/components/ConfirmModal.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useRef } from "react";
+import { Fragment, useEffect, useRef } from "react";
 import { Dialog, Transition } from "@headlessui/react";
 import { ExclamationTriangleIcon } from "@heroicons/react/24/outline";
 
@@ -28,6 +28,20 @@ export function ConfirmModal({
   errorMessage,
 }: ConfirmModalProps) {
   const confirmButtonRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Enter" && !isLoading) {
+        e.preventDefault();
+        onConfirm();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen, isLoading, onConfirm]);
 
   const variantStyles = {
     danger: {

--- a/frontend/src/components/ConfirmModal.tsx
+++ b/frontend/src/components/ConfirmModal.tsx
@@ -88,12 +88,6 @@ export function ConfirmModal({
             >
               <Dialog.Panel
                 className="w-full max-w-md transform overflow-hidden rounded-2xl bg-white dark:bg-slate-800 p-6 text-left align-middle shadow-xl transition-all"
-                onKeyDown={(e) => {
-                  if (e.key === "Enter" && !isLoading) {
-                    e.preventDefault();
-                    onConfirm();
-                  }
-                }}
               >
                 <div className="flex items-start gap-4">
                   <div className={`flex-shrink-0 ${styles.icon}`}>


### PR DESCRIPTION
## Summary
- Added a useEffect-based global keydown listener in ConfirmModal to reliably capture Enter key presses
- This fixes the issue where pressing Enter in the /clear confirmation dialog did not trigger the confirm action

## Problem
The ConfirmModal's `onKeyDown` handler on `Dialog.Panel` was not reliably capturing Enter key presses when running inside an iframe (open-ace). Root causes:
1. headlessui's FocusTrap only enables `InitialFocus` on non-touch devices
2. The Dialog div has `tabIndex={-1}`, which can cause focus to land on the Dialog div instead of Dialog.Panel, and events bubble UP (not DOWN)
3. Portal rendering in iframe context can cause focus management issues

## Solution
Added a `useEffect` that listens for Enter key on `document` when the modal is open. This is the same pattern used by `GlobalEscHandler` in `App.tsx` for Escape key handling.

## Testing
- TypeScript type check passes
- ESLint passes
- Manual testing: Open /clear dialog, press Enter → dialog should confirm