### PR TITLE
fix: scope loop detection per agent to fix fork agent false positives (#140)

### DIFF
--- a/backend/handlers/chat.test.ts
+++ b/backend/handlers/chat.test.ts
@@ -1076,4 +1076,125 @@ describe("Chat Handler - Permission Mode Tests", () => {
       expect(capturedController).toBeInstanceOf(AbortController);
     });
   });
+
+  describe("Per-agent Loop Detection", () => {
+    it("should not trigger loop detection when fork agents send independent errors", async () => {
+      const chatRequest: ChatRequest = {
+        message: "Test parallel agents",
+        requestId: "req-agent-loop-1",
+        permissionMode: "auto-edit",
+      };
+
+      mockContext.req.json = vi.fn().mockResolvedValue(chatRequest);
+
+      // 3 messages: 2 from different fork agents, 1 from main session
+      // Each has the same error but should NOT accumulate together
+      const makeErrorMsg = (id: string, forkId: string | null) => ({
+        type: "user" as const,
+        message: {
+          role: "user" as const,
+          content: [{
+            type: "tool_result" as const,
+            tool_use_id: id,
+            content: "Error: command not found",
+            is_error: true,
+          }],
+        },
+        parent_tool_use_id: forkId,
+      });
+
+      mockQuery.mockImplementation(
+        () =>
+          ({
+            [Symbol.asyncIterator]: async function* () {
+              // Fork agent A error
+              yield makeErrorMsg("err-1", "fork_a") as any;
+              // Fork agent B error
+              yield makeErrorMsg("err-2", "fork_b") as any;
+              // Main session error (1st)
+              yield makeErrorMsg("err-3", null) as any;
+              // Success to complete
+              yield {
+                type: "assistant",
+                message: { content: [{ type: "text", text: "Done" }] },
+                session_id: "sess-agent-loop",
+                parent_tool_use_id: null,
+              } as any;
+            },
+            interrupt: vi.fn(),
+            next: vi.fn(),
+            return: vi.fn(),
+            throw: vi.fn(),
+          }) as any,
+      );
+
+      const response = await handleChatRequest(mockContext, requestAbortControllers, pendingPermissions);
+      const reader = response.body!.getReader();
+      const decoder = new TextDecoder();
+      const chunks: string[] = [];
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        chunks.push(decoder.decode(value));
+      }
+
+      // Should NOT abort — each agent only has 1 error, below threshold
+      const allChunks = chunks.join("");
+      expect(allChunks).not.toContain("loop detected");
+    });
+
+    it("should trigger loop detection when a single fork agent accumulates enough errors", async () => {
+      const chatRequest: ChatRequest = {
+        message: "Test single fork agent loop",
+        requestId: "req-agent-loop-2",
+        permissionMode: "auto-edit",
+      };
+
+      mockContext.req.json = vi.fn().mockResolvedValue(chatRequest);
+
+      const makeErrorMsg = (id: string, forkId: string | null) => ({
+        type: "user" as const,
+        message: {
+          role: "user" as const,
+          content: [{
+            type: "tool_result" as const,
+            tool_use_id: id,
+            content: "Error: command not found",
+            is_error: true,
+          }],
+        },
+        parent_tool_use_id: forkId,
+      });
+
+      mockQuery.mockImplementation(
+        () =>
+          ({
+            [Symbol.asyncIterator]: async function* () {
+              // Same fork agent sends 3 errors → should trigger loop
+              yield makeErrorMsg("err-a1", "fork_loop") as any;
+              yield makeErrorMsg("err-a2", "fork_loop") as any;
+              yield makeErrorMsg("err-a3", "fork_loop") as any;
+            },
+            interrupt: vi.fn(),
+            next: vi.fn(),
+            return: vi.fn(),
+            throw: vi.fn(),
+          }) as any,
+      );
+
+      const response = await handleChatRequest(mockContext, requestAbortControllers, pendingPermissions);
+      const reader = response.body!.getReader();
+      const decoder = new TextDecoder();
+      const chunks: string[] = [];
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        chunks.push(decoder.decode(value));
+      }
+
+      // Should abort with loop detected for the fork agent
+      const allChunks = chunks.join("");
+      expect(allChunks).toContain("loop detected");
+    });
+  });
 });

