### PR TITLE
fix: prevent concurrent CLI sessions and detect interrupted conversations

### DIFF
--- a/backend/handlers/chat.test.ts
+++ b/backend/handlers/chat.test.ts
@@ -23,6 +23,7 @@ vi.mock("../utils/logger", () => ({
       debug: vi.fn(),
       error: vi.fn(),
       info: vi.fn(),
+      warn: vi.fn(),
     },
   },
 }));
@@ -829,6 +830,150 @@ describe("Chat Handler - Permission Mode Tests", () => {
 
       const result = await promise;
       expect(result.behavior).toBe("deny");
+    });
+  });
+
+  describe("Session Concurrency Guard", () => {
+    it("should abort existing request when new request arrives for same session", async () => {
+      let resolveBlocker: () => void;
+      const blocker = new Promise<void>((r) => { resolveBlocker = r; });
+
+      const firstRequest: ChatRequest = {
+        message: "First message",
+        requestId: "req-concurrent-1",
+        sessionId: "sess-concurrent",
+      };
+      mockContext.req.json = vi.fn().mockResolvedValueOnce(firstRequest);
+
+      mockQuery.mockReturnValueOnce({
+        [Symbol.asyncIterator]: async function* () {
+          yield { type: "assistant", message: { content: [{ type: "text", text: "First" }] }, session_id: "sess-concurrent", parent_tool_use_id: null } as any;
+          await blocker;
+        },
+      } as any);
+
+      const response1 = await handleChatRequest(mockContext, requestAbortControllers, pendingPermissions);
+      const reader1 = response1.body!.getReader();
+      await reader1.read();
+      await new Promise(r => setTimeout(r, 50));
+
+      expect(requestAbortControllers.has("req-concurrent-1")).toBe(true);
+      const firstAc = requestAbortControllers.get("req-concurrent-1")!;
+      expect(firstAc.signal.aborted).toBe(false);
+
+      const secondRequest: ChatRequest = {
+        message: "Second message",
+        requestId: "req-concurrent-2",
+        sessionId: "sess-concurrent",
+      };
+      mockContext.req.json = vi.fn().mockResolvedValueOnce(secondRequest);
+      mockQuery.mockReturnValueOnce({
+        [Symbol.asyncIterator]: async function* () {
+          yield { type: "assistant", message: { content: [{ type: "text", text: "Second" }] }, session_id: "sess-concurrent", parent_tool_use_id: null } as any;
+        },
+      } as any);
+
+      await handleChatRequest(mockContext, requestAbortControllers, pendingPermissions);
+
+      expect(firstAc.signal.aborted).toBe(true);
+      expect(requestAbortControllers.has("req-concurrent-1")).toBe(false);
+
+      resolveBlocker();
+      reader1.cancel().catch(() => {});
+    });
+
+    it("should not interfere with requests that have no sessionId", async () => {
+      const req1: ChatRequest = { message: "Msg 1", requestId: "req-no-session-1" };
+      const req2: ChatRequest = { message: "Msg 2", requestId: "req-no-session-2" };
+
+      mockContext.req.json = vi.fn()
+        .mockResolvedValueOnce(req1)
+        .mockResolvedValueOnce(req2);
+
+      const makeIterator = () => ({
+        [Symbol.asyncIterator]: async function* () {
+          yield { type: "assistant", message: { content: [{ type: "text", text: "OK" }] }, session_id: "s", parent_tool_use_id: null } as any;
+        },
+      } as any);
+
+      mockQuery.mockReturnValueOnce(makeIterator()).mockReturnValueOnce(makeIterator());
+
+      const res1 = await handleChatRequest(mockContext, requestAbortControllers, pendingPermissions);
+      const res2 = await handleChatRequest(mockContext, requestAbortControllers, pendingPermissions);
+
+      for (const res of [res1, res2]) {
+        const reader = res.body!.getReader();
+        while (true) { const { done } = await reader.read(); if (done) break; }
+      }
+
+      expect(requestAbortControllers.size).toBe(0);
+    });
+
+    it("should clean up session mapping after request completes normally", async () => {
+      const req: ChatRequest = { message: "Msg", requestId: "req-cleanup", sessionId: "sess-cleanup-test" };
+      mockContext.req.json = vi.fn().mockResolvedValue(req);
+      mockQuery.mockReturnValueOnce({
+        [Symbol.asyncIterator]: async function* () {
+          yield { type: "assistant", message: { content: [{ type: "text", text: "Done" }] }, session_id: "sess-cleanup-test", parent_tool_use_id: null } as any;
+        },
+      } as any);
+
+      const res = await handleChatRequest(mockContext, requestAbortControllers, pendingPermissions);
+      const reader = res.body!.getReader();
+      while (true) { const { done } = await reader.read(); if (done) break; }
+
+      expect(requestAbortControllers.has("req-cleanup")).toBe(false);
+    });
+
+    it("should resolve pending permissions from superseded request", async () => {
+      let capturedCanUseTool: any;
+      let resolveBlocker: () => void;
+      const blocker = new Promise<void>((r) => { resolveBlocker = r; });
+
+      const firstRequest: ChatRequest = {
+        message: "Msg",
+        requestId: "req-pp-1",
+        sessionId: "sess-pp",
+      };
+      mockContext.req.json = vi.fn().mockResolvedValueOnce(firstRequest);
+
+      mockQuery.mockImplementationOnce((args: any) => ({
+        [Symbol.asyncIterator]: async function* () {
+          capturedCanUseTool = args.options.canUseTool;
+          yield { type: "assistant", message: { content: [{ type: "text", text: "Hello" }] }, session_id: "sess-pp", parent_tool_use_id: null } as any;
+          await blocker;
+        },
+      } as any));
+
+      const res1 = await handleChatRequest(mockContext, requestAbortControllers, pendingPermissions);
+      const reader1 = res1.body!.getReader();
+      await reader1.read();
+      await new Promise(r => setTimeout(r, 50));
+
+      const ac1 = requestAbortControllers.get("req-pp-1")!;
+      const canUseToolPromise = capturedCanUseTool!("edit", { file: "/test" }, { signal: ac1.signal });
+      await new Promise(r => setTimeout(r, 50));
+      expect(pendingPermissions.size).toBeGreaterThan(0);
+
+      const secondRequest: ChatRequest = {
+        message: "Msg 2",
+        requestId: "req-pp-2",
+        sessionId: "sess-pp",
+      };
+      mockContext.req.json = vi.fn().mockResolvedValue(secondRequest);
+      mockQuery.mockReturnValue({
+        [Symbol.asyncIterator]: async function* () {
+          yield { type: "assistant", message: { content: [{ type: "text", text: "World" }] }, session_id: "sess-pp", parent_tool_use_id: null } as any;
+        },
+      } as any);
+
+      await handleChatRequest(mockContext, requestAbortControllers, pendingPermissions);
+
+      const result = await canUseToolPromise;
+      expect(result.behavior).toBe("deny");
+
+      resolveBlocker();
+      reader1.cancel().catch(() => {});
     });
   });
 

