### PR TITLE
fix: resolve VS Code WebSocket 1006 error

### DIFF
--- a/backend/handlers/vscode.ts
+++ b/backend/handlers/vscode.ts
@@ -290,13 +290,19 @@ vscodeProxy.on("error", (err, _req, _res) => {
 export function createVSCodeUpgradeHandler() {
   return (req: IncomingMessage, socket: Duplex, head: Buffer) => {
     const port = getVSCodePort();
-    if (!port || !req.url?.startsWith("/vscode")) {
+    if (!port) {
       socket.destroy();
       return;
     }
 
-    const targetPath = req.url.replace(/^\/vscode\/?/, "/") || "/";
-    req.url = targetPath;
+    // code-server uses paths like /stable-{hash}/ws for WebSocket.
+    // Only proxy known code-server paths to avoid routing future
+    // non-code-server WebSocket upgrades to the wrong target.
+    const urlPath = req.url?.split("?")[0] ?? "";
+    if (!urlPath.includes("/ws")) {
+      socket.destroy();
+      return;
+    }
 
     vscodeProxy.ws(req, socket, head, {
       target: `http://localhost:${port}`,


### PR DESCRIPTION
## Summary
- Remove `/vscode` path prefix check from WebSocket upgrade handler to fix code-server WebSocket connection failures
- code-server doesn't support `--base-path`, so its WebSocket paths don't include the `/vscode` prefix
- The handler was calling `socket.destroy()` on unmatched paths, causing the "WebSocket close with status code 1006" error

## Test plan
- [ ] Start the app, open a project, click the VS Code button in the file changes panel
- [ ] Verify code-server loads without the "An unexpected error occurred" reload prompt
- [ ] Verify WebSocket connections are established (check browser DevTools Network tab)
- [ ] Verify stopping VS Code still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)