### PR TITLE
fix: clear thinking/assistant state on remote SSE disconnect

### DIFF
--- a/frontend/src/components/ChatPage.tsx
+++ b/frontend/src/components/ChatPage.tsx
@@ -1193,6 +1193,7 @@ export function ChatPage() {
         aborted = true;
       } else if (isRemoteWorkspace && remoteChat.session) {
         remoteChat.abortCurrentRequest();
+        resetRequestState();
         aborted = true;
       }
 

--- a/frontend/src/components/ChatPage.tsx
+++ b/frontend/src/components/ChatPage.tsx
@@ -810,6 +810,7 @@ export function ChatPage() {
   const handleAbort = useCallback(() => {
     if (isRemoteWorkspace && remoteChat.session) {
       remoteChat.abortCurrentRequest();
+      resetRequestState();
       return;
     }
     abortRequest(currentRequestId, isLoading, resetRequestState);

--- a/frontend/src/hooks/useRemoteChat.ts
+++ b/frontend/src/hooks/useRemoteChat.ts
@@ -49,6 +49,17 @@ export function useRemoteChat(options?: RemoteChatOptions) {
   const optionsRef = useRef(options);
   optionsRef.current = options;
 
+  // Clear orphaned streaming state (thinking/assistant) from StreamingContext
+  const clearStreamingState = useCallback(() => {
+    const opts = optionsRef.current;
+    if (opts?.streamingContext?.setCurrentThinkingMessage) {
+      opts.streamingContext.setCurrentThinkingMessage(null);
+    }
+    if (opts?.streamingContext?.setCurrentAssistantMessage) {
+      opts.streamingContext.setCurrentAssistantMessage(null);
+    }
+  }, []);
+
   /**
    * Shared SSE line handler — detects permission_request events, result
    * events, and forwards regular output via onStreamLine.
@@ -136,6 +147,7 @@ export function useRemoteChat(options?: RemoteChatOptions) {
               console.error("[useRemoteChat] SSE error:", err);
               setError(t("chat.remoteDisconnected"));
               setIsLoading(false);
+              clearStreamingState();
               setSession((prev) =>
                 prev ? { ...prev, status: "error" } : null
               );
@@ -143,6 +155,7 @@ export function useRemoteChat(options?: RemoteChatOptions) {
             () => {
               console.log("[useRemoteChat] SSE done");
               setIsLoading(false);
+              clearStreamingState();
               // If the session was active and SSE closed, it likely means
               // the server was restarted or the session was marked completed.
               if (session?.status === "active") {
@@ -261,6 +274,7 @@ export function useRemoteChat(options?: RemoteChatOptions) {
               console.error("[useRemoteChat] SSE error:", err);
               setError(t("chat.remoteReconnectFailed"));
               setIsLoading(false);
+              clearStreamingState();
               setSession((prev) =>
                 prev ? { ...prev, status: "error" } : null
               );
@@ -268,6 +282,7 @@ export function useRemoteChat(options?: RemoteChatOptions) {
             () => {
               console.log("[useRemoteChat] SSE done");
               setIsLoading(false);
+              clearStreamingState();
             },
           );
           eventSourceRef.current = es;
@@ -321,10 +336,11 @@ export function useRemoteChat(options?: RemoteChatOptions) {
     try {
       await abortRemoteRequest(session.session_id);
       setIsLoading(false);
+      clearStreamingState();
     } catch (err) {
       console.error("[useRemoteChat] Failed to abort request:", err);
     }
-  }, [session]);
+  }, [session, clearStreamingState]);
 
   const stopSessionHandler = useCallback(async () => {
     if (!session) return;


### PR DESCRIPTION
## Summary
- Remote sessions could get stuck in "thinking" state when the SSE connection dropped, because `useRemoteChat` only cleared `isLoading` but left `currentThinkingMessage` and `currentAssistantMessage` orphaned
- Added `clearStreamingState()` helper in `useRemoteChat.ts` that clears both states via `StreamingContext`, and called it in all SSE error/done callbacks and `abortCurrentRequest`
- Added `resetRequestState()` call in `ChatPage.tsx` thinking timeout handler for remote sessions, matching the local session behavior

## Test plan
- [ ] Open a remote (Open-ACE) session and simulate an SSE disconnect (e.g. kill the remote CLI process) — UI should no longer stay stuck in "thinking"
- [ ] Test remote abort via the stop button — thinking/assistant state should clear
- [ ] Test remote thinking timeout (wait for the 5-min timeout) — state should clear and notification should appear
- [ ] Verify local chat sessions are unaffected

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)