### PR TITLE
fix: bridge Claude Code session resume and handle stream errors

### DIFF
--- a/backend/handlers/chat.ts
+++ b/backend/handlers/chat.ts
@@ -442,6 +442,7 @@ export async function handleChatRequest(
       "Session bridged: original={originalSessionId} effective={effectiveSessionId}",
       { originalSessionId: chatRequest.sessionId, effectiveSessionId: bridgedSessionId },
     );
+    // Intentionally mutate request to update sessionId for downstream use
     chatRequest.sessionId = bridgedSessionId ?? undefined;
   }
 

--- a/backend/handlers/chat.ts
+++ b/backend/handlers/chat.ts
@@ -3,6 +3,7 @@ import { query, type PermissionMode, type AuthType, type PermissionResult } from
 import type { ChatRequest, StreamResponse } from "../../shared/types.ts";
 import { logger } from "../utils/logger.ts";
 import { checkLoop, type LoopState } from "../utils/loopDetector.ts";
+import { bridgeSession } from "../utils/sessionBridge.ts";
 import type { PendingPermission } from "./permission.ts";
 import type { ServerResponse } from "node:http";
 
@@ -251,6 +252,7 @@ async function executeQwenCommand(
         ...(mappedPermissionMode ? { permissionMode: mappedPermissionMode } : {}),
         ...(model ? { model } : {}),
         ...(authType ? { authType } : {}),
+        stderr: true,
         canUseTool,
         timeout: { canUseTool: SESSION_TIMEOUT_MS, controlRequest: SESSION_TIMEOUT_MS },
       },
@@ -427,6 +429,20 @@ export async function handleChatRequest(
       activeSessions.delete(chatRequest.sessionId);
     }
     activeSessions.set(chatRequest.sessionId, chatRequest.requestId);
+  }
+
+  // Bridge session from Claude Code directory if not found in qwen directory.
+  // This allows resuming Claude Code sessions that were loaded from history.
+  const bridgedSessionId = await bridgeSession(
+    chatRequest.workingDirectory,
+    chatRequest.sessionId,
+  );
+  if (bridgedSessionId !== chatRequest.sessionId) {
+    logger.chat.info(
+      "Session bridged: original={originalSessionId} effective={effectiveSessionId}",
+      { originalSessionId: chatRequest.sessionId, effectiveSessionId: bridgedSessionId },
+    );
+    chatRequest.sessionId = bridgedSessionId ?? undefined;
   }
 
   const encoder = new TextEncoder();

--- a/backend/utils/sessionBridge.test.ts
+++ b/backend/utils/sessionBridge.test.ts
@@ -2,9 +2,9 @@ import { describe, expect, it, vi, beforeEach } from "vitest";
 import { join } from "node:path";
 import { promises as fs } from "node:fs";
 
-// Mock os module to return a fixed home directory
+// Mock os module with vi.fn to allow per-test overrides
 vi.mock("./os.ts", () => ({
-  getHomeDir: () => "/mock/home",
+  getHomeDir: vi.fn(() => "/mock/home"),
 }));
 
 // Mock logger
@@ -20,25 +20,36 @@ vi.mock("./logger.ts", () => ({
 }));
 
 // Import after mocks are set up
-import { bridgeSession } from "./sessionBridge.ts";
+import { bridgeSession, encodeProjectPath } from "./sessionBridge.ts";
 
-// Helpers to construct expected paths
+// Helpers to construct expected paths using the production encoding
 const QWEN_BASE = "/mock/home/.qwen/projects";
 const CLAUDE_BASE = "/mock/home/.claude/projects";
 
