### PR TITLE
fix: improve VS Code proxy headers and add auth token to editor URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,10 @@ backend/dist/
 *.swp
 *.swo
 
+# Claude Code
+.claude/
+.agents/
+
 # OS files
 .DS_Store
 Thumbs.db

--- a/backend/app.ts
+++ b/backend/app.ts
@@ -18,10 +18,16 @@ import { handleHistoriesRequest } from "./handlers/histories.ts";
 import { handleConversationRequest } from "./handlers/conversations.ts";
 import { handleChatRequest } from "./handlers/chat.ts";
 import { handleAbortRequest } from "./handlers/abort.ts";
-import { handlePermissionRespond, type PendingPermission } from "./handlers/permission.ts";
+import {
+  handlePermissionRespond,
+  type PendingPermission,
+} from "./handlers/permission.ts";
 import { handleVersionRequest } from "./handlers/version.ts";
 import { handleModelsRequest } from "./handlers/models.ts";
-import { handleQuotaStatusRequest, quotaCheckMiddleware } from "./handlers/quota.ts";
+import {
+  handleQuotaStatusRequest,
+  quotaCheckMiddleware,
+} from "./handlers/quota.ts";
 import { logger } from "./utils/logger.ts";
 import { readBinaryFile } from "./utils/fs.ts";
 import { handleDeleteProjectRequest } from "./handlers/projects.ts";
