### PR TITLE
fix: keepalive not reaching frontend causes stall detector false positive

### DIFF
--- a/backend/handlers/chat.ts
+++ b/backend/handlers/chat.ts
@@ -13,6 +13,12 @@ let _activeChatCount = 0;
 const SESSION_TIMEOUT_MS = 24 * 60 * 60 * 1_000;
 
 /**
+ * Keepalive heartbeat interval. Frontend stall detector triggers after 60s
+ * of silence, so 4 missed heartbeats (4 × 15s) = stall detected.
+ */
+const KEEPALIVE_INTERVAL_MS = 15_000;
+
+/**
  * Maps UI permission mode to Qwen SDK permission mode
  * Qwen SDK uses 'auto-edit' instead of 'acceptEdits'
  */
@@ -403,7 +409,7 @@ export async function handleChatRequest(
       // because structured NDJSON is more likely to be flushed as a complete chunk.
       keepaliveId = setInterval(() => {
         try { controller.enqueue(encoder.encode('{"type":"heartbeat"}\n')); } catch { clearInterval(keepaliveId); }
-      }, 15_000);
+      }, KEEPALIVE_INTERVAL_MS);
 
       try {
         await executeQwenCommand(

--- a/backend/handlers/chat.ts
+++ b/backend/handlers/chat.ts
@@ -4,6 +4,7 @@ import type { ChatRequest, StreamResponse } from "../../shared/types.ts";
 import { logger } from "../utils/logger.ts";
 import { checkLoop, type LoopState } from "../utils/loopDetector.ts";
 import type { PendingPermission } from "./permission.ts";
+import type { ServerResponse } from "node:http";
 
 /** Track number of concurrent chat requests for diagnostics */
 let _activeChatCount = 0;
@@ -351,6 +352,7 @@ export async function handleChatRequest(
 ) {
   const chatRequest: ChatRequest = await c.req.json();
   const { cliPath, authType } = c.var.config as { cliPath: string; authType?: AuthType };
+  const outgoing = (c.env as { outgoing?: ServerResponse })?.outgoing;
 
   logger.chat.debug(
     "Received chat request {*}",
@@ -381,6 +383,12 @@ export async function handleChatRequest(
 
   const stream = new ReadableStream({
     async start(controller) {
+      // Ensure small keepalive chunks are flushed immediately (fixes stall
+      // detector false positives caused by TCP/HTTP buffering of single-byte \n)
+      if (outgoing?.socket) {
+        outgoing.socket.setNoDelay(true);
+      }
+
       const enqueue = (response: StreamResponse): boolean => {
         try {
           controller.enqueue(encoder.encode(JSON.stringify(response) + "\n"));
@@ -390,9 +398,11 @@ export async function handleChatRequest(
         }
       };
 
-      // Send keepalive newlines to prevent browser timeout (ERR_INCOMPLETE_CHUNKED_ENCODING)
+      // Send keepalive heartbeat to prevent browser timeout (ERR_INCOMPLETE_CHUNKED_ENCODING)
+      // and stall detector false positives. Using a JSON heartbeat instead of bare \n
+      // because structured NDJSON is more likely to be flushed as a complete chunk.
       keepaliveId = setInterval(() => {
-        try { controller.enqueue(encoder.encode("\n")); } catch { clearInterval(keepaliveId); }
+        try { controller.enqueue(encoder.encode('{"type":"heartbeat"}\n')); } catch { clearInterval(keepaliveId); }
       }, 15_000);
 
       try {

--- a/backend/runtime/deno.ts
+++ b/backend/runtime/deno.ts
@@ -82,7 +82,7 @@ export class DenoRuntime implements Runtime {
   serve(
     port: number,
     hostname: string,
-    handler: (req: Request) => Response | Promise<Response>,
+    handler: (req: Request, env?: unknown) => Response | Promise<Response>,
   ): Promise<void> {
     const server = Deno.serve({ port, hostname }, handler);
     // Return the finished promise which resolves when server closes

--- a/backend/runtime/node.ts
+++ b/backend/runtime/node.ts
@@ -7,7 +7,6 @@
 import { spawn, type SpawnOptions } from "node:child_process";
 import process from "node:process";
 import { serve } from "@hono/node-server";
-import { Hono } from "hono";
 import type { CommandResult, Runtime } from "./types.ts";
 import type { MiddlewareHandler } from "hono";
 import { serveStatic } from "@hono/node-server/serve-static";

--- a/backend/runtime/node.ts
+++ b/backend/runtime/node.ts
@@ -108,21 +108,14 @@ export class NodeRuntime implements Runtime {
   async serve(
     port: number,
     hostname: string,
-    handler: (req: Request) => Response | Promise<Response>,
+    handler: (req: Request, env?: unknown) => Response | Promise<Response>,
   ): Promise<void> {
-    // Use Hono with Node.js server to handle Web API Request/Response
-    const app = new Hono();
-
-    // Route all requests to the provided handler
-    app.all("*", async (c) => {
-      const response = await handler(c.req.raw);
-      return response;
-    });
-
-    // Start the server using @hono/node-server
-    // The serve function returns a server instance that keeps the process alive
+    // Pass handler directly to @hono/node-server so that
+    // { incoming, outgoing } Node.js bindings are available as c.env
+    // in Hono handlers. The previous double-wrapping via a separate
+    // Hono().all("*", ...) discarded these bindings.
     const server = serve({
-      fetch: app.fetch,
+      fetch: handler,
       port,
       hostname,
       serverOptions: {

--- a/backend/runtime/types.ts
+++ b/backend/runtime/types.ts
@@ -29,7 +29,7 @@ export interface Runtime {
   serve(
     port: number,
     hostname: string,
-    handler: (req: Request) => Response | Promise<Response>,
+    handler: (req: Request, env?: unknown) => Response | Promise<Response>,
   ): Promise<void>;
 
   // Static file serving (different middleware)

--- a/frontend/src/components/ChatPage.tsx
+++ b/frontend/src/components/ChatPage.tsx
@@ -706,7 +706,9 @@ export function ChatPage() {
           if (done || shouldAbort) break;
 
           stallDetector.onData();
-
+          // NOTE: Must be called before processStreamLine() below. Heartbeats
+          // arrive as NDJSON lines — if this call were moved after line parsing,
+          // the stall timer would never be reset and would falsely trigger.
           lineBuffer += decoder.decode(value, { stream: true });
           const lines = lineBuffer.split("\n");
           lineBuffer = lines.pop() || "";

--- a/frontend/src/hooks/streaming/useStreamParser.test.ts
+++ b/frontend/src/hooks/streaming/useStreamParser.test.ts
@@ -374,6 +374,19 @@ describe("useStreamParser", () => {
       });
     });
 
+    it("should handle heartbeat without producing messages", () => {
+      const { result } = renderHook(() => useStreamParser());
+
+      result.current.processStreamLine(
+        JSON.stringify({ type: "heartbeat" }),
+        mockContext,
+      );
+
+      expect(mockContext.addMessage).not.toHaveBeenCalled();
+      expect(mockContext.updateLastMessage).not.toHaveBeenCalled();
+      expect(mockContext.setCurrentAssistantMessage).not.toHaveBeenCalled();
+    });
+
     it("should handle aborted stream responses", () => {
       const { result } = renderHook(() => useStreamParser());
 

--- a/frontend/src/hooks/streaming/useStreamParser.ts
+++ b/frontend/src/hooks/streaming/useStreamParser.ts
@@ -305,6 +305,9 @@ export function useStreamParser() {
           };
           context.addMessage(abortedMessage);
           context.setCurrentAssistantMessage(null);
+        } else if (data.type === "heartbeat") {
+          // Backend keepalive — resets stall detector via stallDetector.onData()
+          // in ChatPage.tsx (called before this function). Nothing to do here.
         }
       } catch (parseError) {
         console.error("Failed to parse stream line:", parseError);

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -1,5 +1,5 @@
 export interface StreamResponse {
-  type: "claude_json" | "error" | "done" | "aborted" | "permission_request";
+  type: "claude_json" | "error" | "done" | "aborted" | "permission_request" | "heartbeat";
   data?: unknown; // SDKMessage object for claude_json type (Qwen SDK message)
   error?: string;
   // Fields for permission_request type


### PR DESCRIPTION
Fixes #125

## Summary

The stall detector (PR #114) fires incorrectly when the backend is alive but the AI is in a long thinking phase. Root cause: single-byte `\n` keepalive bytes are not reliably delivered to the browser, causing the 60-second timeout to trigger.

Three changes:

1. **Eliminate double Hono wrapping** — pass handler directly to `serve()` so `c.env` contains `{ incoming, outgoing }` Node.js bindings
2. **Call `socket.setNoDelay(true)`** at stream start to ensure small keepalive chunks are flushed immediately
3. **Replace `\n` with `{"type":"heartbeat"}\n`** — structured NDJSON is more reliably transmitted as a complete chunk

## Root Cause

The `@hono/node-server` adapter's `flow()` function calls `outgoing.write(value)` per chunk but never calls `socket.setNoDelay()`, `uncork()`, or `flush()`. Single-byte `\n` keepalives were being buffered by Node.js's HTTP response internal buffer and never delivered to the browser. Additionally, the outer Hono wrapper in `runtime/node.ts` discarded `c.env` bindings, preventing handlers from accessing the raw `ServerResponse` to fix this.

## Test Plan

- [ ] `npm run dev` → send message → verify heartbeat `{"type":"heartbeat"}` visible in DevTools Network panel
- [ ] Trigger AI thinking > 60s → verify stall detector does NOT fire
- [ ] `npx vitest run backend/handlers/chat.test.ts` → 25 passed
- [ ] `tsc --noEmit` → clean (frontend + backend)

🤖 Generated with [Claude Code](https://claude.com/claude-code)