### PR TITLE
fix: support BrowserRouter basename via window.__WEBUI_BASENAME__

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -45,7 +45,8 @@ function RootRedirect() {
 }
 
 function App() {
-  const basename = (window as any).__WEBUI_BASENAME__ as string | undefined;
+  const raw = window.__WEBUI_BASENAME__;
+  const basename = typeof raw === "string" && raw ? raw : undefined;
   return (
     <SettingsProvider>
       <GlobalEscHandler>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -45,10 +45,11 @@ function RootRedirect() {
 }
 
 function App() {
+  const basename = (window as any).__WEBUI_BASENAME__ as string | undefined;
   return (
     <SettingsProvider>
       <GlobalEscHandler>
-        <Router>
+        <Router basename={basename}>
           <Routes>
             <Route path="/" element={<RootRedirect />} />
             <Route path="/projects/*" element={<ChatPage />} />

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,1 +1,5 @@
 /// <reference types="vite/client" />
+
+interface Window {
+  __WEBUI_BASENAME__?: string;
+}


### PR DESCRIPTION
## Summary
- BrowserRouter now reads `window.__WEBUI_BASENAME__` as its `basename` prop, enabling correct route matching when deployed behind nginx reverse proxy at `/webui/{port}/`
- Eliminates the need for fragile JS-level `sub_filter` rewriting in nginx (which breaks every time webui is rebuilt due to minified variable name changes)

## Problem
When Open-ACE deploys webui behind HTTPS nginx proxy, each user's webui is accessed via `/webui/{port}/`. The BrowserRouter had no `basename` configured, causing all routes to fail with "No routes matched location". The previous workaround was a nginx `sub_filter` that matched minified JS patterns like `(0,U.jsx)(mi,{children:`, which broke when the webui was rebuilt with different minified names (e.g., `(0,z.jsx)(yi,{children:`).

## Test plan
- [x] Verified built JS contains `window.__WEBUI_BASENAME__` reference in Router's basename prop
- [x] Deployed to production server and confirmed workspace loads correctly via `/webui/3100/`
- [x] Verified no regression when `__WEBUI_BASENAME__` is undefined (standalone mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)