### PR TITLE
fix: permission dialog still showing for tools in allowedTools

### DIFF
--- a/backend/handlers/chat.ts
+++ b/backend/handlers/chat.ts
@@ -159,6 +159,15 @@ async function executeQwenCommand(
           logger.chat.debug("canUseTool: auto-approving tool in session allowedTools: {toolName}", { toolName });
           return { behavior: "allow", updatedInput: input };
         }
+        logger.chat.info(
+          "canUseTool: allowedTools did not match toolName={toolName}, allowedTools={allowedTools}",
+          { toolName, allowedTools },
+        );
+      } else {
+        logger.chat.info(
+          "canUseTool: allowedTools is empty for toolName={toolName}",
+          { toolName },
+        );
       }
 
       const permissionId = crypto.randomUUID();
@@ -349,9 +358,13 @@ export async function handleChatRequest(
     "Received chat request {*}",
     chatRequest as unknown as Record<string, unknown>,
   );
-  logger.chat.debug(
-    "Chat request permissionMode: {permissionMode}",
-    { permissionMode: chatRequest.permissionMode },
+  logger.chat.info(
+    "Chat request allowedTools: count={count} tools={allowedTools} permissionMode={permissionMode}",
+    {
+      count: chatRequest.allowedTools?.length ?? 0,
+      allowedTools: chatRequest.allowedTools ?? [],
+      permissionMode: chatRequest.permissionMode,
+    },
   );
 
   logger.chat.info(

--- a/backend/handlers/chat.ts
+++ b/backend/handlers/chat.ts
@@ -159,14 +159,9 @@ async function executeQwenCommand(
           logger.chat.debug("canUseTool: auto-approving tool in session allowedTools: {toolName}", { toolName });
           return { behavior: "allow", updatedInput: input };
         }
-        logger.chat.info(
+        logger.chat.debug(
           "canUseTool: allowedTools did not match toolName={toolName}, allowedTools={allowedTools}",
           { toolName, allowedTools },
-        );
-      } else {
-        logger.chat.info(
-          "canUseTool: allowedTools is empty for toolName={toolName}",
-          { toolName },
         );
       }
 
@@ -358,7 +353,7 @@ export async function handleChatRequest(
     "Received chat request {*}",
     chatRequest as unknown as Record<string, unknown>,
   );
-  logger.chat.info(
+  logger.chat.debug(
     "Chat request allowedTools: count={count} tools={allowedTools} permissionMode={permissionMode}",
     {
       count: chatRequest.allowedTools?.length ?? 0,

--- a/frontend/src/components/ChatPage.tsx
+++ b/frontend/src/components/ChatPage.tsx
@@ -884,8 +884,9 @@ export function ChatPage() {
       // For shell tools, persist pattern to localStorage; for non-shell, only this request
       const isShell = permissionRequest.toolName === "run_shell_command";
       if (isShell) {
+        let accumulated = allowedTools;
         permissionRequest.patterns.forEach((pattern) => {
-          allowToolPermanent(pattern, allowedTools);
+          accumulated = allowToolPermanent(pattern, accumulated);
         });
       }
       try {
@@ -953,8 +954,11 @@ export function ChatPage() {
 
     // Proactive canUseTool flow — update state for future queries + respond
     if (permissionRequest.permissionId) {
+      // Chain allowToolPermanent calls to avoid React batching race:
+      // each call receives the previous result as baseTools, so all patterns accumulate.
+      let accumulated = allowedTools;
       permissionRequest.patterns.forEach((pattern) => {
-        allowToolPermanent(pattern, allowedTools);
+        accumulated = allowToolPermanent(pattern, accumulated);
       });
       try {
         const resp = await sendPermissionResponse(permissionRequest.permissionId, "allow", {
@@ -973,6 +977,7 @@ export function ChatPage() {
     }
 
     // Legacy reactive flow
+    // Accumulate all patterns into a single update to avoid React batching race
     let updatedAllowedTools = allowedTools;
     permissionRequest.patterns.forEach((pattern) => {
       updatedAllowedTools = allowToolPermanent(pattern, updatedAllowedTools);

--- a/frontend/src/hooks/chat/usePermissions.ts
+++ b/frontend/src/hooks/chat/usePermissions.ts
@@ -95,7 +95,11 @@ export function usePermissions(options: UsePermissionsOptions = {}) {
   useEffect(() => {
     const handler = (e: StorageEvent) => {
       if (e.key === STORAGE_KEYS.ALLOWED_TOOLS) {
-        setAllowedTools(e.newValue ? JSON.parse(e.newValue) : []);
+        try {
+          setAllowedTools(e.newValue ? JSON.parse(e.newValue) : []);
+        } catch {
+          setAllowedTools([]);
+        }
       }
     };
     window.addEventListener("storage", handler);
@@ -188,6 +192,7 @@ export function usePermissions(options: UsePermissionsOptions = {}) {
   const allowToolPermanent = useCallback(
     (pattern: string, baseTools?: string[]) => {
       const currentAllowedTools = baseTools || allowedTools;
+      if (currentAllowedTools.includes(pattern)) return currentAllowedTools;
       const updatedAllowedTools = [...currentAllowedTools, pattern];
       setAllowedTools(updatedAllowedTools);
       setStorageItem(STORAGE_KEYS.ALLOWED_TOOLS, updatedAllowedTools);

--- a/frontend/src/hooks/chat/usePermissions.ts
+++ b/frontend/src/hooks/chat/usePermissions.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef } from "react";
+import { useState, useCallback, useRef, useEffect } from "react";
 import type { PermissionMode } from "../../types";
 import { STORAGE_KEYS, getStorageItem, setStorageItem, removeStorageItem } from "../../utils/storage";
 
@@ -90,6 +90,18 @@ export function usePermissions(options: UsePermissionsOptions = {}) {
   const [allowedTools, setAllowedTools] = useState<string[]>(() =>
     getStorageItem<string[]>(STORAGE_KEYS.ALLOWED_TOOLS, []),
   );
+
+  // Sync allowedTools from localStorage when another tab modifies it
+  useEffect(() => {
+    const handler = (e: StorageEvent) => {
+      if (e.key === STORAGE_KEYS.ALLOWED_TOOLS) {
+        setAllowedTools(e.newValue ? JSON.parse(e.newValue) : []);
+      }
+    };
+    window.addEventListener("storage", handler);
+    return () => window.removeEventListener("storage", handler);
+  }, []);
+
   const [permissionRequest, setPermissionRequest] =
     useState<PermissionRequest | null>(null);
   const permissionRequestRef = useRef<PermissionRequest | null>(null);


### PR DESCRIPTION
## Summary

- 添加诊断日志：在 `canUseTool` 和 `handleChatRequest` 中记录 `allowedTools` 实际值，便于定位 defense-in-depth 检查失败的原因
- 修复 `allowToolPermanent` 多 pattern 竞争：`forEach` 中每个调用使用同一个 base `allowedTools`，React 批量 setState 只保留最后一个 pattern。改为链式传递前一次的结果作为下一次的 base
- 添加 `storage` 事件监听：跨 Tab 同步 `allowedTools`，Tab A 授权后 Tab B 立即生效

## Shell 工具行为

Shell 工具的权限行为**保持不变**：
- "允许本次"：持久化特定命令 pattern（如 `run_shell_command(git status:*)`）
- "允许总是"：同上
- "允许所有 shell 命令"：持久化裸 `run_shell_command`（所有命令自动批准）
- 粒度：多词命令（git/npm/yarn/docker/cargo）按子命令区分，`git status` ≠ `git pull`

## Test plan

- [x] `cd backend && npx vitest run chat.test.ts` — 25 passed, 1 skipped
- [ ] 手动验证：添加 "edit" 到 allowedTools → 发消息触发 edit → 不弹框
- [ ] 手动验证：检查后端日志中的 `allowedTools` 诊断信息
- [ ] 手动验证：开两个 Tab → Tab A 允许工具 → Tab B 发消息触发同一工具 → 不弹框

## Related

- Issue #116 — 所有 Tool 的权限确认行为文档
- PR #112 — 首次添加 defense-in-depth 检查

🤖 Generated with [Claude Code](https://claude.com/claude-code)