### PR TITLE
fix: sync controlRequest timeout with canUseTool to prevent session abort

### DIFF
--- a/backend/handlers/chat.ts
+++ b/backend/handlers/chat.ts
@@ -235,7 +235,7 @@ async function executeQwenCommand(
         ...(model ? { model } : {}),
         ...(authType ? { authType } : {}),
         canUseTool,
-        timeout: { canUseTool: 86_400_000 },
+        timeout: { canUseTool: 86_400_000, controlRequest: 86_400_000 },
       },
     })) {
       messageCount++;

--- a/backend/handlers/chat.ts
+++ b/backend/handlers/chat.ts
@@ -8,6 +8,9 @@ import type { PendingPermission } from "./permission.ts";
 /** Track number of concurrent chat requests for diagnostics */
 let _activeChatCount = 0;
 
+/** 24-hour timeout for user-facing operations (permission prompts, control requests) */
+const SESSION_TIMEOUT_MS = 24 * 60 * 60 * 1_000;
+
 /**
  * Maps UI permission mode to Qwen SDK permission mode
  * Qwen SDK uses 'auto-edit' instead of 'acceptEdits'
@@ -235,7 +238,7 @@ async function executeQwenCommand(
         ...(model ? { model } : {}),
         ...(authType ? { authType } : {}),
         canUseTool,
-        timeout: { canUseTool: 86_400_000, controlRequest: 86_400_000 },
+        timeout: { canUseTool: SESSION_TIMEOUT_MS, controlRequest: SESSION_TIMEOUT_MS },
       },
     })) {
       messageCount++;


### PR DESCRIPTION
## Summary
- Set `controlRequest` timeout to 24h (matching `canUseTool`) when starting SDK sessions
- Prevents loop detection from aborting sessions when users take >60s to respond to permission prompts

## Root Cause
WebUI configured `canUseTool` at 24h but left `controlRequest` at the SDK default of 60s. When users didn't respond to permission dialogs within 60s, the CLI returned `Control request timeout` errors. After 3 occurrences, loop detection auto-aborted the session.

## Test plan
- [ ] Start a WebUI session, trigger a permission prompt, wait >60s before responding — session should remain active and respond normally
- [ ] Respond to a permission prompt within 60s — should work as before (no regression)
- [ ] Verify loop detection still works for genuine loops (e.g. repeated `input_closed` errors)

Fixes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)