-function encodePath(p: string): string {
-  return p.replace(/\/$/, "").replace(/[^a-zA-Z0-9]/g, "-");
-}
-
 function qwenSessionPath(cwd: string, sid: string) {
-  return join(QWEN_BASE, encodePath(cwd), "chats", `${sid}.jsonl`);
+  return join(QWEN_BASE, encodeProjectPath(cwd), "chats", `${sid}.jsonl`);
 }
 
 function claudeSessionPath(cwd: string, sid: string) {
-  return join(CLAUDE_BASE, encodePath(cwd), `${sid}.jsonl`);
+  return join(CLAUDE_BASE, encodeProjectPath(cwd), `${sid}.jsonl`);
 }
 
-describe("sessionBridge", () => {
+describe("encodeProjectPath", () => {
+  it("replaces all non-alphanumeric chars with dash (matches CLI sanitizeCwd)", () => {
+    expect(encodeProjectPath("/Users/dev/my project@v2"))
+      .toBe("-Users-dev-my-project-v2");
+    expect(encodeProjectPath("/Users/dev/open-ace"))
+      .toBe("-Users-dev-open-ace");
+    expect(encodeProjectPath("/path/with.dots_and:colons"))
+      .toBe("-path-with-dots-and-colons");
+  });
+
+  it("strips trailing slash before encoding", () => {
+    expect(encodeProjectPath("/Users/dev/")).toBe("-Users-dev");
+  });
+});
+
+describe("bridgeSession", () => {
   const mockCwd = "/Users/dev/project";
   const mockSid = "abc-123-def";
 
@@ -67,7 +78,6 @@ describe("sessionBridge", () => {
     const qwenPath = qwenSessionPath(mockCwd, mockSid);
     const claudePath = claudeSessionPath(mockCwd, mockSid);
 
-    // qwen path doesn't exist, claude path exists
     vi.spyOn(fs, "access")
       .mockRejectedValueOnce(new Error("not found")) // qwen
       .mockResolvedValueOnce(undefined); // claude
@@ -91,18 +101,18 @@ describe("sessionBridge", () => {
     expect(result).toBe(undefined);
   });
 
-  it("returns original sessionId on unexpected errors (non-blocking)", async () => {
-    vi.spyOn(fs, "access").mockRejectedValueOnce(new Error("permission denied"));
-    vi.spyOn(fs, "access").mockRejectedValueOnce(new Error("permission denied"));
+  it("returns original sessionId when outer catch handles unexpected error", async () => {
+    // Trigger outer catch by making getHomeDir return undefined, causing
+    // getQwenSessionPath to throw "Home directory not found"
+    const os = await import("./os.ts");
+    vi.mocked(os.getHomeDir).mockReturnValueOnce(undefined);
 
     const result = await bridgeSession(mockCwd, mockSid);
-    // Falls through to catch which returns original sessionId
-    expect(result).toBe(undefined);
+    // Outer catch returns original sessionId to avoid blocking the request
+    expect(result).toBe(mockSid);
   });
 
   it("copies subdirectories when they exist", async () => {
-    const claudeDir = claudeSessionPath(mockCwd, mockSid).replace(/\.jsonl$/, "");
-
     vi.spyOn(fs, "access")
       .mockRejectedValueOnce(new Error("not found")) // qwen
       .mockResolvedValueOnce(undefined); // claude
@@ -110,25 +120,20 @@ describe("sessionBridge", () => {
     vi.spyOn(fs, "mkdir").mockResolvedValue(undefined);
     vi.spyOn(fs, "copyFile").mockResolvedValue(undefined);
 
-    // readdir returns subdirectory entries
     vi.spyOn(fs, "readdir")
       .mockResolvedValueOnce([
         { name: "subagents", isDirectory: () => true, isFile: () => false, isSymbolicLink: () => false },
         { name: "tool-results", isDirectory: () => true, isFile: () => false, isSymbolicLink: () => false },
       ] as fs.Dirent[])
-      // copyDir calls for each subdirectory
       .mockResolvedValue([] as fs.Dirent[])
       .mockResolvedValue([] as fs.Dirent[]);
 
     const result = await bridgeSession(mockCwd, mockSid);
     expect(result).toBe(mockSid);
-    // mkdir called for qwen chats dir + 2 subdirectories
     expect(fs.mkdir).toHaveBeenCalledTimes(3);
   });
 
   it("skips symlinks when copying subdirectories", async () => {
-    const claudeDir = claudeSessionPath(mockCwd, mockSid).replace(/\.jsonl$/, "");
-
     vi.spyOn(fs, "access")
       .mockRejectedValueOnce(new Error("not found")) // qwen
       .mockResolvedValueOnce(undefined); // claude
@@ -142,17 +147,17 @@ describe("sessionBridge", () => {
 
     const result = await bridgeSession(mockCwd, mockSid);
     expect(result).toBe(mockSid);
-    // Only mkdir for chats dir, not for symlink
     expect(fs.mkdir).toHaveBeenCalledTimes(1);
   });
 
-  it("encodes paths correctly matching CLI sanitizeCwd", async () => {
-    const specialCwd = "/Users/dev/my project@v2";
-    const encoded = encodePath(specialCwd);
+  it("uses production encodeProjectPath for path construction", async () => {
+    const specialCwd = "/Users/dev/my project";
+    const encoded = encodeProjectPath(specialCwd);
 
-    // All non-alphanumeric chars should be replaced with '-'
-    expect(encoded).toBe("-Users-dev-my-project-v2");
+    // Verify spaces are encoded (the production function handles this)
     expect(encoded).not.toContain(" ");
-    expect(encoded).not.toContain("@");
+
+    const qwenPath = qwenSessionPath(specialCwd, mockSid);
+    expect(qwenPath).toContain(encoded);
   });
 });

--- a/backend/utils/sessionBridge.test.ts
+++ b/backend/utils/sessionBridge.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { join } from "node:path";
+import { promises as fs } from "node:fs";
+
+// Mock os module to return a fixed home directory
+vi.mock("./os.ts", () => ({
+  getHomeDir: () => "/mock/home",
+}));
+
+// Mock logger
+vi.mock("./logger.ts", () => ({
+  logger: {
+    chat: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    },
+  },
+}));
+
+// Import after mocks are set up
+import { bridgeSession } from "./sessionBridge.ts";
+
+// Helpers to construct expected paths
+const QWEN_BASE = "/mock/home/.qwen/projects";
+const CLAUDE_BASE = "/mock/home/.claude/projects";
+
+function encodePath(p: string): string {
+  return p.replace(/\/$/, "").replace(/[^a-zA-Z0-9]/g, "-");
+}
+
+function qwenSessionPath(cwd: string, sid: string) {
+  return join(QWEN_BASE, encodePath(cwd), "chats", `${sid}.jsonl`);
+}
+
+function claudeSessionPath(cwd: string, sid: string) {
+  return join(CLAUDE_BASE, encodePath(cwd), `${sid}.jsonl`);
+}
+
+describe("sessionBridge", () => {
+  const mockCwd = "/Users/dev/project";
+  const mockSid = "abc-123-def";
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns sessionId unchanged when no workingDirectory", async () => {
+    const result = await bridgeSession(undefined, mockSid);
+    expect(result).toBe(mockSid);
+  });
+
+  it("returns sessionId unchanged when no sessionId", async () => {
+    const result = await bridgeSession(mockCwd, undefined);
+    expect(result).toBe(undefined);
+  });
+
+  it("returns sessionId when session exists in qwen directory", async () => {
+    vi.spyOn(fs, "access").mockResolvedValueOnce(undefined); // qwen path exists
+
+    const result = await bridgeSession(mockCwd, mockSid);
+    expect(result).toBe(mockSid);
+  });
+
+  it("copies session from claude to qwen when only in claude directory", async () => {
+    const qwenPath = qwenSessionPath(mockCwd, mockSid);
+    const claudePath = claudeSessionPath(mockCwd, mockSid);
+
+    // qwen path doesn't exist, claude path exists
+    vi.spyOn(fs, "access")
+      .mockRejectedValueOnce(new Error("not found")) // qwen
+      .mockResolvedValueOnce(undefined); // claude
+
+    vi.spyOn(fs, "mkdir").mockResolvedValue(undefined);
+    vi.spyOn(fs, "copyFile").mockResolvedValue(undefined);
+    vi.spyOn(fs, "readdir").mockRejectedValue(new Error("no dir"));
+
+    const result = await bridgeSession(mockCwd, mockSid);
+
+    expect(result).toBe(mockSid);
+    expect(fs.copyFile).toHaveBeenCalledWith(claudePath, qwenPath);
+  });
+
+  it("returns undefined when session not found in either directory", async () => {
+    vi.spyOn(fs, "access")
+      .mockRejectedValueOnce(new Error("not found")) // qwen
+      .mockRejectedValueOnce(new Error("not found")); // claude
+
+    const result = await bridgeSession(mockCwd, mockSid);
+    expect(result).toBe(undefined);
+  });
+
+  it("returns original sessionId on unexpected errors (non-blocking)", async () => {
+    vi.spyOn(fs, "access").mockRejectedValueOnce(new Error("permission denied"));
+    vi.spyOn(fs, "access").mockRejectedValueOnce(new Error("permission denied"));
+
+    const result = await bridgeSession(mockCwd, mockSid);
+    // Falls through to catch which returns original sessionId
+    expect(result).toBe(undefined);
+  });
+
+  it("copies subdirectories when they exist", async () => {
+    const claudeDir = claudeSessionPath(mockCwd, mockSid).replace(/\.jsonl$/, "");
+
+    vi.spyOn(fs, "access")
+      .mockRejectedValueOnce(new Error("not found")) // qwen
+      .mockResolvedValueOnce(undefined); // claude
+
+    vi.spyOn(fs, "mkdir").mockResolvedValue(undefined);
+    vi.spyOn(fs, "copyFile").mockResolvedValue(undefined);
+
+    // readdir returns subdirectory entries
+    vi.spyOn(fs, "readdir")
+      .mockResolvedValueOnce([
+        { name: "subagents", isDirectory: () => true, isFile: () => false, isSymbolicLink: () => false },
+        { name: "tool-results", isDirectory: () => true, isFile: () => false, isSymbolicLink: () => false },
+      ] as fs.Dirent[])
+      // copyDir calls for each subdirectory
+      .mockResolvedValue([] as fs.Dirent[])
+      .mockResolvedValue([] as fs.Dirent[]);
+
+    const result = await bridgeSession(mockCwd, mockSid);
+    expect(result).toBe(mockSid);
+    // mkdir called for qwen chats dir + 2 subdirectories
+    expect(fs.mkdir).toHaveBeenCalledTimes(3);
+  });
+
+  it("skips symlinks when copying subdirectories", async () => {
+    const claudeDir = claudeSessionPath(mockCwd, mockSid).replace(/\.jsonl$/, "");
+
+    vi.spyOn(fs, "access")
+      .mockRejectedValueOnce(new Error("not found")) // qwen
+      .mockResolvedValueOnce(undefined); // claude
+
+    vi.spyOn(fs, "mkdir").mockResolvedValue(undefined);
+    vi.spyOn(fs, "copyFile").mockResolvedValue(undefined);
+
+    vi.spyOn(fs, "readdir").mockResolvedValueOnce([
+      { name: "symlink-dir", isDirectory: () => true, isFile: () => false, isSymbolicLink: () => true },
+    ] as fs.Dirent[]);
+
+    const result = await bridgeSession(mockCwd, mockSid);
+    expect(result).toBe(mockSid);
+    // Only mkdir for chats dir, not for symlink
+    expect(fs.mkdir).toHaveBeenCalledTimes(1);
+  });
+
+  it("encodes paths correctly matching CLI sanitizeCwd", async () => {
+    const specialCwd = "/Users/dev/my project@v2";
+    const encoded = encodePath(specialCwd);
+
+    // All non-alphanumeric chars should be replaced with '-'
+    expect(encoded).toBe("-Users-dev-my-project-v2");
+    expect(encoded).not.toContain(" ");
+    expect(encoded).not.toContain("@");
+  });
+});

--- a/backend/utils/sessionBridge.ts
+++ b/backend/utils/sessionBridge.ts
@@ -13,12 +13,18 @@ import { join, dirname } from "node:path";
 import { getHomeDir } from "./os.ts";
 import { logger } from "./logger.ts";
 
+/** Max recursion depth for copyDir to prevent symlink cycles */
+const MAX_COPY_DEPTH = 10;
+
 /**
- * Encode a project path to match the directory naming convention.
- * Both Claude Code and qwen replace '/', '\', ':', '.', '_' with '-'.
+ * Encode a project path to match the directory naming convention used by
+ * both CLIs. Replaces all non-alphanumeric characters with '-'.
+ *
+ * Must match qwen-code-cli: core/src/utils/paths.ts → sanitizeCwd()
+ * which uses: cwd.replace(/[^a-zA-Z0-9]/g, '-')
  */
 function encodeProjectPath(projectPath: string): string {
-  return projectPath.replace(/\/$/, "").replace(/[/\\:._]/g, "-");
+  return projectPath.replace(/\/$/, "").replace(/[^a-zA-Z0-9]/g, "-");
 }
 
 /**
@@ -44,19 +50,24 @@ function getClaudeSessionPath(workingDirectory: string, sessionId: string): stri
 }
 
 /**
- * Recursively copy a directory.
+ * Recursively copy a directory with symlink and depth protection.
  */
-async function copyDir(src: string, dest: string): Promise<void> {
+async function copyDir(src: string, dest: string, depth = 0): Promise<void> {
+  if (depth > MAX_COPY_DEPTH) {
+    logger.chat.warn("copyDir: max depth exceeded at {src}, skipping", { src });
+    return;
+  }
   await fs.mkdir(dest, { recursive: true });
   const entries = await fs.readdir(src, { withFileTypes: true });
   for (const entry of entries) {
     const srcPath = join(src, entry.name);
     const destPath = join(dest, entry.name);
-    if (entry.isDirectory()) {
-      await copyDir(srcPath, destPath);
-    } else {
+    if (entry.isDirectory() && !entry.isSymbolicLink()) {
+      await copyDir(srcPath, destPath, depth + 1);
+    } else if (entry.isFile()) {
       await fs.copyFile(srcPath, destPath);
     }
+    // Skip symlinks to prevent cycle traversal
   }
 }
 
@@ -111,7 +122,7 @@ export async function bridgeSession(
     try {
       const entries = await fs.readdir(claudeSessionDir, { withFileTypes: true });
       for (const entry of entries) {
-        if (entry.isDirectory()) {
+        if (entry.isDirectory() && !entry.isSymbolicLink()) {
           const srcDir = join(claudeSessionDir, entry.name);
           const destDir = join(qwenSessionDir, entry.name);
           await copyDir(srcDir, destDir);

--- a/backend/utils/sessionBridge.ts
+++ b/backend/utils/sessionBridge.ts
@@ -1,0 +1,136 @@
+/**
+ * Session bridge between Claude Code and qwen CLI session storage.
+ *
+ * Claude Code stores sessions in ~/.claude/projects/<project>/, while the
+ * qwen CLI stores them in ~/.qwen/projects/<project>/chats/. When the webui
+ * loads a Claude Code session from history and the user sends a new message,
+ * the qwen CLI cannot find the session file. This module bridges the gap by
+ * copying the session file (and its subdirectories) to the qwen directory.
+ */
+
+import { promises as fs } from "node:fs";
+import { join, dirname } from "node:path";
+import { getHomeDir } from "./os.ts";
+import { logger } from "./logger.ts";
+
+/**
+ * Encode a project path to match the directory naming convention.
+ * Both Claude Code and qwen replace '/', '\', ':', '.', '_' with '-'.
+ */
+function encodeProjectPath(projectPath: string): string {
+  return projectPath.replace(/\/$/, "").replace(/[/\\:._]/g, "-");
+}
+
+/**
+ * Get the qwen session file path.
+ * qwen stores: ~/.qwen/projects/<encodedProject>/chats/<sessionId>.jsonl
+ */
+function getQwenSessionPath(workingDirectory: string, sessionId: string): string {
+  const homeDir = getHomeDir();
+  if (!homeDir) throw new Error("Home directory not found");
+  const encoded = encodeProjectPath(workingDirectory);
+  return join(homeDir, ".qwen", "projects", encoded, "chats", `${sessionId}.jsonl`);
+}
+
+/**
+ * Get the Claude Code session file path.
+ * Claude stores: ~/.claude/projects/<encodedProject>/<sessionId>.jsonl
+ */
+function getClaudeSessionPath(workingDirectory: string, sessionId: string): string {
+  const homeDir = getHomeDir();
+  if (!homeDir) throw new Error("Home directory not found");
+  const encoded = encodeProjectPath(workingDirectory);
+  return join(homeDir, ".claude", "projects", encoded, `${sessionId}.jsonl`);
+}
+
+/**
+ * Recursively copy a directory.
+ */
+async function copyDir(src: string, dest: string): Promise<void> {
+  await fs.mkdir(dest, { recursive: true });
+  const entries = await fs.readdir(src, { withFileTypes: true });
+  for (const entry of entries) {
+    const srcPath = join(src, entry.name);
+    const destPath = join(dest, entry.name);
+    if (entry.isDirectory()) {
+      await copyDir(srcPath, destPath);
+    } else {
+      await fs.copyFile(srcPath, destPath);
+    }
+  }
+}
+
+/**
+ * Ensure a qwen session file exists for resume. If the session only exists in
+ * the Claude Code directory, copy it (and its subdirectories) to the qwen
+ * directory. Returns the effective sessionId or undefined if not found anywhere.
+ */
+export async function bridgeSession(
+  workingDirectory: string | undefined,
+  sessionId: string | undefined,
+): Promise<string | undefined> {
+  if (!sessionId || !workingDirectory) return sessionId;
+
+  try {
+    const qwenPath = getQwenSessionPath(workingDirectory, sessionId);
+
+    // Fast path: session already exists in qwen directory
+    try {
+      await fs.access(qwenPath);
+      return sessionId;
+    } catch {
+      // Not found in qwen, continue to check Claude Code
+    }
+
+    const claudePath = getClaudeSessionPath(workingDirectory, sessionId);
+
+    // Check if session exists in Claude Code directory
+    try {
+      await fs.access(claudePath);
+    } catch {
+      // Not found anywhere — let the CLI handle the missing session
+      logger.chat.warn(
+        "Session {sessionId} not found in qwen or claude directories, clearing for fresh start",
+        { sessionId },
+      );
+      return undefined;
+    }
+
+    // Copy session JSONL file to qwen directory
+    await fs.mkdir(dirname(qwenPath), { recursive: true });
+    await fs.copyFile(claudePath, qwenPath);
+
+    logger.chat.info(
+      "Bridged session {sessionId} from claude to qwen directory",
+      { sessionId },
+    );
+
+    // Copy subdirectories (subagents, tool-results) if they exist
+    const claudeSessionDir = claudePath.replace(/\.jsonl$/, "");
+    const qwenSessionDir = qwenPath.replace(/\.jsonl$/, "");
+    try {
+      const entries = await fs.readdir(claudeSessionDir, { withFileTypes: true });
+      for (const entry of entries) {
+        if (entry.isDirectory()) {
+          const srcDir = join(claudeSessionDir, entry.name);
+          const destDir = join(qwenSessionDir, entry.name);
+          await copyDir(srcDir, destDir);
+          logger.chat.debug(
+            "Bridged session subdirectory {subdir} for session {sessionId}",
+            { subdir: entry.name, sessionId },
+          );
+        }
+      }
+    } catch {
+      // Session directory doesn't exist or is empty — that's fine
+    }
+
+    return sessionId;
+  } catch (error) {
+    logger.chat.error(
+      "Error bridging session {sessionId}: {error}",
+      { sessionId, error },
+    );
+    return sessionId; // Don't block the request on bridge errors
+  }
+}

--- a/backend/utils/sessionBridge.ts
+++ b/backend/utils/sessionBridge.ts
@@ -23,7 +23,7 @@ const MAX_COPY_DEPTH = 10;
  * Must match qwen-code-cli: core/src/utils/paths.ts → sanitizeCwd()
  * which uses: cwd.replace(/[^a-zA-Z0-9]/g, '-')
  */
-function encodeProjectPath(projectPath: string): string {
+export function encodeProjectPath(projectPath: string): string {
   return projectPath.replace(/\/$/, "").replace(/[^a-zA-Z0-9]/g, "-");
 }
 

--- a/frontend/src/components/ChatPage.tsx
+++ b/frontend/src/components/ChatPage.tsx
@@ -309,6 +309,8 @@ export function ChatPage() {
             thinkingTimeout: {
               onThinkingTimeout: (content, info) => thinkingTimeoutRef.current?.(content, info),
             },
+            // Clear stale sessionId on stream errors
+            onStreamError: () => { setCurrentSessionId(null); },
           },
           onPermissionRequest: (event) => {
             // Forward remote CLI permission request to the existing permission panel
@@ -698,6 +700,9 @@ export function ChatPage() {
           },
           // Track normal completion (result message received)
           onResultReceived: () => { receivedResult = true; },
+          // Clear stale sessionId on stream errors (e.g. CLI crash) so next
+          // request creates a fresh session instead of retrying a dead one
+          onStreamError: () => { setCurrentSessionId(null); },
         };
 
         let lineBuffer = "";

--- a/frontend/src/components/ChatPage.tsx
+++ b/frontend/src/components/ChatPage.tsx
@@ -310,7 +310,13 @@ export function ChatPage() {
               onThinkingTimeout: (content, info) => thinkingTimeoutRef.current?.(content, info),
             },
             // Clear stale sessionId on stream errors
-            onStreamError: () => { setCurrentSessionId(null); },
+            // Only clear sessionId on fatal errors, keep for transient ones
+            onStreamError: (error: string) => {
+              const fatalPatterns = ["exit", "session", "not found", "input closed"];
+              if (fatalPatterns.some(p => error.toLowerCase().includes(p))) {
+                setCurrentSessionId(null);
+              }
+            },
           },
           onPermissionRequest: (event) => {
             // Forward remote CLI permission request to the existing permission panel
@@ -700,9 +706,15 @@ export function ChatPage() {
           },
           // Track normal completion (result message received)
           onResultReceived: () => { receivedResult = true; },
-          // Clear stale sessionId on stream errors (e.g. CLI crash) so next
-          // request creates a fresh session instead of retrying a dead one
-          onStreamError: () => { setCurrentSessionId(null); },
+          // Clear stale sessionId only on fatal stream errors (CLI crash, session
+          // not found) — transient errors (network blip, timeout) keep sessionId
+          // to allow resume on retry
+          onStreamError: (error: string) => {
+            const fatalPatterns = ["exit", "session", "not found", "input closed"];
+            if (fatalPatterns.some(p => error.toLowerCase().includes(p))) {
+              setCurrentSessionId(null);
+            }
+          },
         };
 
         let lineBuffer = "";

--- a/frontend/src/components/ChatPage.tsx
+++ b/frontend/src/components/ChatPage.tsx
@@ -61,6 +61,15 @@ interface QuotaStatus {
   daily?: QuotaPeriodStatus;
 }
 
+/** Error patterns that indicate a fatal session failure requiring sessionId reset */
+const FATAL_SESSION_ERROR_PATTERNS = [
+  "exited with",
+  "exit code",
+  "session",
+  "not found",
+  "input closed",
+];
+
 export function ChatPage() {
   const location = useLocation();
   const navigate = useNavigate();
@@ -312,8 +321,7 @@ export function ChatPage() {
             // Clear stale sessionId on stream errors
             // Only clear sessionId on fatal errors, keep for transient ones
             onStreamError: (error: string) => {
-              const fatalPatterns = ["exit", "session", "not found", "input closed"];
-              if (fatalPatterns.some(p => error.toLowerCase().includes(p))) {
+              if (FATAL_SESSION_ERROR_PATTERNS.some(p => error.toLowerCase().includes(p))) {
                 setCurrentSessionId(null);
               }
             },
@@ -710,8 +718,7 @@ export function ChatPage() {
           // not found) — transient errors (network blip, timeout) keep sessionId
           // to allow resume on retry
           onStreamError: (error: string) => {
-            const fatalPatterns = ["exit", "session", "not found", "input closed"];
-            if (fatalPatterns.some(p => error.toLowerCase().includes(p))) {
+            if (FATAL_SESSION_ERROR_PATTERNS.some(p => error.toLowerCase().includes(p))) {
               setCurrentSessionId(null);
             }
           },

--- a/frontend/src/hooks/streaming/useMessageProcessor.ts
+++ b/frontend/src/hooks/streaming/useMessageProcessor.ts
@@ -61,6 +61,8 @@ export interface StreamingContext {
   thinkingTimeout?: ThinkingTimeoutInfo;
   // Called when a 'result' message is received — signals normal completion
   onResultReceived?: () => void;
+  // Called when a stream error is received — allows clearing stale sessionId
+  onStreamError?: (error: string) => void;
 }
 
 /**

--- a/frontend/src/hooks/streaming/useStreamParser.ts
+++ b/frontend/src/hooks/streaming/useStreamParser.ts
@@ -295,6 +295,7 @@ export function useStreamParser() {
             timestamp: Date.now(),
           };
           context.addMessage(errorMessage);
+          context.onStreamError?.(data.error || "Unknown error");
         } else if (data.type === "aborted") {
           const abortedMessage: AbortMessage = {
             type: "system",


### PR DESCRIPTION
## Summary

Fixes #131

When the webui loads a Claude Code session from history and the user sends a new message, the qwen CLI cannot find the session file (stored in `~/.claude/` instead of `~/.qwen/`), causing exit code 1 with no visible error message. The user's messages repeatedly fail with no recovery path.

Three-layer fix:

1. **Session bridge** (`backend/utils/sessionBridge.ts`): Before the CLI tries `--resume`, check if the session exists in the qwen directory. If not, check the Claude Code directory. If found, copy the session file (and subdirectories like `subagents/`, `tool-results/`) to the qwen directory so resume works.

2. **Enable stderr capture** (`backend/handlers/chat.ts`): Pass `stderr: true` to the SDK query options so CLI error messages are logged instead of silently discarded (`ProcessTransport` defaults stderr to `'ignore'`).

3. **Clear stale sessionId on stream errors** (frontend): Add `onStreamError` callback to `StreamingContext`. When the stream parser receives `type: "error"`, call `setCurrentSessionId(null)` so the next request creates a fresh session instead of retrying the dead one in an infinite loop.

## Test plan

- [ ] Load a Claude Code session from history in the webui, send a new message → should resume successfully
- [ ] Send a message with a non-existent sessionId → should create a fresh session (not crash)
- [ ] Verify CLI errors appear in backend logs (`/tmp/qwen-code-webui-*/webui*.log`)
- [ ] Verify consecutive messages after an error don't enter an infinite retry loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)