--- a/backend/handlers/chat.ts
+++ b/backend/handlers/chat.ts
@@ -8,6 +8,13 @@ import type { PendingPermission } from "./permission.ts";
 /** Track number of concurrent chat requests for diagnostics */
 let _activeChatCount = 0;
 
+/**
+ * Maps sessionId → requestId for active streaming requests.
+ * Prevents concurrent CLI processes for the same session, which causes
+ * API call conflicts and premature stream termination (issue #123).
+ */
+const activeSessions = new Map<string, string>();
+
 /** 24-hour timeout for user-facing operations (permission prompts, control requests) */
 const SESSION_TIMEOUT_MS = 24 * 60 * 60 * 1_000;
 
@@ -312,6 +319,10 @@ async function executeQwenCommand(
       ac.abort();
       requestAbortControllers.delete(requestId);
     }
+    // Clean up session mapping so a new request can start for this session
+    if (sessionId && activeSessions.get(sessionId) === requestId) {
+      activeSessions.delete(sessionId);
+    }
 
     logger.chat.info(
       "[DIAG] Chat request FINALLY requestId={requestId} durationMs={durationMs} "
@@ -374,6 +385,32 @@ export async function handleChatRequest(
       pendingPermissions: pendingPermissions.size,
     },
   );
+
+  // Abort any existing request for the same session to prevent concurrent CLI
+  // processes from conflicting (issue #123). This can happen when the frontend
+  // stream closes prematurely and the user sends a new message before the old
+  // CLI subprocess is fully terminated.
+  if (chatRequest.sessionId) {
+    const existingRequestId = activeSessions.get(chatRequest.sessionId);
+    if (existingRequestId) {
+      const existingAc = requestAbortControllers.get(existingRequestId);
+      if (existingAc && !existingAc.signal.aborted) {
+        logger.chat.warn(
+          "[DIAG] Aborting existing request for session sessionId={sessionId} "
+          + "oldRequestId={oldRequestId} newRequestId={newRequestId}",
+          {
+            sessionId: chatRequest.sessionId,
+            oldRequestId: existingRequestId,
+            newRequestId: chatRequest.requestId,
+          },
+        );
+        existingAc.abort();
+        requestAbortControllers.delete(existingRequestId);
+      }
+      activeSessions.delete(chatRequest.sessionId);
+    }
+    activeSessions.set(chatRequest.sessionId, chatRequest.requestId);
+  }
 
   const encoder = new TextEncoder();
 
