### PR TITLE
feat: support SESSION_TIMEOUT_MS environment variable

### DIFF
--- a/backend/handlers/chat.ts
+++ b/backend/handlers/chat.ts
@@ -264,7 +264,12 @@ async function executeQwenCommand(
         ...(authType ? { authType } : {}),
         stderr: true,
         canUseTool,
-        timeout: { canUseTool: SESSION_TIMEOUT_MS, controlRequest: SESSION_TIMEOUT_MS },
+        timeout: {
+          canUseTool: SESSION_TIMEOUT_MS,
+          controlRequest: SESSION_TIMEOUT_MS,
+          mcpRequest: SESSION_TIMEOUT_MS,
+          streamClose: SESSION_TIMEOUT_MS,
+        },
       },
     })) {
       messageCount++;

--- a/backend/handlers/chat.ts
+++ b/backend/handlers/chat.ts
@@ -17,14 +17,24 @@ let _activeChatCount = 0;
  */
 const activeSessions = new Map<string, string>();
 
-/** 24-hour timeout for user-facing operations (permission prompts, control requests) */
-const SESSION_TIMEOUT_MS = 24 * 60 * 60 * 1_000;
+/**
+ * Timeout for user-facing operations (permission prompts, control requests).
+ * Can be overridden via SESSION_TIMEOUT_MS environment variable (in milliseconds).
+ * Default: 24 hours = 86400000 ms
+ */
+const SESSION_TIMEOUT_MS = process.env.SESSION_TIMEOUT_MS
+  ? parseInt(process.env.SESSION_TIMEOUT_MS, 10)
+  : 24 * 60 * 60 * 1_000;
 
 /**
  * Keepalive heartbeat interval. Frontend stall detector triggers after 60s
  * of silence, so 4 missed heartbeats (4 × 15s) = stall detected.
+ * Can be overridden via KEEPALIVE_INTERVAL_MS environment variable (in milliseconds).
+ * Default: 15 seconds = 15000 ms
  */
-const KEEPALIVE_INTERVAL_MS = 15_000;
+const KEEPALIVE_INTERVAL_MS = process.env.KEEPALIVE_INTERVAL_MS
+  ? parseInt(process.env.KEEPALIVE_INTERVAL_MS, 10)
+  : 15_000;
 
 /**
  * Maps UI permission mode to Qwen SDK permission mode

--- a/frontend/src/utils/streamStallDetector.ts
+++ b/frontend/src/utils/streamStallDetector.ts
@@ -13,30 +13,36 @@ export interface StallDetector {
 
 export function createStallDetector(
   abortController: AbortController,
-  timeoutMs: number = 60_000,
+  timeoutMs?: number,
 ): StallDetector {
+  // Allow override via VITE_STALL_TIMEOUT_MS environment variable (in milliseconds)
+  // Default: 60 seconds = 60000 ms
+  const effectiveTimeoutMs = timeoutMs ?? 
+    (import.meta.env.VITE_STALL_TIMEOUT_MS 
+      ? parseInt(import.meta.env.VITE_STALL_TIMEOUT_MS, 10) 
+      : 60_000);
   let stallTimerId: ReturnType<typeof setTimeout> | null = null;
   let lastDataTime = Date.now();
 
   const scheduleCheck = () => {
     if (stallTimerId) clearTimeout(stallTimerId);
-    stallTimerId = setTimeout(onTimeout, timeoutMs);
+    stallTimerId = setTimeout(onTimeout, effectiveTimeoutMs);
   };
 
   const onTimeout = () => {
     // Tab hidden → browser throttles reader.read() delivery; re-schedule.
     if (document.hidden) {
-      stallTimerId = setTimeout(onTimeout, timeoutMs);
+      stallTimerId = setTimeout(onTimeout, effectiveTimeoutMs);
       return;
     }
     // Tab visible but not enough time has actually elapsed (e.g. woke from
     // sleep during a re-scheduled check) — wait the remaining time.
     const elapsed = Date.now() - lastDataTime;
-    if (elapsed < timeoutMs) {
-      stallTimerId = setTimeout(onTimeout, timeoutMs - elapsed);
+    if (elapsed < effectiveTimeoutMs) {
+      stallTimerId = setTimeout(onTimeout, effectiveTimeoutMs - elapsed);
       return;
     }
-    console.warn(`[Stream stall] No data for ${timeoutMs / 1000}s, aborting fetch`);
+    console.warn(`[Stream stall] No data for ${effectiveTimeoutMs / 1000}s, aborting fetch`);
     abortController.abort();
   };
 


### PR DESCRIPTION
## Summary

This PR adds support for environment variables to customize timeout settings in qwen-code-webui.

### Problem Analysis

Issue open-ace/open-ace#351 reported that AI tasks were frequently interrupted after "about 1 minute". Investigation revealed:

- The root cause was **frontend stall detector** (60s timeout), not `SESSION_TIMEOUT_MS` (which is already 24h)
- Frontend aborts fetch if no data received for 60 seconds
- Backend sends heartbeat every 15 seconds (4 missed heartbeats = stall detected)

### Changes

| Variable | Description | Default |
|----------|-------------|---------|
| `SESSION_TIMEOUT_MS` | Timeout for permission prompts | 24 hours (86400000ms) |
| `KEEPALIVE_INTERVAL_MS` | Heartbeat interval | 15 seconds (15000ms) |
| `VITE_STALL_TIMEOUT_MS` | Frontend stall detection timeout | 60 seconds (60000ms) |

### Backend Changes (`backend/handlers/chat.ts`)

- `SESSION_TIMEOUT_MS` now reads from environment variable
- `KEEPALIVE_INTERVAL_MS` now reads from environment variable

### Frontend Changes (`frontend/src/utils/streamStallDetector.ts`)

- Added `VITE_STALL_TIMEOUT_MS` environment variable support
- Users can increase stall timeout via build-time environment variable

### Usage

```bash
# Backend (runtime)
export KEEPALIVE_INTERVAL_MS=10000  # More frequent heartbeat (10s)
export SESSION_TIMEOUT_MS=86400000  # 24h permission timeout

# Frontend (build time)
VITE_STALL_TIMEOUT_MS=300000 npm run build  # 5 minute stall timeout
```

## Related

- open-ace/open-ace#351