### PR TITLE
ci: add branch protection to prevent direct commits to main

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Prevent direct commits to main/master branch.
+# Contributors should create a feature branch and submit a PR instead.
+
+branch=$(git symbolic-ref --short HEAD 2>/dev/null)
+
+if [ "$branch" = "main" ] || [ "$branch" = "master" ]; then
+  echo ""
+  echo "Error: Direct commits to '$branch' are not allowed."
+  echo "Please create a feature branch and submit a PR instead."
+  echo ""
+  echo "  git checkout -b your-feature-branch"
+  echo ""
+  exit 1
+fi

--- a/.github/workflows/protect-main.yml
+++ b/.github/workflows/protect-main.yml
@@ -1,0 +1,15 @@
+name: Protect Main Branch
+
+on:
+  push:
+    branches: [main, master]
+
+jobs:
+  check-direct-push:
+    runs-on: ubuntu-latest
+    if: "!startsWith(github.event.head_commit.message, 'Merge pull request')"
+    steps:
+      - name: Reject direct push to main
+        run: |
+          echo "::error::Direct pushes to main are not allowed. Please use a pull request."
+          exit 1

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Claude Code Web UI - Development Tasks
 
-.PHONY: format format-check lint typecheck test build dev clean
+.PHONY: format format-check lint typecheck test build dev clean setup
 
 # Formatting
 format: format-frontend format-backend
@@ -60,6 +60,10 @@ check: format-check lint typecheck test build-frontend
 # Install dependencies
 install:
 	cd frontend && npm ci
+
+# Setup git hooks (run after cloning)
+setup:
+	git config core.hooksPath .githooks
 
 # Format specific files (usage: make format-files FILES="file1 file2")
 format-files:


### PR DESCRIPTION
## Summary
- Add `.githooks/pre-commit` to block direct commits to `main`/`master` locally
- Add GitHub Actions workflow to reject non-PR pushes to `main` as CI fallback
- Add `make setup` target to configure `core.hooksPath` for team onboarding

## Test plan
- [ ] Run `make setup` then `git checkout main && git commit --allow-empty -m "test"` — should be rejected
- [ ] Push directly to main — CI should fail
- [ ] Push via PR — CI should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)