### PR TITLE
fix: pass stderr as function instead of boolean to QueryOptions

### DIFF
--- a/backend/handlers/chat.ts
+++ b/backend/handlers/chat.ts
@@ -252,7 +252,9 @@ async function executeQwenCommand(
         ...(mappedPermissionMode ? { permissionMode: mappedPermissionMode } : {}),
         ...(model ? { model } : {}),
         ...(authType ? { authType } : {}),
-        stderr: true,
+        stderr: (message: string) => {
+          logger.chat.info("CLI stderr: {message}", { message });
+        },
         canUseTool,
         timeout: { canUseTool: SESSION_TIMEOUT_MS, controlRequest: SESSION_TIMEOUT_MS },
       },


### PR DESCRIPTION
## Summary

- Fix `stderr: true` (boolean) to `stderr: (message) => logger.chat.info(...)` in chat handler

## Why

The `@qwen-code/sdk` QueryOptions type requires `stderr` to be `(message: string) => void`, not a boolean. Passing `true` caused:

```
Error: Invalid QueryOptions: stderr: stderr must be a function
```

This error prevented all AI responses — users could send messages but received no reply.

## Test plan

- [ ] Send a chat message and verify AI responds
- [ ] Check webui logs for no "Invalid QueryOptions" errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)