### PR TITLE
fix: rewrite Origin header for code-server proxy

### DIFF
--- a/backend/app.ts
+++ b/backend/app.ts
@@ -181,7 +181,9 @@ export function createApp(
         }
       });
       headers.set("host", `localhost:${port}`);
-      headers.set("origin", `http://localhost:${port}`);
+      if (headers.has("origin")) {
+        headers.set("origin", `http://localhost:${port}`);
+      }
 
       const method = c.req.method;
       let body: BodyInit | null = null;

--- a/backend/app.ts
+++ b/backend/app.ts
@@ -175,10 +175,13 @@ export function createApp(
     try {
       const headers = new Headers();
       c.req.raw.headers.forEach((value, key) => {
-        if (key.toLowerCase() !== "host") {
+        const lower = key.toLowerCase();
+        if (lower !== "host") {
           headers.set(key, value);
         }
       });
+      headers.set("host", `localhost:${port}`);
+      headers.set("origin", `http://localhost:${port}`);
 
       const method = c.req.method;
       let body: BodyInit | null = null;

--- a/backend/handlers/vscode.ts
+++ b/backend/handlers/vscode.ts
@@ -290,12 +290,12 @@ vscodeProxy.on("error", (err, _req, _res) => {
 export function createVSCodeUpgradeHandler() {
   return (req: IncomingMessage, socket: Duplex, head: Buffer) => {
     const port = getVSCodePort();
-    if (!port) {
+    if (!port || !req.url?.startsWith("/vscode")) {
       socket.destroy();
       return;
     }
 
-    req.url = req.url?.replace(/^\/vscode\/?/, "/") || "/";
+    req.url = req.url.replace(/^\/vscode\/?/, "/") || "/";
 
     vscodeProxy.ws(req, socket, head, {
       target: `http://localhost:${port}`,

--- a/backend/handlers/vscode.ts
+++ b/backend/handlers/vscode.ts
@@ -295,15 +295,14 @@ export function createVSCodeUpgradeHandler() {
       return;
     }
 
-    // code-server WebSocket upgrades come from the iframe at /vscode/,
-    // with paths like /vscode/stable-{hash}?reconnectionToken=...
-    // Proxy all upgrades to code-server when it's running.
-    const originalUrl = req.url;
     req.url = req.url?.replace(/^\/vscode\/?/, "/") || "/";
 
     vscodeProxy.ws(req, socket, head, {
       target: `http://localhost:${port}`,
-      headers: { host: `localhost:${port}` },
+      headers: {
+        host: `localhost:${port}`,
+        origin: `http://localhost:${port}`,
+      },
     });
   };
 }

--- a/backend/handlers/vscode.ts
+++ b/backend/handlers/vscode.ts
@@ -295,14 +295,11 @@ export function createVSCodeUpgradeHandler() {
       return;
     }
 
-    // code-server uses paths like /stable-{hash}/ws for WebSocket.
-    // Only proxy known code-server paths to avoid routing future
-    // non-code-server WebSocket upgrades to the wrong target.
-    const urlPath = req.url?.split("?")[0] ?? "";
-    if (!urlPath.includes("/ws")) {
-      socket.destroy();
-      return;
-    }
+    // code-server WebSocket upgrades come from the iframe at /vscode/,
+    // with paths like /vscode/stable-{hash}?reconnectionToken=...
+    // Proxy all upgrades to code-server when it's running.
+    const originalUrl = req.url;
+    req.url = req.url?.replace(/^\/vscode\/?/, "/") || "/";
 
     vscodeProxy.ws(req, socket, head, {
       target: `http://localhost:${port}`,


### PR DESCRIPTION
## Summary
- code-server validates the `Origin` header on both WebSocket upgrade and HTTP requests as CSRF protection
- When the browser sends `Origin: http://localhost:3101` (webui port), code-server rejects it with 403 because it's running on a different random port (e.g. 52307)
- Rewrite both `host` and `origin` headers to match code-server's actual port in the HTTP proxy (`app.ts`) and WebSocket upgrade handler (`vscode.ts`)

## Root cause analysis
The WebSocket 1006 error was caused by code-server's built-in CSRF protection rejecting cross-origin WebSocket upgrade requests. The browser automatically includes an `Origin` header matching the webui's origin (port 3101), which differs from code-server's port (random). This caused code-server to return 403 Forbidden on the WebSocket handshake, resulting in the "WebSocket close with status code 1006" error in VS Code.

## Test plan
- [x] Verified WebSocket upgrade succeeds with `Origin` header via raw TCP test
- [x] Verified VS Code editor loads in browser (Playwright) without WebSocket error
- [x] Verified code-server walkthrough/splash screen renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)