@@ -52,7 +58,15 @@ export interface AppConfig {
 export function createApp(
   runtime: Runtime,
   config: AppConfig,
-): { app: Hono<ConfigContext>; shutdown: () => void; vscodeUpgradeHandler: (req: import("node:http").IncomingMessage, socket: import("node:stream").Duplex, head: Buffer) => void } {
+): {
+  app: Hono<ConfigContext>;
+  shutdown: () => void;
+  vscodeUpgradeHandler: (
+    req: import("node:http").IncomingMessage,
+    socket: import("node:stream").Duplex,
+    head: Buffer,
+  ) => void;
+} {
   const app = new Hono<ConfigContext>();
 
   // Store AbortControllers for each request (shared with chat handler)
@@ -110,7 +124,9 @@ export function createApp(
   app.get("/api/version", () => handleVersionRequest());
   app.get("/api/models", (c) => handleModelsRequest(c));
   app.get("/api/projects", (c) => handleProjectsRequest(c));
-  app.delete("/api/projects/:encodedProjectName", (c) => handleDeleteProjectRequest(c));
+  app.delete("/api/projects/:encodedProjectName", (c) =>
+    handleDeleteProjectRequest(c),
+  );
   app.get("/api/quota/status", (c) => handleQuotaStatusRequest(c));
 
   // Git file change tracking APIs
@@ -140,7 +156,8 @@ export function createApp(
   );
 
   app.post("/api/chat", quotaCheckMiddleware, (c) =>
-    handleChatRequest(c, requestAbortControllers, pendingPermissions));
+    handleChatRequest(c, requestAbortControllers, pendingPermissions),
+  );
 
   // VS Code reverse proxy — fetch for HTTP, http-proxy for WebSocket (via upgrade handler)
   app.all("/vscode/*", async (c) => {
@@ -172,6 +189,9 @@ export function createApp(
       const response = await fetch(fullUrl, { method, headers, body });
 
       const responseHeaders = new Headers(response.headers);
+      responseHeaders.delete("content-encoding");
+      responseHeaders.delete("content-length");
+      responseHeaders.delete("transfer-encoding");
       const contentType = response.headers.get("content-type") || "";
       if (contentType.includes("text/html")) {
         responseHeaders.delete("X-Frame-Options");

--- a/backend/scripts/build-bundle.js
+++ b/backend/scripts/build-bundle.js
@@ -25,6 +25,7 @@ await build({
     "@hono/node-server",
     "hono",
     "commander",
+    "http-proxy",
   ],
   sourcemap: true,
 });

--- a/frontend/src/components/file-changes/FileChangesPanel.tsx
+++ b/frontend/src/components/file-changes/FileChangesPanel.tsx
@@ -25,9 +25,9 @@ export function FileChangesPanel({
     if (showVSCode) {
       await vscode.stop();
       setShowVSCode(false);
-    } else {
+    } else if (workingDirectory) {
       setShowVSCode(true);
-      await vscode.start(workingDirectory || "");
+      await vscode.start(workingDirectory);
     }
   }, [showVSCode, workingDirectory, vscode]);
 

--- a/frontend/src/components/file-changes/FileChangesPanel.tsx
+++ b/frontend/src/components/file-changes/FileChangesPanel.tsx
@@ -25,9 +25,9 @@ export function FileChangesPanel({
     if (showVSCode) {
       await vscode.stop();
       setShowVSCode(false);
-    } else if (workingDirectory) {
+    } else {
       setShowVSCode(true);
-      await vscode.start(workingDirectory);
+      await vscode.start(workingDirectory || "");
     }
   }, [showVSCode, workingDirectory, vscode]);
 

--- a/frontend/src/components/file-changes/VSCodeEditor.tsx
+++ b/frontend/src/components/file-changes/VSCodeEditor.tsx
@@ -20,9 +20,7 @@ export function VSCodeEditor({
     return (
       <div className="flex-1 flex items-center justify-center p-4">
         <div className="text-center max-w-sm">
-          <p className="text-sm text-red-500 dark:text-red-400 mb-2">
-            {error}
-          </p>
+          <p className="text-sm text-red-500 dark:text-red-400 mb-2">{error}</p>
           {error.includes("not installed") && (
             <p className="text-xs text-slate-500 dark:text-slate-400 font-mono bg-slate-100 dark:bg-slate-800 rounded p-2 mt-2">
               curl -fsSL https://code-server.dev/install.sh | sh
@@ -48,7 +46,10 @@ export function VSCodeEditor({
             {t("fileChanges.startingVSCode")}
           </p>
           <p className="text-xs text-slate-400 mt-1">
-            {t("fileChanges.startingVSCodeHint", "Starting code-server (~1s)...")}
+            {t(
+              "fileChanges.startingVSCodeHint",
+              "Starting code-server (~1s)...",
+            )}
           </p>
         </div>
       </div>

--- a/frontend/src/hooks/useVSCode.ts
+++ b/frontend/src/hooks/useVSCode.ts
@@ -79,7 +79,7 @@ export function useVSCode(): VSCodeState {
       const response = await fetch(getVSCodeStatusUrl());
       const data = await response.json();
       setIsRunning(data.running);
-      setUrl(data.url || null);
+      setUrl(data.url ? addTokenToUrl(data.url) : null);
     } catch {
       // Ignore
     }

--- a/frontend/src/hooks/useVSCode.ts
+++ b/frontend/src/hooks/useVSCode.ts
@@ -1,5 +1,10 @@
 import { useState, useCallback } from "react";
-import { getVSCodeStartUrl, getVSCodeStopUrl, getVSCodeStatusUrl } from "../config/api";
+import {
+  getVSCodeStartUrl,
+  getVSCodeStopUrl,
+  getVSCodeStatusUrl,
+} from "../config/api";
+import { addTokenToUrl } from "../utils/token";
 
 interface VSCodeState {
   isRunning: boolean;
@@ -21,6 +26,12 @@ export function useVSCode(): VSCodeState {
     setIsLoading(true);
     setError(null);
 
+    if (workingDirectory.trim() === "") {
+      setError("Select a project first to open VS Code");
+      setIsLoading(false);
+      return;
+    }
+
     try {
       const controller = new AbortController();
       const timeout = setTimeout(() => controller.abort(), 35_000);
@@ -38,12 +49,14 @@ export function useVSCode(): VSCodeState {
       }
 
       setIsRunning(true);
-      setUrl(data.url);
+      setUrl(addTokenToUrl(data.url));
     } catch (err) {
       if (err instanceof DOMException && err.name === "AbortError") {
         setError("VS Code startup timed out");
       } else {
-        setError(err instanceof Error ? err.message : "Failed to start VS Code");
+        setError(
+          err instanceof Error ? err.message : "Failed to start VS Code",
+        );
       }
     } finally {
       setIsLoading(false);


### PR DESCRIPTION
## Summary
- Strip upstream `content-encoding`, `content-length`, `transfer-encoding` headers in VS Code reverse proxy to avoid encoding conflicts when proxying responses
- Externalize `http-proxy` from esbuild bundle (was being bundled incorrectly)
- Add auth token to VS Code editor URL via `addTokenToUrl` on startup
- Guard against empty `workingDirectory` before starting VS Code, showing an error message instead
- Add `.claude/` and `.agents/` to `.gitignore`

## Test plan
- [ ] Start VS Code editor from the file changes panel — confirm it loads correctly
- [ ] Verify auth token is appended to the VS Code URL
- [ ] Try opening VS Code without selecting a project — confirm error message appears
- [ ] Verify proxy responses no longer have duplicate/conflicting encoding headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)