### PR TITLE
fix: remove reactive permission flow that misinterpreted execution errors

### DIFF
--- a/frontend/src/components/ChatPage.tsx
+++ b/frontend/src/components/ChatPage.tsx
@@ -291,8 +291,6 @@ export function ChatPage() {
             setHasReceivedInit,
             shouldShowInitMessage: () => !hasShownInitMessage,
             onInitMessageShown: () => setHasShownInitMessage(true),
-            onPermissionError: (toolName, patterns, toolUseId) =>
-              permissionErrorRef.current?.(toolName, patterns, toolUseId),
             onCommandResultLoop: (...args) => commandLoopCheckRef.current?.(...args) ?? null,
             onShowCommandLoopRequest: (request) => {
               notificationTriggeredRef.current = true;
@@ -655,7 +653,6 @@ export function ChatPage() {
             localHasReceivedInit = received;
             setHasReceivedInit(received);
           },
-          onPermissionError: handlePermissionError,
           onAbortRequest: async () => {
             shouldAbort = true;
             await createAbortHandler(requestId)();

--- a/frontend/src/hooks/streaming/useStreamParser.ts
+++ b/frontend/src/hooks/streaming/useStreamParser.ts
@@ -179,8 +179,7 @@ export function useStreamParser() {
         shouldShowInitMessage: context.shouldShowInitMessage,
         onInitMessageShown: context.onInitMessageShown,
 
-        // Permission/Error handling
-        onPermissionError: context.onPermissionError,
+        // Error handling
         onAbortRequest: context.onAbortRequest,
 
         // Auto-rejection loop detection

--- a/frontend/src/utils/UnifiedMessageProcessor.test.ts
+++ b/frontend/src/utils/UnifiedMessageProcessor.test.ts
@@ -123,7 +123,6 @@ describe("UnifiedMessageProcessor - Loop Detection Integration", () => {
           autoRejectionCalls.push({ toolName, content });
           return null;
         },
-        onPermissionError: () => {},
         onAbortRequest: () => {},
       });
 
@@ -180,20 +179,14 @@ describe("UnifiedMessageProcessor - Loop Detection Integration", () => {
       expect(permissionErrorCalled).toBe(false);
     });
 
-    it("should show permission dialog when no auto-rejection loop", () => {
+    it("should NOT show permission dialog when no auto-rejection loop", () => {
       const processor = createProcessor();
-      let permissionErrorCalled = false;
-      let loopRequestShown = false;
+      const messages: any[] = [];
 
       const context = createMockContext({
         onAutoRejection: () => null,
-        onShowCommandLoopRequest: () => {
-          loopRequestShown = true;
-        },
-        onPermissionError: () => {
-          permissionErrorCalled = true;
-        },
-        onAbortRequest: () => {},
+        onShowCommandLoopRequest: () => {},
+        addMessage: (msg) => messages.push(msg),
       });
 
       sendToolUse(processor, context, "tool-noloop-1", "run_shell_command", {
@@ -206,8 +199,10 @@ describe("UnifiedMessageProcessor - Loop Detection Integration", () => {
         "[Operation Cancelled] Reason: Error: Input closed",
       );
 
-      expect(permissionErrorCalled).toBe(true);
-      expect(loopRequestShown).toBe(false);
+      // Error tool_result should pass through as normal tool_result, not trigger permission dialog
+      const resultMsg = messages.find((m) => m.type === "tool_result");
+      expect(resultMsg).toBeDefined();
+      expect(resultMsg.content).toContain("Input closed");
     });
 
     it("should not trigger auto-rejection for tool_use_error", () => {
@@ -219,7 +214,6 @@ describe("UnifiedMessageProcessor - Loop Detection Integration", () => {
           autoRejectionCalled = true;
           return null;
         },
-        onPermissionError: () => {},
         onAbortRequest: () => {},
       });
 
@@ -299,7 +293,7 @@ describe("UnifiedMessageProcessor - Loop Detection Integration", () => {
       expect(loopRequestShown!.toolName).toBe("run_shell_command");
     });
 
-    it("should NOT call onCommandResultLoop for is_error tool results", () => {
+    it("should call onCommandResultLoop for is_error tool results too", () => {
       const processor = createProcessor();
       let commandLoopCalled = false;
 
@@ -309,8 +303,6 @@ describe("UnifiedMessageProcessor - Loop Detection Integration", () => {
           return null;
         },
         onAutoRejection: () => null,
-        onPermissionError: () => {},
-        onAbortRequest: () => {},
       });
 
       sendToolUse(processor, context, "tool-err-1", "run_shell_command", {
@@ -323,13 +315,13 @@ describe("UnifiedMessageProcessor - Loop Detection Integration", () => {
         "[Operation Cancelled] Input closed",
       );
 
-      // is_error tool results should NOT trigger command result loop detection
-      expect(commandLoopCalled).toBe(false);
+      // is_error tool results now pass through to command result loop detection
+      expect(commandLoopCalled).toBe(true);
     });
   });
 
   describe("Three detection mechanisms independence", () => {
-    it("should route is_error and non-error results to different detection paths", () => {
+    it("should route is_error results through both auto-rejection and command result detection", () => {
       const processor = createProcessor();
       const autoRejectionCalls: string[] = [];
       const commandResultCalls: string[] = [];
@@ -343,11 +335,9 @@ describe("UnifiedMessageProcessor - Loop Detection Integration", () => {
           commandResultCalls.push(toolName);
           return null;
         },
-        onPermissionError: () => {},
-        onAbortRequest: () => {},
       });
 
-      // 1. is_error → auto-rejection path
+      // 1. is_error → auto-rejection + command result path
       sendToolUse(processor, context, "tool-ind-1", "run_shell_command", {
         command: "ssh",
       });
@@ -358,7 +348,7 @@ describe("UnifiedMessageProcessor - Loop Detection Integration", () => {
         "Input closed",
       );
 
-      // 2. non-error → command result path
+      // 2. non-error → command result path only
       sendToolUse(processor, context, "tool-ind-2", "run_shell_command", {
         command: "go build",
       });
@@ -370,9 +360,10 @@ describe("UnifiedMessageProcessor - Loop Detection Integration", () => {
       );
 
       expect(autoRejectionCalls).toHaveLength(1);
-      expect(commandResultCalls).toHaveLength(1);
+      expect(commandResultCalls).toHaveLength(2);
       expect(autoRejectionCalls[0]).toBe("run_shell_command");
       expect(commandResultCalls[0]).toBe("run_shell_command");
+      expect(commandResultCalls[1]).toBe("run_shell_command");
     });
   });
 
@@ -386,7 +377,6 @@ describe("UnifiedMessageProcessor - Loop Detection Integration", () => {
           autoRejectionCalls.push(toolName);
           return null;
         },
-        onPermissionError: () => {},
         onAbortRequest: () => {},
       });
 
@@ -418,16 +408,12 @@ describe("UnifiedMessageProcessor - Loop Detection Integration", () => {
   });
 
   describe("onAutoRejection is optional", () => {
-    it("should fall back to permission error when onAutoRejection is not provided", () => {
+    it("should pass is_error tool_result through as normal result when onAutoRejection is not provided", () => {
       const processor = createProcessor();
-      let permissionErrorCalled = false;
+      const messages: any[] = [];
 
       const context = createMockContext({
-        // No onAutoRejection
-        onPermissionError: () => {
-          permissionErrorCalled = true;
-        },
-        onAbortRequest: () => {},
+        addMessage: (msg) => messages.push(msg),
       });
 
       sendToolUse(processor, context, "tool-noar-1", "run_shell_command", {
@@ -440,7 +426,10 @@ describe("UnifiedMessageProcessor - Loop Detection Integration", () => {
         "Input closed",
       );
 
-      expect(permissionErrorCalled).toBe(true);
+      // Without onAutoRejection, error should pass through as normal tool_result
+      const resultMsg = messages.find((m) => m.type === "tool_result");
+      expect(resultMsg).toBeDefined();
+      expect(resultMsg.content).toContain("Input closed");
     });
   });
 });
@@ -541,7 +530,6 @@ describe("UnifiedMessageProcessor - Qwen SDK Format", () => {
           autoRejectionCalls.push({ toolName, content });
           return null;
         },
-        onPermissionError: () => {},
         onAbortRequest: () => {},
       });
 
@@ -701,7 +689,6 @@ describe("UnifiedMessageProcessor - Qwen SDK Format", () => {
           autoRejectionCalls.push({ toolName, content });
           return null;
         },
-        onPermissionError: () => {},
         onAbortRequest: () => {},
       });
 
@@ -872,7 +859,6 @@ describe("UnifiedMessageProcessor - Qwen SDK Format", () => {
           autoRejectionCalls.push(toolName);
           return null;
         },
-        onPermissionError: () => {},
         onAbortRequest: () => {},
       });
 

--- a/frontend/src/utils/UnifiedMessageProcessor.ts
+++ b/frontend/src/utils/UnifiedMessageProcessor.ts
@@ -53,13 +53,7 @@ export interface ProcessingContext {
   shouldShowInitMessage?: () => boolean;
   onInitMessageShown?: () => void;
 
-  // Permission/Error handling
-  onPermissionError?: (
-    toolName: string,
-    patterns: string[],
-    toolUseId: string,
-    requestId?: string,
-  ) => void;
+  // Error handling
   onAbortRequest?: () => void;
 
   // Auto-rejection loop detection (SDK-level rejections, e.g. stdin closed)
@@ -138,53 +132,6 @@ export class UnifiedMessageProcessor {
     return this.toolUseCache.get(id);
   }
 
-  /**
-   * Handle permission errors during streaming
-   */
-  private handlePermissionError(
-    contentItem: { tool_use_id?: string; content?: string | unknown[] },
-    context: ProcessingContext,
-  ): void {
-    // Get cached tool_use information first (needed for both paths)
-    const toolUseId = contentItem.tool_use_id || "";
-    const cachedToolInfo = this.getCachedToolInfo(toolUseId);
-
-    // Extract tool information for permission handling
-    const { toolName, commands } = extractToolInfo(
-      cachedToolInfo?.name,
-      cachedToolInfo?.input,
-    );
-
-    // Check for auto-rejection loop before aborting
-    if (context.onAutoRejection) {
-      const content =
-        typeof contentItem.content === "string"
-          ? contentItem.content
-          : JSON.stringify(contentItem.content);
-      const loopRequest = context.onAutoRejection(toolName, content);
-      if (loopRequest && context.onShowCommandLoopRequest) {
-        // Loop detected - show loop dialog and abort
-        if (context.onAbortRequest) {
-          context.onAbortRequest();
-        }
-        context.onShowCommandLoopRequest(loopRequest);
-        return;
-      }
-    }
-
-    // No loop - normal permission error handling
-    if (context.onAbortRequest) {
-      context.onAbortRequest();
-    }
-
-    // Compute patterns based on tool type
-    const patterns = generateToolPatterns(toolName, commands);
-
-    // Notify parent component about permission error
-    if (context.onPermissionError) {
-      context.onPermissionError(toolName, patterns, toolUseId);
-    }
-  }
 
   /**
    * Process tool_result content item
@@ -215,15 +162,34 @@ export class UnifiedMessageProcessor {
         ? contentItem.content
         : JSON.stringify(contentItem.content);
 
-    // Check for permission errors - but skip tool use errors and proactive denials
+    // is_error tool_results: check for auto-rejection loops, but do NOT show
+    // permission dialogs. The proactive canUseTool flow handles real permission
+    // requests; execution errors (file_not_found etc.) should pass through as
+    // normal tool results so the model can adjust. See issue #127.
     if (
       options.isStreaming &&
       contentItem.is_error &&
       !isToolUseError(content) &&
       !content.includes("[proactive]")
     ) {
-      this.handlePermissionError(contentItem, context);
-      return;
+      // Only abort the stream if an auto-rejection loop is detected
+      if (context.onAutoRejection) {
+        const toolUseId = contentItem.tool_use_id || "";
+        const cachedToolInfo = this.getCachedToolInfo(toolUseId);
+        const { toolName } = extractToolInfo(
+          cachedToolInfo?.name,
+          cachedToolInfo?.input,
+        );
+        const loopRequest = context.onAutoRejection(toolName, content);
+        if (loopRequest && context.onShowCommandLoopRequest) {
+          if (context.onAbortRequest) {
+            context.onAbortRequest();
+          }
+          context.onShowCommandLoopRequest(loopRequest);
+          return;
+        }
+      }
+      // No loop detected — fall through to normal tool_result processing
     }
 
     const cachedToolInfo = this.getCachedToolInfo(toolUseId);

--- a/frontend/src/utils/UnifiedMessageProcessor.ts
+++ b/frontend/src/utils/UnifiedMessageProcessor.ts
@@ -15,7 +15,7 @@ import {
 } from "./messageConversion";
 import { isThinkingContentItem } from "./messageTypes";
 import type { ThinkingTimeoutContext } from "../hooks/streaming/useMessageProcessor";
-import { extractToolInfo, generateToolPatterns } from "./toolUtils";
+import { extractToolInfo } from "./toolUtils";
 import { TOOL_NAMES } from "./toolNames";
 import type { CommandLoopRequest } from "../hooks/chat/usePermissions";
 


### PR DESCRIPTION
## Summary

- Remove the reactive permission flow that treated ALL `is_error` tool_results as permission denials, causing meaningless permission dialogs for execution errors (file_not_found, edit mismatches, etc.)
- Retain auto-rejection loop detection — only abort the stream when a loop is actually detected
- Execution errors now pass through as normal tool_results so the model can adjust within the same response

## Root Cause

The `UnifiedMessageProcessor` reactive flow at line 218-227 treated every `is_error: true` tool_result as a permission denial, showing a dialog and aborting the stream. This was wrong because:

1. **Only `ToolErrorType.EXECUTION_DENIED` is a permission denial** — the other 30+ error types (file_not_found, edit_no_occurrence_found, shell_execute_error, etc.) are execution errors
2. **The proactive `canUseTool` flow already handles all real permission requests** — once it approves a tool, there's no subsequent permission denial possible
3. **The reactive flow's permission handling was ineffective anyway** — L1/L4 deny rules take priority over `allowedTools`, hooks run independently

## Changes

| File | Change |
|------|--------|
| `UnifiedMessageProcessor.ts` | Inline auto-rejection loop check, remove `handlePermissionError()` and `onPermissionError` from ProcessingContext |
| `UnifiedMessageProcessor.test.ts` | Update tests: errors no longer trigger permission dialog, but still trigger loop detection |
| `ChatPage.tsx` | Remove `onPermissionError` from local streaming context (proactive flow uses `onPermissionRequest` separately) |
| `useStreamParser.ts` | Remove `onPermissionError` passthrough |

## Test plan

- [x] 20/20 UnifiedMessageProcessor tests pass
- [ ] Manual test: trigger a `read_file` for a non-existent file — should show error inline, NOT permission dialog
- [ ] Manual test: permission request for `edit` tool still shows proactive dialog via `canUseTool`
- [ ] Manual test: repeated "Input closed" errors still trigger auto-rejection loop dialog

Fixes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)