### PR TITLE
chore: bump version to 0.2.29

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qwen-code-webui",
-  "version": "0.2.28",
+  "version": "0.2.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qwen-code-webui",
-      "version": "0.2.28",
+      "version": "0.2.29",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.11",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qwen-code-webui",
-  "version": "0.2.28",
+  "version": "0.2.29",
   "type": "module",
   "description": "Web-based interface for the Qwen Code CLI with streaming chat interface",
   "keywords": [


### PR DESCRIPTION
Version bump after npm publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)