### PR TITLE
fix: prevent stream stall detector false positives (#125)

### DIFF
--- a/backend/handlers/chat.ts
+++ b/backend/handlers/chat.ts
@@ -21,8 +21,8 @@ const activeSessions = new Map<string, string>();
 const SESSION_TIMEOUT_MS = 24 * 60 * 60 * 1_000;
 
 /**
- * Keepalive heartbeat interval. Frontend stall detector triggers after 60s
- * of silence, so 4 missed heartbeats (4 × 15s) = stall detected.
+ * Keepalive heartbeat interval. Frontend stall detector triggers after 120s
+ * of silence, so 8 missed heartbeats (8 × 15s) = stall detected.
  */
 const KEEPALIVE_INTERVAL_MS = 15_000;
 
@@ -485,10 +485,29 @@ export async function handleChatRequest(
       };
 
       // Send keepalive heartbeat to prevent browser timeout (ERR_INCOMPLETE_CHUNKED_ENCODING)
-      // and stall detector false positives. Using a JSON heartbeat instead of bare \n
-      // because structured NDJSON is more likely to be flushed as a complete chunk.
+      // and stall detector false positives.
+      //
+      // CRITICAL: Write directly to the ServerResponse (`outgoing`) instead of
+      // controller.enqueue(). The @hono/node-server stream consumer reads from
+      // the ReadableStream asynchronously via reader.read() → writable.write().
+      // When the Node.js event loop is busy with SDK processing, the consumer's
+      // reader.read() promise may not resolve promptly, causing enqueued heartbeats
+      // to sit in the stream's internal queue unread. Direct ServerResponse.write()
+      // bypasses this buffering and hits the TCP socket immediately (setNoDelay is
+      // already enabled). Node.js ServerResponse transparently applies chunked
+      // encoding framing to each write(), so this is safe alongside the stream
+      // consumer's writes — they never overlap because JS is single-threaded.
       keepaliveId = setInterval(() => {
-        try { controller.enqueue(encoder.encode('{"type":"heartbeat"}\n')); } catch { clearInterval(keepaliveId); }
+        try {
+          const heartbeat = encoder.encode('{"type":"heartbeat"}\n');
+          if (outgoing && !outgoing.writableEnded && !outgoing.destroyed) {
+            outgoing.write(heartbeat);
+            logger.chat.debug("[KEEPALIVE] Heartbeat sent directly to socket");
+          } else {
+            // Fallback: outgoing not available (e.g. tests) — use stream enqueue
+            controller.enqueue(heartbeat);
+          }
+        } catch { clearInterval(keepaliveId); }
       }, KEEPALIVE_INTERVAL_MS);
 
       try {

--- a/frontend/src/components/ChatPage.tsx
+++ b/frontend/src/components/ChatPage.tsx
@@ -609,8 +609,8 @@ export function ChatPage() {
       let receivedResult = false;
       let reader: ReadableStreamDefaultReader<Uint8Array> | null = null;
 
-      // Stream stall detection: abort fetch if no data received for 60s.
-      // Backend sends keepalive \n every 15s, so 60s = 4 missed keepalives.
+      // Stream stall detection: abort fetch if no data received for 120s.
+      // Backend sends heartbeat every 15s, so 120s = 8 missed heartbeats.
       const fetchAbortController = new AbortController();
       const stallDetector = createStallDetector(fetchAbortController);
 

--- a/frontend/src/hooks/streaming/useStreamParser.ts
+++ b/frontend/src/hooks/streaming/useStreamParser.ts
@@ -311,6 +311,7 @@ export function useStreamParser() {
         } else if (data.type === "heartbeat") {
           // Backend keepalive — resets stall detector via stallDetector.onData()
           // in ChatPage.tsx (called before this function). Nothing to do here.
+          console.debug("[Keepalive] Heartbeat received at", new Date().toISOString());
         }
       } catch (parseError) {
         console.error("Failed to parse stream line:", parseError);

--- a/frontend/src/utils/streamStallDetector.test.ts
+++ b/frontend/src/utils/streamStallDetector.test.ts
@@ -18,35 +18,35 @@ describe("createStallDetector", () => {
   it("aborts after timeout when no data is received", () => {
     const abortController = new AbortController();
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-    createStallDetector(abortController, 60_000);
+    createStallDetector(abortController, 120_000);
 
     expect(abortController.signal.aborted).toBe(false);
 
-    vi.advanceTimersByTime(60_000);
+    vi.advanceTimersByTime(120_000);
 
     expect(abortController.signal.aborted).toBe(true);
     expect(warnSpy).toHaveBeenCalledWith(
-      "[Stream stall] No data for 60s, aborting fetch",
+      "[Stream stall] No data for 120s, aborting fetch",
     );
     warnSpy.mockRestore();
   });
 
   it("resets timer when onData is called", () => {
     const abortController = new AbortController();
-    const detector = createStallDetector(abortController, 60_000);
+    const detector = createStallDetector(abortController, 120_000);
 
-    // Advance 30s, then receive data
-    vi.advanceTimersByTime(30_000);
+    // Advance 60s, then receive data
+    vi.advanceTimersByTime(60_000);
     expect(abortController.signal.aborted).toBe(false);
 
     detector.onData();
 
-    // Advance another 30s (60s since data, but only 30s since last reset)
-    vi.advanceTimersByTime(30_000);
+    // Advance another 60s (120s since data, but only 60s since last reset)
+    vi.advanceTimersByTime(60_000);
     expect(abortController.signal.aborted).toBe(false);
 
-    // Advance another 30s = 60s since last onData
-    vi.advanceTimersByTime(30_000);
+    // Advance another 60s = 120s since last onData
+    vi.advanceTimersByTime(60_000);
     expect(abortController.signal.aborted).toBe(true);
 
     detector.dispose();
@@ -54,12 +54,12 @@ describe("createStallDetector", () => {
 
   it("does not abort when tab is hidden", () => {
     const abortController = new AbortController();
-    const detector = createStallDetector(abortController, 60_000);
+    const detector = createStallDetector(abortController, 120_000);
 
     // Tab goes hidden before timeout
-    vi.advanceTimersByTime(50_000);
+    vi.advanceTimersByTime(100_000);
     Object.defineProperty(document, "hidden", { value: true, writable: true, configurable: true });
-    vi.advanceTimersByTime(10_000); // 60s total — timer fires while hidden
+    vi.advanceTimersByTime(20_000); // 120s total — timer fires while hidden
 
     expect(abortController.signal.aborted).toBe(false);
 
@@ -67,8 +67,8 @@ describe("createStallDetector", () => {
     Object.defineProperty(document, "hidden", { value: false, writable: true, configurable: true });
     document.dispatchEvent(new Event("visibilitychange"));
 
-    // Should abort 60s after visibility change (because lastDataTime is old)
-    vi.advanceTimersByTime(60_000);
+    // Should abort 120s after visibility change (because lastDataTime is old)
+    vi.advanceTimersByTime(120_000);
     expect(abortController.signal.aborted).toBe(true);
 
     detector.dispose();
@@ -76,7 +76,7 @@ describe("createStallDetector", () => {
 
   it("cleans up timers and listeners on dispose", () => {
     const abortController = new AbortController();
-    const detector = createStallDetector(abortController, 60_000);
+    const detector = createStallDetector(abortController, 120_000);
     const removeSpy = vi.spyOn(document, "removeEventListener");
 
     detector.dispose();
@@ -84,18 +84,34 @@ describe("createStallDetector", () => {
     expect(removeSpy).toHaveBeenCalledWith("visibilitychange", expect.any(Function));
 
     // Should NOT abort after timeout if already disposed
-    vi.advanceTimersByTime(120_000);
+    vi.advanceTimersByTime(240_000);
     expect(abortController.signal.aborted).toBe(false);
 
     removeSpy.mockRestore();
   });
 
+  it("uses 120s default timeout", () => {
+    const abortController = new AbortController();
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    createStallDetector(abortController); // no timeoutMs arg → default
+
+    vi.advanceTimersByTime(119_999);
+    expect(abortController.signal.aborted).toBe(false);
+
+    vi.advanceTimersByTime(1);
+    expect(abortController.signal.aborted).toBe(true);
+    expect(warnSpy).toHaveBeenCalledWith(
+      "[Stream stall] No data for 120s, aborting fetch",
+    );
+    warnSpy.mockRestore();
+  });
+
   it("does not abort if data keeps arriving within timeout", () => {
     const abortController = new AbortController();
-    const detector = createStallDetector(abortController, 60_000);
+    const detector = createStallDetector(abortController, 120_000);
 
-    // Simulate keepalive every 15s for 3 minutes
-    for (let i = 0; i < 12; i++) {
+    // Simulate keepalive every 15s for 5 minutes
+    for (let i = 0; i < 20; i++) {
       vi.advanceTimersByTime(14_000);
       detector.onData();
     }

--- a/frontend/src/utils/streamStallDetector.ts
+++ b/frontend/src/utils/streamStallDetector.ts
@@ -13,7 +13,7 @@ export interface StallDetector {
 
 export function createStallDetector(
   abortController: AbortController,
-  timeoutMs: number = 60_000,
+  timeoutMs: number = 120_000,
 ): StallDetector {
   let stallTimerId: ReturnType<typeof setTimeout> | null = null;
   let lastDataTime = Date.now();


### PR DESCRIPTION
## Problem

Issue #125: Frontend incorrectly shows "连接已断开" after ~60s of silence even though the backend AI is actively working and sending keepalive heartbeats.

## Root Cause

The keepalive heartbeats were written via `controller.enqueue()` into the `ReadableStream`. The `@hono/node-server` stream consumer reads from this stream via `reader.read()` → `writable.write()`. When the Node.js event loop was busy with SDK processing, the consumer's `reader.read()` promise didn't resolve promptly, causing enqueued heartbeats to sit in the stream's internal queue **unread** — they never reached the TCP socket, so the browser never received them.

## Three-Layer Fix

### 1. Backend: Direct socket write for heartbeats
Write heartbeats directly to `ServerResponse.write()` (bypassing the `ReadableStream` buffering entirely). This ensures heartbeats always reach the TCP socket immediately, regardless of stream consumer state. Falls back to `controller.enqueue()` when `outgoing` is unavailable (e.g. tests).

### 2. Frontend: Increase stall timeout to 120s
Increased from 60s to 120s (8 missed heartbeats × 15s = stall detected). This provides much more tolerance for intermittent network conditions, tab throttling, and system sleep/wake edge cases.

### 3. Frontend: Heartbeat debug logging
Added `console.debug` logging when heartbeats are received, making it easy to diagnose future connectivity issues via browser DevTools.

## Files Changed
- `backend/handlers/chat.ts` — Direct socket heartbeat write
- `frontend/src/utils/streamStallDetector.ts` — Default timeout 60s → 120s
- `frontend/src/components/ChatPage.tsx` — Updated comments
- `frontend/src/hooks/streaming/useStreamParser.ts` — Heartbeat debug logging
- `frontend/src/utils/streamStallDetector.test.ts` — Updated tests for 120s timeout

Closes #125