@@ -438,6 +475,23 @@ export async function handleChatRequest(
           },
         );
         ac.abort();
+
+        // Defense: log warning if subprocess may still be alive after 3s.
+        // The SDK's transport.close() sends SIGTERM, then SIGKILL after 5s,
+        // but the gap can allow a resumed session to spawn a second CLI process.
+        const checkId = setTimeout(() => {
+          if (requestAbortControllers.has(chatRequest.requestId)) {
+            logger.chat.warn(
+              "[DIAG] Subprocess may still be alive 3s after cancel requestId={requestId}",
+              { requestId: chatRequest.requestId },
+            );
+          }
+        }, 3_000);
+        if (checkId.unref) checkId.unref();
+      }
+      // Clean up session mapping
+      if (chatRequest.sessionId && activeSessions.get(chatRequest.sessionId) === chatRequest.requestId) {
+        activeSessions.delete(chatRequest.sessionId);
       }
     },
   });

--- a/backend/handlers/chat.ts
+++ b/backend/handlers/chat.ts
@@ -406,6 +406,15 @@ export async function handleChatRequest(
         );
         existingAc.abort();
         requestAbortControllers.delete(existingRequestId);
+        // Resolve any pending permissions from the old request immediately
+        // rather than waiting for its finally block, so the new request's
+        // permission prompts don't collide with stale ones.
+        for (const [permissionId, pending] of pendingPermissions) {
+          if (pending.abortSignal === existingAc.signal) {
+            pending.resolve({ behavior: "deny", message: "Request superseded by new session request" });
+            pendingPermissions.delete(permissionId);
+          }
+        }
       }
       activeSessions.delete(chatRequest.sessionId);
     }
@@ -476,16 +485,20 @@ export async function handleChatRequest(
         );
         ac.abort();
 
-        // Defense: log warning if subprocess may still be alive after 3s.
-        // The SDK's transport.close() sends SIGTERM, then SIGKILL after 5s,
-        // but the gap can allow a resumed session to spawn a second CLI process.
+        // Log diagnostic 3s after cancel. The SDK's transport.close() sends
+        // SIGTERM, then SIGKILL after 5s. Log unconditionally to capture
+        // cases where the subprocess outlives the abort signal cleanup.
+        const diagRequestId = chatRequest.requestId;
         const checkId = setTimeout(() => {
-          if (requestAbortControllers.has(chatRequest.requestId)) {
-            logger.chat.warn(
-              "[DIAG] Subprocess may still be alive 3s after cancel requestId={requestId}",
-              { requestId: chatRequest.requestId },
-            );
-          }
+          logger.chat.warn(
+            "[DIAG] Post-cancel check requestId={requestId} activeCount={activeCount} "
+            + "concurrentRequests={concurrentRequests}",
+            {
+              requestId: diagRequestId,
+              activeCount: _activeChatCount,
+              concurrentRequests: requestAbortControllers.size,
+            },
+          );
         }, 3_000);
         if (checkId.unref) checkId.unref();
       }

