### PR TITLE
fix: replace onPermissionError with type-safe negative assertion

### DIFF
--- a/frontend/src/utils/UnifiedMessageProcessor.test.ts
+++ b/frontend/src/utils/UnifiedMessageProcessor.test.ts
@@ -144,7 +144,7 @@ describe("UnifiedMessageProcessor - Loop Detection Integration", () => {
     it("should show loop dialog when auto-rejection loop detected", () => {
       const processor = createProcessor();
       let loopRequestShown: CommandLoopRequest | null = null;
-      let permissionErrorCalled = false;
+      let abortCalled = false;
 
       const context = createMockContext({
         onAutoRejection: (toolName, content) => {
@@ -158,9 +158,8 @@ describe("UnifiedMessageProcessor - Loop Detection Integration", () => {
         onShowCommandLoopRequest: (request) => {
           loopRequestShown = request;
         },
-        onAbortRequest: () => {},
-        onPermissionError: () => {
-          permissionErrorCalled = true;
+        onAbortRequest: () => {
+          abortCalled = true;
         },
       });
 
@@ -176,7 +175,7 @@ describe("UnifiedMessageProcessor - Loop Detection Integration", () => {
 
       expect(loopRequestShown).not.toBeNull();
       expect(loopRequestShown!.toolName).toBe("run_shell_command");
-      expect(permissionErrorCalled).toBe(false);
+      expect(abortCalled).toBe(false);
     });
 
     it("should NOT show permission dialog when no auto-rejection loop", () => {


### PR DESCRIPTION
## Summary
- `onPermissionError` was never part of `ProcessingContext`, causing a TS build error
- Replace with `onAbortRequest` tracking to preserve the negative assertion that abort is not triggered during loop detection

## Test plan
- [x] `cd frontend && npm run build` passes
- [x] `cd frontend && npx vitest run` — 174 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)