--- a/backend/handlers/chat.ts
+++ b/backend/handlers/chat.ts
@@ -276,7 +276,8 @@ async function executeQwenCommand(
       // Backend loop detection — failsafe if frontend detection fails.
       // Each agent (main session or fork) maintains its own LoopState
       // so parallel fork agents don't accumulate toward the same counter (#140).
-      const forkId = (sdkMessage as Record<string, unknown>).parent_tool_use_id as string | undefined;
+      const rawForkId = (sdkMessage as Record<string, unknown>).parent_tool_use_id;
+      const forkId = typeof rawForkId === "string" ? rawForkId : undefined;
       const ls = forkId
         ? (agentLoopStates.get(forkId) ?? { errorCount: 0, lastFingerprint: "", firstErrorTime: 0 })
         : loopState;

--- a/backend/handlers/chat.ts
+++ b/backend/handlers/chat.ts
@@ -269,7 +269,10 @@ async function executeQwenCommand(
       }
 
       // Backend loop detection — failsafe if frontend detection fails
-      const loopResult = checkLoop(sdkMessage, loopState);
+      // Skip for fork agent messages — they have their own CLI-side
+      // LoopDetectionService and should not affect the main session (#140)
+      const isForkMessage = !!(sdkMessage as Record<string, unknown>).parent_tool_use_id;
+      const loopResult = isForkMessage ? null : checkLoop(sdkMessage, loopState);
       if (loopResult) {
         logger.chat.error(
           "Loop detected: fingerprint={fingerprint}, count={count}, aborting CLI",

--- a/backend/handlers/chat.ts
+++ b/backend/handlers/chat.ts
@@ -122,6 +122,11 @@ async function executeQwenCommand(
 
     const loopState: LoopState = { errorCount: 0, lastFingerprint: "", firstErrorTime: 0 };
 
+    // Per-agent loop states keyed by parent_tool_use_id (#140).
+    // Each fork agent gets its own LoopState so parallel agents don't
+    // accumulate toward the same counter.
+    const agentLoopStates = new Map<string, LoopState>();
+
     // Create the canUseTool callback — proactive permission handling
     const canUseTool = async (
       toolName: string,
@@ -268,11 +273,17 @@ async function executeQwenCommand(
         );
       }
 
-      // Backend loop detection — failsafe if frontend detection fails
-      // Skip for fork agent messages — they have their own CLI-side
-      // LoopDetectionService and should not affect the main session (#140)
-      const isForkMessage = !!(sdkMessage as Record<string, unknown>).parent_tool_use_id;
-      const loopResult = isForkMessage ? null : checkLoop(sdkMessage, loopState);
+      // Backend loop detection — failsafe if frontend detection fails.
+      // Each agent (main session or fork) maintains its own LoopState
+      // so parallel fork agents don't accumulate toward the same counter (#140).
+      const forkId = (sdkMessage as Record<string, unknown>).parent_tool_use_id as string | undefined;
+      const ls = forkId
+        ? (agentLoopStates.get(forkId) ?? { errorCount: 0, lastFingerprint: "", firstErrorTime: 0 })
+        : loopState;
+      if (forkId && !agentLoopStates.has(forkId)) {
+        agentLoopStates.set(forkId, ls);
+      }
+      const loopResult = checkLoop(sdkMessage, ls);
       if (loopResult) {
         logger.chat.error(
           "Loop detected: fingerprint={fingerprint}, count={count}, aborting CLI",

--- a/frontend/src/components/ChatPage.tsx
+++ b/frontend/src/components/ChatPage.tsx
@@ -277,7 +277,7 @@ export function ChatPage() {
   // Refs for command loop detection — declared early so remote streamingContext
   // can reference them. Wired to actual functions after usePermissions is called.
   const commandLoopCheckRef = useRef<
-    ((toolName: string, input: Record<string, unknown>, result: { exitCode?: number; output: string }) => CommandLoopRequest | null) | null
+    ((toolName: string, input: Record<string, unknown>, result: { exitCode?: number; output: string }, agentId?: string) => CommandLoopRequest | null) | null
   >(null);
   const commandLoopShowRef = useRef<((request: CommandLoopRequest) => void) | null>(null);
 
@@ -311,8 +311,8 @@ export function ChatPage() {
                 setCurrentSessionId(null);
               }
             },
-            onAutoRejection: (toolName, content) => {
-              return recordAutoRejection(toolName, content);
+            onAutoRejection: (toolName, content, agentId) => {
+              return recordAutoRejection(toolName, content, agentId);
             },
             // Thinking timeout
             thinkingTimeout: {
@@ -675,8 +675,8 @@ export function ChatPage() {
             await createAbortHandler(requestId)();
           },
           // Auto-rejection loop detection
-          onAutoRejection: (toolName, content) => {
-            return recordAutoRejection(toolName, content);
+          onAutoRejection: (toolName, content, agentId) => {
+            return recordAutoRejection(toolName, content, agentId);
           },
           // Command result loop detection — auto-abort on loop
           onCommandResultLoop: checkCommandResultLoop,

--- a/frontend/src/hooks/chat/usePermissions.ts
+++ b/frontend/src/hooks/chat/usePermissions.ts
@@ -272,10 +272,13 @@ export function usePermissions(options: UsePermissionsOptions = {}) {
   }, []);
 
   /**
-   * Generate a key for command identification
+   * Generate a key for command identification, scoped per agentId.
+   * When agentId is provided (fork agent), it becomes a key prefix so
+   * each agent's loop counters are fully independent (#140).
    */
   const generateCommandKey = useCallback(
-    (toolName: string, input: Record<string, unknown>): string => {
+    (toolName: string, input: Record<string, unknown>, agentId?: string): string => {
+      const prefix = agentId ? `${agentId}:` : "";
       // For shell commands, use the command string
       if (input.command && typeof input.command === "string") {
         // Normalize command: remove path variations, keep core structure
@@ -283,11 +286,11 @@ export function usePermissions(options: UsePermissionsOptions = {}) {
           .replace(/\s+/g, " ")
           .trim()
           .substring(0, 100);
-        return `${toolName}:${normalizedCommand}`;
+        return `${prefix}${toolName}:${normalizedCommand}`;
       }
       // For other tools, use JSON representation (truncated)
       const inputStr = JSON.stringify(input).substring(0, 100);
-      return `${toolName}:${inputStr}`;
+      return `${prefix}${toolName}:${inputStr}`;
     },
     []
   );
@@ -300,7 +303,8 @@ export function usePermissions(options: UsePermissionsOptions = {}) {
     (
       toolName: string,
       input: Record<string, unknown>,
-      result: { exitCode?: number; output: string }
+      result: { exitCode?: number; output: string },
+      agentId?: string,
     ): CommandLoopRequest | null => {
       // Skip if loop detection is disabled for this session
       if (loopDetectionDisabledRef.current) {
@@ -325,12 +329,12 @@ export function usePermissions(options: UsePermissionsOptions = {}) {
 
       if (!isError && !hasErrorKeywords) {
         // Clear tracking for successful results
-        const key = generateCommandKey(toolName, input);
+        const key = generateCommandKey(toolName, input, agentId);
         commandResultsRef.current.delete(key);
         return null;
       }
 
-      const key = generateCommandKey(toolName, input);
+      const key = generateCommandKey(toolName, input, agentId);
       const errorFingerprint = generateErrorFingerprint(result.output);
 
       // Get existing entry
@@ -413,9 +417,12 @@ export function usePermissions(options: UsePermissionsOptions = {}) {
    * Returns CommandLoopRequest if loop detected, null otherwise
    */
   const recordAutoRejection = useCallback(
-    (toolName: string, content: string): CommandLoopRequest | null => {
+    (toolName: string, content: string, agentId?: string): CommandLoopRequest | null => {
       const config = loopDetectionConfigRef.current;
       const now = Date.now();
+
+      // Build a scoped key for agent isolation
+      const scopeKey = agentId ? `${agentId}:${toolName}` : toolName;
 
       // Reset counter if outside the time window
       if (now - lastAutoRejectionTimeRef.current > config.resetWindowMs) {
@@ -443,12 +450,12 @@ export function usePermissions(options: UsePermissionsOptions = {}) {
       // Skip loop detection for excluded tools
       if (config.excludedTools.has(toolName)) return null;
 
-      // Check if same tracking key as last auto-rejection
-      if (lastAutoRejectionToolRef.current === toolName) {
+      // Check if same scoped key as last auto-rejection
+      if (lastAutoRejectionToolRef.current === scopeKey) {
         autoRejectionCountRef.current++;
       } else {
         autoRejectionCountRef.current = 1;
-        lastAutoRejectionToolRef.current = toolName;
+        lastAutoRejectionToolRef.current = scopeKey;
       }
 
       lastAutoRejectionTimeRef.current = now;

--- a/frontend/src/hooks/chat/usePermissions.ts
+++ b/frontend/src/hooks/chat/usePermissions.ts
@@ -431,10 +431,10 @@ export function usePermissions(options: UsePermissionsOptions = {}) {
       const isInputClosed = lowerContent.includes("input closed") ||
         (lowerContent.includes("operation cancelled") && lowerContent.includes("input closed"));
 
-      // "Input closed" is a session-level fatal error — detect immediately,
-      // but only for the main session. Fork agents have their own stdin
-      // lifecycle and their "Input closed" should not abort the parent session.
-      if (isInputClosed && !agentId) {
+      // "Input closed" is a session-level fatal error — always detect immediately.
+      // When this occurs the CLI process is dead, so the entire session tree
+      // (including all fork agents) is unusable regardless of which agent reported it.
+      if (isInputClosed) {
         autoRejectionStatesRef.current.delete(scopeKey);
         return {
           isOpen: true,

--- a/frontend/src/hooks/chat/usePermissions.ts
+++ b/frontend/src/hooks/chat/usePermissions.ts
@@ -122,9 +122,10 @@ export function usePermissions(options: UsePermissionsOptions = {}) {
   const loopDetectionConfigRef = useRef(DEFAULT_LOOP_DETECTION_CONFIG);
 
   // Auto-rejection loop detection state (SDK-level rejections, e.g. stdin closed)
-  const autoRejectionCountRef = useRef(0);
-  const lastAutoRejectionToolRef = useRef<string>("");
-  const lastAutoRejectionTimeRef = useRef(0);
+  // Map-based per-agent counter: key = agentId:toolName (or just toolName for main session)
+  const autoRejectionStatesRef = useRef<
+    Map<string, { count: number; lastTime: number }>
+  >(new Map());
 
   // Command result loop detection state
   const commandResultLoopConfigRef = useRef(DEFAULT_COMMAND_RESULT_LOOP_CONFIG);
@@ -407,14 +408,14 @@ export function usePermissions(options: UsePermissionsOptions = {}) {
   const disableCommandResultLoopDetection = useCallback(() => {
     commandResultsRef.current.clear();
     // Reset auto-rejection counters too
-    autoRejectionCountRef.current = 0;
-    lastAutoRejectionToolRef.current = "";
+    autoRejectionStatesRef.current.clear();
     closeCommandLoopRequest();
   }, [closeCommandLoopRequest]);
 
   /**
    * Record an auto-rejected tool call (SDK-level rejection, e.g. stdin closed)
    * Returns CommandLoopRequest if loop detected, null otherwise
+   * Each agent (main session or fork) maintains independent counters (#140).
    */
   const recordAutoRejection = useCallback(
     (toolName: string, content: string, agentId?: string): CommandLoopRequest | null => {
@@ -424,11 +425,6 @@ export function usePermissions(options: UsePermissionsOptions = {}) {
       // Build a scoped key for agent isolation
       const scopeKey = agentId ? `${agentId}:${toolName}` : toolName;
 
-      // Reset counter if outside the time window
-      if (now - lastAutoRejectionTimeRef.current > config.resetWindowMs) {
-        autoRejectionCountRef.current = 0;
-      }
-
       // "Input closed" is a session-level fatal error — always detect immediately
       // Match the full SDK error format to avoid false positives from benign "Operation Cancelled"
       const lowerContent = content.toLowerCase();
@@ -436,7 +432,7 @@ export function usePermissions(options: UsePermissionsOptions = {}) {
         (lowerContent.includes("operation cancelled") && lowerContent.includes("input closed"));
 
       if (isInputClosed) {
-        autoRejectionCountRef.current = 0;
+        autoRejectionStatesRef.current.delete(scopeKey);
         return {
           isOpen: true,
           toolName,
@@ -450,19 +446,20 @@ export function usePermissions(options: UsePermissionsOptions = {}) {
       // Skip loop detection for excluded tools
       if (config.excludedTools.has(toolName)) return null;
 
-      // Check if same scoped key as last auto-rejection
-      if (lastAutoRejectionToolRef.current === scopeKey) {
-        autoRejectionCountRef.current++;
-      } else {
-        autoRejectionCountRef.current = 1;
-        lastAutoRejectionToolRef.current = scopeKey;
-      }
+      // Get or create per-key state
+      const states = autoRejectionStatesRef.current;
+      const existing = states.get(scopeKey);
+      const state = existing && now - existing.lastTime <= config.resetWindowMs
+        ? existing
+        : { count: 0, lastTime: now };
 
-      lastAutoRejectionTimeRef.current = now;
+      state.count++;
+      state.lastTime = now;
+      states.set(scopeKey, state);
 
       // Check threshold
-      if (autoRejectionCountRef.current >= config.maxConsecutiveDenials) {
-        autoRejectionCountRef.current = 0;
+      if (state.count >= config.maxConsecutiveDenials) {
+        states.delete(scopeKey);
         return {
           isOpen: true,
           toolName,
@@ -480,8 +477,7 @@ export function usePermissions(options: UsePermissionsOptions = {}) {
    * Reset the auto-rejection counter
    */
   const resetAutoRejectionCounter = useCallback(() => {
-    autoRejectionCountRef.current = 0;
-    lastAutoRejectionToolRef.current = "";
+    autoRejectionStatesRef.current.clear();
   }, []);
 
   return {

--- a/frontend/src/hooks/chat/usePermissions.ts
+++ b/frontend/src/hooks/chat/usePermissions.ts
@@ -431,7 +431,10 @@ export function usePermissions(options: UsePermissionsOptions = {}) {
       const isInputClosed = lowerContent.includes("input closed") ||
         (lowerContent.includes("operation cancelled") && lowerContent.includes("input closed"));
 
-      if (isInputClosed) {
+      // "Input closed" is a session-level fatal error — detect immediately,
+      // but only for the main session. Fork agents have their own stdin
+      // lifecycle and their "Input closed" should not abort the parent session.
+      if (isInputClosed && !agentId) {
         autoRejectionStatesRef.current.delete(scopeKey);
         return {
           isOpen: true,

--- a/frontend/src/hooks/streaming/useMessageProcessor.ts
+++ b/frontend/src/hooks/streaming/useMessageProcessor.ts
@@ -40,12 +40,14 @@ export interface StreamingContext {
   onAutoRejection?: (
     toolName: string,
     content: string,
+    agentId?: string,
   ) => CommandLoopRequest | null;
   // Command result loop detection
   onCommandResultLoop?: (
     toolName: string,
     input: Record<string, unknown>,
-    result: { exitCode?: number; output: string }
+    result: { exitCode?: number; output: string },
+    agentId?: string,
   ) => CommandLoopRequest | null;
   onShowCommandLoopRequest?: (request: CommandLoopRequest) => void;
   // Proactive canUseTool permission handling

--- a/frontend/src/utils/UnifiedMessageProcessor.test.ts
+++ b/frontend/src/utils/UnifiedMessageProcessor.test.ts
@@ -778,13 +778,13 @@ describe("UnifiedMessageProcessor - Qwen SDK Format", () => {
       expect(loopCheckCalls[0].toolName).toBe("run_shell_command");
     });
 
-    it("should skip auto-rejection loop detection for fork agent messages", () => {
+    it("should pass agentId for fork agent auto-rejection loop detection", () => {
       const processor = createProcessor();
-      const autoRejectionCalls: Array<{ toolName: string; content: string }> = [];
+      const autoRejectionCalls: Array<{ toolName: string; content: string; agentId?: string }> = [];
 
       const context = createMockContext({
-        onAutoRejection: (toolName, content) => {
-          autoRejectionCalls.push({ toolName, content });
+        onAutoRejection: (toolName, content, agentId) => {
+          autoRejectionCalls.push({ toolName, content, agentId });
           return null;
         },
         onAbortRequest: () => {},
@@ -822,17 +822,18 @@ describe("UnifiedMessageProcessor - Qwen SDK Format", () => {
         { isStreaming: true },
       );
 
-      // Should NOT trigger auto-rejection because it's a fork agent
-      expect(autoRejectionCalls).toHaveLength(0);
+      // Should trigger auto-rejection WITH agentId (not skipped)
+      expect(autoRejectionCalls).toHaveLength(1);
+      expect(autoRejectionCalls[0].agentId).toBe("call_agent_fork_1");
     });
 
-    it("should skip command result loop detection for fork agent messages", () => {
+    it("should pass agentId for fork agent command result loop detection", () => {
       const processor = createProcessor();
-      const loopCheckCalls: Array<{ toolName: string; result: any }> = [];
+      const loopCheckCalls: Array<{ toolName: string; result: any; agentId?: string }> = [];
 
       const context = createMockContext({
-        onCommandResultLoop: (toolName, _input, result) => {
-          loopCheckCalls.push({ toolName, result });
+        onCommandResultLoop: (toolName, _input, result, agentId) => {
+          loopCheckCalls.push({ toolName, result, agentId });
           return null;
         },
       });
@@ -869,17 +870,18 @@ describe("UnifiedMessageProcessor - Qwen SDK Format", () => {
         { isStreaming: true },
       );
 
-      // Should NOT trigger command result loop detection because it's a fork agent
-      expect(loopCheckCalls).toHaveLength(0);
+      // Should trigger command result loop check WITH agentId (not skipped)
+      expect(loopCheckCalls).toHaveLength(1);
+      expect(loopCheckCalls[0].agentId).toBe("call_agent_fork_2");
     });
 
-    it("should skip auto-rejection loop detection for fork agent user messages", () => {
+    it("should not trigger auto-rejection for fork agent user messages without is_error", () => {
       const processor = createProcessor();
-      const autoRejectionCalls: Array<{ toolName: string; content: string }> = [];
+      const autoRejectionCalls: Array<{ toolName: string; content: string; agentId?: string }> = [];
 
       const context = createMockContext({
-        onAutoRejection: (toolName, content) => {
-          autoRejectionCalls.push({ toolName, content });
+        onAutoRejection: (toolName, content, agentId) => {
+          autoRejectionCalls.push({ toolName, content, agentId });
           return null;
         },
         onAbortRequest: () => {},
@@ -890,7 +892,10 @@ describe("UnifiedMessageProcessor - Qwen SDK Format", () => {
         command: "git diff main...HEAD",
       });
 
-      // Send error result as user message with parent_tool_use_id (fork agent)
+      // Send result as user message with parent_tool_use_id (fork agent).
+      // The Qwen parts functionResponse path sets is_error=false, so
+      // auto-rejection should NOT be triggered (this is correct behavior —
+      // only tool_result messages with is_error=true trigger auto-rejection).
       processor.processMessage(
         {
           type: "user",
@@ -912,7 +917,7 @@ describe("UnifiedMessageProcessor - Qwen SDK Format", () => {
         { isStreaming: true },
       );
 
-      // Should NOT trigger auto-rejection because it's a fork agent
+      // Should NOT trigger auto-rejection because is_error is false in this path
       expect(autoRejectionCalls).toHaveLength(0);
     });
 

--- a/frontend/src/utils/UnifiedMessageProcessor.test.ts
+++ b/frontend/src/utils/UnifiedMessageProcessor.test.ts
@@ -875,7 +875,7 @@ describe("UnifiedMessageProcessor - Qwen SDK Format", () => {
       expect(loopCheckCalls[0].agentId).toBe("call_agent_fork_2");
     });
 
-    it("should not trigger auto-rejection for fork agent user messages without is_error", () => {
+    it("should not trigger auto-rejection for non-error tool results (is_error=false path)", () => {
       const processor = createProcessor();
       const autoRejectionCalls: Array<{ toolName: string; content: string; agentId?: string }> = [];
 

--- a/frontend/src/utils/UnifiedMessageProcessor.test.ts
+++ b/frontend/src/utils/UnifiedMessageProcessor.test.ts
@@ -778,6 +778,144 @@ describe("UnifiedMessageProcessor - Qwen SDK Format", () => {
       expect(loopCheckCalls[0].toolName).toBe("run_shell_command");
     });
 
+    it("should skip auto-rejection loop detection for fork agent messages", () => {
+      const processor = createProcessor();
+      const autoRejectionCalls: Array<{ toolName: string; content: string }> = [];
+
+      const context = createMockContext({
+        onAutoRejection: (toolName, content) => {
+          autoRejectionCalls.push({ toolName, content });
+          return null;
+        },
+        onAbortRequest: () => {},
+      });
+
+      // Send tool call from main session
+      sendFunctionCall(processor, context, "fork-err-1", "run_shell_command", {
+        command: "git diff main...HEAD",
+      });
+
+      // Send error result via top-level tool_result with parent_tool_use_id (fork agent)
+      processor.processMessage(
+        {
+          type: "tool_result",
+          message: {
+            role: "user",
+            parts: [
+              {
+                functionResponse: {
+                  id: "fork-err-1",
+                  name: "run_shell_command",
+                  response: { error: "[Operation Cancelled] Reason: Error: Input closed" },
+                },
+              },
+            ],
+          },
+          toolCallResult: {
+            callId: "fork-err-1",
+            status: "cancelled",
+            resultDisplay: "[Operation Cancelled]",
+          },
+          parent_tool_use_id: "call_agent_fork_1",
+        } as any,
+        context,
+        { isStreaming: true },
+      );
+
+      // Should NOT trigger auto-rejection because it's a fork agent
+      expect(autoRejectionCalls).toHaveLength(0);
+    });
+
+    it("should skip command result loop detection for fork agent messages", () => {
+      const processor = createProcessor();
+      const loopCheckCalls: Array<{ toolName: string; result: any }> = [];
+
+      const context = createMockContext({
+        onCommandResultLoop: (toolName, _input, result) => {
+          loopCheckCalls.push({ toolName, result });
+          return null;
+        },
+      });
+
+      // Send tool call
+      sendFunctionCall(processor, context, "fork-cmd-1", "run_shell_command", {
+        command: "git diff main...HEAD",
+      });
+
+      // Send error result via top-level tool_result with parent_tool_use_id (fork agent)
+      processor.processMessage(
+        {
+          type: "tool_result",
+          message: {
+            role: "user",
+            parts: [
+              {
+                functionResponse: {
+                  id: "fork-cmd-1",
+                  name: "run_shell_command",
+                  response: { output: "Exit Code: 1\nError: command failed" },
+                },
+              },
+            ],
+          },
+          toolCallResult: {
+            callId: "fork-cmd-1",
+            status: "error",
+            resultDisplay: "Exit Code: 1",
+          },
+          parent_tool_use_id: "call_agent_fork_2",
+        } as any,
+        context,
+        { isStreaming: true },
+      );
+
+      // Should NOT trigger command result loop detection because it's a fork agent
+      expect(loopCheckCalls).toHaveLength(0);
+    });
+
+    it("should skip auto-rejection loop detection for fork agent user messages", () => {
+      const processor = createProcessor();
+      const autoRejectionCalls: Array<{ toolName: string; content: string }> = [];
+
+      const context = createMockContext({
+        onAutoRejection: (toolName, content) => {
+          autoRejectionCalls.push({ toolName, content });
+          return null;
+        },
+        onAbortRequest: () => {},
+      });
+
+      // Send tool call from main session using Qwen format (functionCall)
+      sendFunctionCall(processor, context, "fork-user-1", "run_shell_command", {
+        command: "git diff main...HEAD",
+      });
+
+      // Send error result as user message with parent_tool_use_id (fork agent)
+      processor.processMessage(
+        {
+          type: "user",
+          message: {
+            role: "user",
+            parts: [
+              {
+                functionResponse: {
+                  id: "fork-user-1",
+                  name: "run_shell_command",
+                  response: { error: "[Operation Cancelled] Reason: Error: Input closed" },
+                },
+              },
+            ],
+          },
+          parent_tool_use_id: "call_agent_fork_3",
+        } as any,
+        context,
+        { isStreaming: true },
+      );
+
+      // Should NOT trigger auto-rejection because it's a fork agent
+      expect(autoRejectionCalls).toHaveLength(0);
+    });
+
     it("should handle streaming of Qwen format messages", () => {
       const processor = createProcessor();
       const messages: any[] = [];

--- a/frontend/src/utils/UnifiedMessageProcessor.ts
+++ b/frontend/src/utils/UnifiedMessageProcessor.ts
@@ -63,13 +63,15 @@ export interface ProcessingContext {
   onAutoRejection?: (
     toolName: string,
     content: string,
+    agentId?: string,
   ) => CommandLoopRequest | null;
 
   // Command result loop detection
   onCommandResultLoop?: (
     toolName: string,
     input: Record<string, unknown>,
-    result: { exitCode?: number; output: string }
+    result: { exitCode?: number; output: string },
+    agentId?: string,
   ) => CommandLoopRequest | null;
   onShowCommandLoopRequest?: (request: CommandLoopRequest) => void;
 
@@ -148,16 +150,16 @@ export class UnifiedMessageProcessor {
     context: ProcessingContext,
     options: ProcessingOptions,
     toolUseResult?: unknown,
-    isForkAgent?: boolean,
+    agentId?: string,
   ): void {
     // Get cached tool_use information to determine tool name
     const toolUseId = contentItem.tool_use_id || "";
-    
+
     // Deduplication: check if this tool_result has already been processed
     if (this.processedToolResults.has(toolUseId)) {
       return;
     }
-    
+
     // Mark this tool_result as processed
     this.processedToolResults.add(toolUseId);
 
@@ -170,12 +172,10 @@ export class UnifiedMessageProcessor {
     // permission dialogs. The proactive canUseTool flow handles real permission
     // requests; execution errors (file_not_found etc.) should pass through as
     // normal tool results so the model can adjust. See issue #127.
-    // Skip loop detection for fork agent messages — they have their own
-    // CLI-side LoopDetectionService and should not accumulate toward
-    // the main session's loop counters (see #140).
+    // agentId scopes loop detection per-agent so parallel fork agents don't
+    // accumulate toward the same counter (#140).
     if (
       options.isStreaming &&
-      !isForkAgent &&
       contentItem.is_error &&
       !isToolUseError(content) &&
       !content.includes("[proactive]")
@@ -188,7 +188,7 @@ export class UnifiedMessageProcessor {
           cachedToolInfo?.name,
           cachedToolInfo?.input,
         );
-        const loopRequest = context.onAutoRejection(toolName, content);
+        const loopRequest = context.onAutoRejection(toolName, content, agentId);
         if (loopRequest && context.onShowCommandLoopRequest) {
           if (context.onAbortRequest) {
             context.onAbortRequest();
@@ -204,14 +204,14 @@ export class UnifiedMessageProcessor {
     const toolName = cachedToolInfo?.name || "Tool";
     const toolInput = cachedToolInfo?.input || {};
 
-    // Check for command result loop detection (streaming only, skip fork agents)
-    if (options.isStreaming && !isForkAgent && context.onCommandResultLoop) {
+    // Check for command result loop detection (streaming only, scoped per agentId)
+    if (options.isStreaming && context.onCommandResultLoop) {
       // Extract exit code and output from tool result
       const exitCode = this.extractExitCode(toolUseResult, content);
       const loopRequest = context.onCommandResultLoop(toolName, toolInput, {
         exitCode,
         output: content,
-      });
+      }, agentId);
 
       if (loopRequest && context.onShowCommandLoopRequest) {
         // Loop detected - show dialog and stop processing
@@ -663,7 +663,7 @@ export class UnifiedMessageProcessor {
             localContext,
             options,
             undefined,
-            !!message.parent_tool_use_id,
+            message.parent_tool_use_id || undefined,
           );
         } else if (part.text && !message.parent_tool_use_id) {
           // Text content in parts — skip if parent_tool_use_id is set
@@ -688,7 +688,7 @@ export class UnifiedMessageProcessor {
             localContext,
             options,
             toolUseResult,
-            !!message.parent_tool_use_id,
+            message.parent_tool_use_id || undefined,
           );
         } else if (contentItem.type === "text" && !message.parent_tool_use_id) {
           // Regular text content — skip if parent_tool_use_id is set
@@ -731,7 +731,7 @@ export class UnifiedMessageProcessor {
       toolCallResult?: { callId?: string; status?: string; resultDisplay?: string };
       parent_tool_use_id?: string | null;
     };
-    const isForkAgent = !!msg.parent_tool_use_id;
+    const agentId = msg.parent_tool_use_id || undefined;
 
     // Extract tool_use_id and content from functionResponse in parts
     const messageParts = msg.message?.parts;
@@ -771,7 +771,7 @@ export class UnifiedMessageProcessor {
             context,
             options,
             msg.toolCallResult,
-            isForkAgent,
+            agentId,
           );
         }
       }

--- a/frontend/src/utils/UnifiedMessageProcessor.ts
+++ b/frontend/src/utils/UnifiedMessageProcessor.ts
@@ -148,6 +148,7 @@ export class UnifiedMessageProcessor {
     context: ProcessingContext,
     options: ProcessingOptions,
     toolUseResult?: unknown,
+    isForkAgent?: boolean,
   ): void {
     // Get cached tool_use information to determine tool name
     const toolUseId = contentItem.tool_use_id || "";
@@ -169,8 +170,12 @@ export class UnifiedMessageProcessor {
     // permission dialogs. The proactive canUseTool flow handles real permission
     // requests; execution errors (file_not_found etc.) should pass through as
     // normal tool results so the model can adjust. See issue #127.
+    // Skip loop detection for fork agent messages — they have their own
+    // CLI-side LoopDetectionService and should not accumulate toward
+    // the main session's loop counters (see #140).
     if (
       options.isStreaming &&
+      !isForkAgent &&
       contentItem.is_error &&
       !isToolUseError(content) &&
       !content.includes("[proactive]")
@@ -199,8 +204,8 @@ export class UnifiedMessageProcessor {
     const toolName = cachedToolInfo?.name || "Tool";
     const toolInput = cachedToolInfo?.input || {};
 
-    // Check for command result loop detection (streaming only)
-    if (options.isStreaming && context.onCommandResultLoop) {
+    // Check for command result loop detection (streaming only, skip fork agents)
+    if (options.isStreaming && !isForkAgent && context.onCommandResultLoop) {
       // Extract exit code and output from tool result
       const exitCode = this.extractExitCode(toolUseResult, content);
       const loopRequest = context.onCommandResultLoop(toolName, toolInput, {
@@ -657,6 +662,8 @@ export class UnifiedMessageProcessor {
             },
             localContext,
             options,
+            undefined,
+            !!message.parent_tool_use_id,
           );
         } else if (part.text && !message.parent_tool_use_id) {
           // Text content in parts — skip if parent_tool_use_id is set
@@ -681,6 +688,7 @@ export class UnifiedMessageProcessor {
             localContext,
             options,
             toolUseResult,
+            !!message.parent_tool_use_id,
           );
         } else if (contentItem.type === "text" && !message.parent_tool_use_id) {
           // Regular text content — skip if parent_tool_use_id is set
@@ -721,7 +729,9 @@ export class UnifiedMessageProcessor {
     const msg = message as unknown as {
       message?: { parts?: unknown[] };
       toolCallResult?: { callId?: string; status?: string; resultDisplay?: string };
+      parent_tool_use_id?: string | null;
     };
+    const isForkAgent = !!msg.parent_tool_use_id;
 
     // Extract tool_use_id and content from functionResponse in parts
     const messageParts = msg.message?.parts;
@@ -761,6 +771,7 @@ export class UnifiedMessageProcessor {
             context,
             options,
             msg.toolCallResult,
+            isForkAgent,
           );
         }
       }


### PR DESCRIPTION
## Summary

Fixes #140 — loop detection false positive when parallel fork agents execute the same command.

## Problem

When multiple fork agents (subagents) run in parallel and independently execute the same command (e.g., `git diff main...HEAD` during a code review), the WebUI's loop detector counts these cross-agent calls as repeated identical commands, triggering a false auto-abort that kills the entire session tree.

## Fix

SDK messages from fork agents carry a non-null `parent_tool_use_id`. This PR uses that field to skip loop detection for fork agent messages in both the frontend and backend:

### Frontend (`UnifiedMessageProcessor.ts`)
- Added `isForkAgent` parameter to `processToolResult()`
- Auto-rejection loop detection and command result loop detection are both skipped when `isForkAgent` is true
- `processUserMessage()` and `processToolResultMessage()` pass `!!message.parent_tool_use_id` as the agent flag

### Backend (`chat.ts`)
- Backend loop detection (`checkLoop`) is skipped when the SDK message has `parent_tool_use_id` set

## Rationale

Fork agents already have their own CLI-side `LoopDetectionService` (in `qwen-code-cli/packages/core/src/services/loopDetectionService.ts`). The WebUI's frontend/backend loop detection exists as a failsafe for the **main session only** — it should not interfere with fork agent workflows.

## Test plan

- [x] 3 new test cases covering fork agent messages for both Qwen SDK and Claude SDK formats
- [x] All 22 existing tests pass (1 pre-existing failure unrelated to this change)
- [x] `make build` passes