--- a/frontend/src/components/ChatPage.tsx
+++ b/frontend/src/components/ChatPage.tsx
@@ -592,6 +592,7 @@ export function ChatPage() {
       // Local state for this streaming session
       let localHasReceivedInit = false;
       let shouldAbort = false;
+      let receivedResult = false;
       let reader: ReadableStreamDefaultReader<Uint8Array> | null = null;
 
       // Stream stall detection: abort fetch if no data received for 60s.
@@ -698,6 +699,8 @@ export function ChatPage() {
           thinkingTimeout: {
             onThinkingTimeout: (content, info) => thinkingTimeoutRef.current?.(content, info),
           },
+          // Track normal completion (result message received)
+          onResultReceived: () => { receivedResult = true; },
         };
 
         let lineBuffer = "";
@@ -774,6 +777,17 @@ export function ChatPage() {
         // Clean up orphan proactive permission dialog (e.g. CLI crash → error → dialog remains)
         if (permissionRequestRef.current?.permissionId) {
           closePermissionRequest();
+        }
+        // Detect interrupted conversation: stream closed without receiving a 'result'
+        // message, and the user didn't initiate the abort. Show a warning so the user
+        // knows the AI may not have finished. Keep sessionId to allow resuming.
+        if (!receivedResult && !shouldAbort && !fetchAbortController.signal.aborted) {
+          addMessage({
+            type: "system",
+            subtype: "interrupted",
+            message: t("chat.errorInterrupted"),
+            timestamp: Date.now(),
+          });
         }
         resetRequestState();
       }

--- a/frontend/src/components/MessageComponents.tsx
+++ b/frontend/src/components/MessageComponents.tsx
@@ -114,6 +114,12 @@ export function SystemMessageComponent({
       return details.join("\n");
     } else if (message.type === "error") {
       return message.message;
+    } else if (
+      message.type === "system" &&
+      "subtype" in message &&
+      message.subtype === "interrupted"
+    ) {
+      return message.message;
     } else if (isHooksMessage(message)) {
       // This is a hooks message - show only the content
       // Remove ANSI escape sequences for cleaner display

--- a/frontend/src/hooks/streaming/useMessageProcessor.ts
+++ b/frontend/src/hooks/streaming/useMessageProcessor.ts
@@ -59,6 +59,8 @@ export interface StreamingContext {
   onPermissionOrphanCleanup?: () => void;
   // Thinking timeout
   thinkingTimeout?: ThinkingTimeoutInfo;
+  // Called when a 'result' message is received — signals normal completion
+  onResultReceived?: () => void;
 }
 
 /**

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -95,6 +95,7 @@
     "statusError": "Error",
     "errorFailedResponse": "Error: Failed to get response",
     "errorStreamStall": "Connection lost. You can send a new message to continue.",
+    "errorInterrupted": "Conversation was interrupted unexpectedly. You can send a new message to continue.",
     "backToChat": "Back to chat",
     "backToHistory": "Back to history",
     "conversationHistory": "Conversation History",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -95,6 +95,7 @@
     "statusError": "错误",
     "errorFailedResponse": "错误：未能获取回复",
     "errorStreamStall": "连接已断开，你可以发送新消息继续对话。",
+    "errorInterrupted": "对话意外中断，你可以发送新消息继续对话。",
     "backToChat": "返回对话",
     "backToHistory": "返回历史记录",
     "conversationHistory": "对话历史",

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -35,6 +35,14 @@ export type AbortMessage = {
   timestamp: number;
 };
 
+// Interrupted message for unexpected stream closure (no result message received)
+export type InterruptedMessage = {
+  type: "system";
+  subtype: "interrupted";
+  message: string;
+  timestamp: number;
+};
+
 // Hooks message for hook execution notifications
 export type HooksMessage = {
   type: "system";
@@ -49,6 +57,7 @@ export type SystemMessage = (
   | SDKResultMessage
   | ErrorMessage
   | AbortMessage
+  | InterruptedMessage
   | HooksMessage
 ) & {
   timestamp: number;

--- a/frontend/src/utils/UnifiedMessageProcessor.ts
+++ b/frontend/src/utils/UnifiedMessageProcessor.ts
@@ -634,6 +634,7 @@ export class UnifiedMessageProcessor {
     if (options.isStreaming) {
       context.setCurrentAssistantMessage?.(null);
       context.setCurrentThinkingMessage?.(null);
+      context.onResultReceived?.();
     }
   }
 


### PR DESCRIPTION
## Summary
- **Backend**: Add session concurrency guard (`activeSessions` map) to abort existing requests before starting new ones for the same session
- **Backend**: Add subprocess liveness check (3s warning) after stream cancel
- **Frontend**: Detect interrupted conversations (no `result` message) and show warning to user

Fixes #123

## Root Cause
When the SSE stream closes prematurely (backend restart, connection issue), the CLI subprocess is not killed immediately. If the user sends a new message (`resume: sessionId`), a second CLI process spawns while the first is still running. Both processes make concurrent API calls to the same session, causing `APIUserAbortError` and the conversation appearing to "suddenly end."

## Changes

### Backend (`backend/handlers/chat.ts`)
- Added `activeSessions` Map (sessionId → requestId) to track active streaming sessions
- New requests for an active session abort the existing request before proceeding
- Added 3-second subprocess liveness diagnostic after `cancel()` callback
- Session mapping cleanup in both `cancel()` and `finally` block

### Frontend
- Added `receivedResult` flag in streaming session to track normal completion
- Show system warning message when stream closes without receiving a `result` message
- Added `InterruptedMessage` type to `types.ts`
- Added `onResultReceived` callback to `StreamingContext` interface
- Call `onResultReceived` from `UnifiedMessageProcessor.processResultMessage`
- Render interrupted messages in `SystemMessageComponent`
- Added i18n strings for both English and Chinese

## Test plan
- [ ] Start a chat with tool calls, let it complete normally → no warning
- [ ] Abort a chat (click stop) → no warning (user-initiated abort)
- [ ] Simulate stream interruption (restart backend mid-stream) → warning appears
- [ ] After interruption, send new message → no concurrent conflict (backend guard)
- [ ] Verify TypeScript compilation passes
- [ ] Check both EN and ZH locales display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)