### PR TITLE
fix: prevent AI sub-agent prompts from appearing as User messages

### DIFF
--- a/frontend/src/utils/UnifiedMessageProcessor.ts
+++ b/frontend/src/utils/UnifiedMessageProcessor.ts
@@ -688,8 +688,9 @@ export class UnifiedMessageProcessor {
             localContext,
             options,
           );
-        } else if (part.text) {
-          // Text content in parts
+        } else if (part.text && !message.parent_tool_use_id) {
+          // Text content in parts — skip if parent_tool_use_id is set
+          // (AI-generated sub-agent prompt, not actual user input)
           const userMessage: ChatMessage = {
             type: "chat",
             role: "user",
@@ -711,8 +712,9 @@ export class UnifiedMessageProcessor {
             options,
             toolUseResult,
           );
-        } else if (contentItem.type === "text") {
-          // Regular text content
+        } else if (contentItem.type === "text" && !message.parent_tool_use_id) {
+          // Regular text content — skip if parent_tool_use_id is set
+          // (AI-generated sub-agent prompt, not actual user input)
           const userMessage: ChatMessage = {
             type: "chat",
             role: "user",
@@ -722,8 +724,8 @@ export class UnifiedMessageProcessor {
           localContext.addMessage(userMessage);
         }
       }
-    } else if (typeof messageContent === "string") {
-      // Simple string content
+    } else if (typeof messageContent === "string" && !message.parent_tool_use_id) {
+      // Simple string content — skip if parent_tool_use_id is set
       const userMessage: ChatMessage = {
         type: "chat",
         role: "user",


### PR DESCRIPTION
## Summary
- When the AI calls the `agent` tool (sub-agent), the CLI emits the AI-generated prompt as a `type: "user"` SDK message with `parent_tool_use_id` pointing to the agent tool call
- The WebUI's `processUserMessage()` unconditionally rendered all text in user messages as blue "User" chat bubbles
- Now checks `parent_tool_use_id` — when non-null, text content is skipped (AI-generated, not user input)

## Root cause
The Qwen CLI's `BaseJsonOutputAdapter.emitUserMessage()` sends sub-agent prompts as `type: "user"` messages with `parent_tool_use_id` set. The WebUI treated all text in user messages as actual user input.

## Test plan
- [x] All 20 existing `UnifiedMessageProcessor` tests pass
- [x] TypeScript type check passes
- [ ] Manual test: trigger an AI sub-agent call and verify the prompt text does not appear as a blue "User" message

🤖 Generated with [Claude Code](https://claude.com/claude-code)