### PR TITLE
Improve file changes panel interactions

### DIFF
--- a/backend/handlers/vscode.ts
+++ b/backend/handlers/vscode.ts
@@ -64,6 +64,46 @@ function isProcessAlive(pid: number): boolean {
   }
 }
 
+function isSameWorkingDirectory(a: string, b: string): boolean {
+  return resolve(a) === resolve(b);
+}
+
+async function stopOwnedVSCodeProcess(
+  processInfo: VSCodeProcess,
+  waitForExit = false,
+) {
+  if (!processInfo.childProcess) return;
+
+  removeLockFile(processInfo.workingDirectory);
+
+  const child = processInfo.childProcess;
+  const pid = processInfo.pid;
+
+  let exitPromise: Promise<void> | null = null;
+  if (waitForExit) {
+    exitPromise = new Promise((resolveExit) => {
+      child.once("exit", () => resolveExit());
+      child.once("close", () => resolveExit());
+    });
+  }
+
+  child.kill("SIGTERM");
+  setTimeout(() => {
+    try {
+      if (isProcessAlive(pid)) {
+        child.kill("SIGKILL");
+      }
+    } catch {}
+  }, 5000);
+
+  if (exitPromise) {
+    await Promise.race([
+      exitPromise,
+      new Promise<void>((resolveTimeout) => setTimeout(resolveTimeout, 2000)),
+    ]);
+  }
+}
+
 async function findCodeServer(
   runtime: AppConfig["runtime"],
 ): Promise<string | null> {
@@ -95,11 +135,25 @@ export async function handleVSCodeStartRequest(c: Context) {
 
   // Check in-memory state first (same backend process, different session)
   if (vscodeProcess && isProcessAlive(vscodeProcess.pid)) {
-    return c.json({
-      port: vscodeProcess.port,
-      url: "/vscode/",
-      alreadyRunning: true,
-    });
+    if (
+      isSameWorkingDirectory(vscodeProcess.workingDirectory, workingDirectory)
+    ) {
+      return c.json({
+        port: vscodeProcess.port,
+        url: "/vscode/",
+        alreadyRunning: true,
+      });
+    }
+
+    logger.app.info(
+      "Restarting VS Code server for requested working directory",
+    );
+    const previousProcess = vscodeProcess;
+    vscodeProcess = null;
+    await stopOwnedVSCodeProcess(previousProcess, true);
+  } else if (vscodeProcess) {
+    removeLockFile(vscodeProcess.workingDirectory);
+    vscodeProcess = null;
   }
 
   // Check lock file for existing instance (multi-user/multi-session across processes)
@@ -222,26 +276,13 @@ export async function handleVSCodeStopRequest(c: Context) {
     return c.json({ success: true, message: "Not running" });
   }
 
-  const child = vscodeProcess.childProcess;
-  const pid = vscodeProcess.pid;
-  const wd = vscodeProcess.workingDirectory;
+  const previousProcess = vscodeProcess;
 
   // Clear state immediately
   vscodeProcess = null;
-  removeLockFile(wd);
 
   // Kill the code-server process
-  if (child) {
-    child.kill("SIGTERM");
-    // Force kill after 5 seconds if still alive
-    setTimeout(() => {
-      try {
-        if (isProcessAlive(pid)) {
-          child.kill("SIGKILL");
-        }
-      } catch {}
-    }, 5000);
-  }
+  void stopOwnedVSCodeProcess(previousProcess);
 
   logger.app.info("VS Code server stopped");
   return c.json({ success: true });

--- a/frontend/src/components/ChatPage.tsx
+++ b/frontend/src/components/ChatPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useCallback, useState, useMemo, useRef } from "react";
 import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
-import { ChevronLeftIcon, ServerIcon } from "@heroicons/react/24/outline";
+import { ChevronLeftIcon, DocumentTextIcon, ServerIcon } from "@heroicons/react/24/outline";
 import { useTranslation } from "react-i18next";
 import type {
   ChatRequest,
@@ -98,6 +98,7 @@ export function ChatPage() {
   const [showFileChanges, setShowFileChanges] = useState(
     urlShowFileChangesPanel !== "false"
   );
+  const [isVSCodePanelOpen, setIsVSCodePanelOpen] = useState(false);
   const [selectedDiffFile, setSelectedDiffFile] = useState<FileChange | null>(null);
 
   // Remote workspace parameters
@@ -154,7 +155,7 @@ export function ChatPage() {
   // Extract and normalize working directory from URL
   // Priority: 1) URL parameter encodedProjectName, 2) URL path
   const urlEncodedProjectName = searchParams.get("encodedProjectName");
-  
+
   const workingDirectory = (() => {
     // If encodedProjectName is provided via URL parameter, resolve the actual path
     if (urlEncodedProjectName) {
@@ -223,7 +224,7 @@ export function ChatPage() {
     if (urlEncodedProjectName) {
       return urlEncodedProjectName;
     }
-    
+
     // Otherwise derive from workingDirectory
     if (!workingDirectory || !projects.length) {
       return null;
@@ -1292,6 +1293,21 @@ export function ChatPage() {
     setIsSettingsOpen(true);
   }, []);
 
+  const setFileChangesPanelVisible = useCallback((visible: boolean) => {
+    setShowFileChanges(visible);
+    if (!visible) {
+      setIsVSCodePanelOpen(false);
+    }
+
+    const nextSearchParams = new URLSearchParams(searchParams);
+    nextSearchParams.set("showFileChangesPanel", visible ? "true" : "false");
+    navigate({ search: nextSearchParams.toString() }, { replace: true });
+  }, [navigate, searchParams]);
+
+  const handleToggleFileChangesPanel = useCallback(() => {
+    setFileChangesPanelVisible(!showFileChanges);
+  }, [setFileChangesPanelVisible, showFileChanges]);
+
   const handleSettingsClose = useCallback(() => {
     setIsSettingsOpen(false);
   }, []);
@@ -1536,6 +1552,34 @@ export function ChatPage() {
               />
             )}
             {!isHistoryView && <HistoryButton onClick={handleHistoryClick} />}
+            {!isHistoryView && (
+              <button
+                onClick={handleToggleFileChangesPanel}
+                className={`p-2 rounded-lg border transition-all duration-200 backdrop-blur-sm shadow-sm hover:shadow-md ${
+                  showFileChanges
+                    ? "bg-blue-600 dark:bg-blue-600 border-blue-700 dark:border-blue-500 scale-105"
+                    : "bg-white/80 dark:bg-slate-800/80 border-slate-200 dark:border-slate-700 hover:bg-white dark:hover:bg-slate-800"
+                }`}
+                aria-label={
+                  showFileChanges
+                    ? t("fileChanges.hidePanel")
+                    : t("fileChanges.showPanel")
+                }
+                title={
+                  showFileChanges
+                    ? t("fileChanges.hidePanel")
+                    : t("fileChanges.showPanel")
+                }
+              >
+                <DocumentTextIcon
+                  className={`w-4 h-4 ${
+                    showFileChanges
+                      ? "text-white"
+                      : "text-slate-600 dark:text-slate-400"
+                  }`}
+                />
+              </button>
+            )}
             <SettingsButton onClick={handleSettingsClick} />
           </div>
         </div>
@@ -1546,7 +1590,7 @@ export function ChatPage() {
             orientation="horizontal"
             autoSave="chat-file-changes-layout"
           >
-            <Panel defaultSize={showFileChanges ? "70%" : "100%"} minSize="30%">
+            <Panel defaultSize={showFileChanges ? "70%" : "100%"} minSize={isVSCodePanelOpen ? "20%" : "30%"}>
               <div className="h-full flex flex-col min-w-0">
         {isHistoryView ? (
           <HistoryView
@@ -1707,11 +1751,12 @@ export function ChatPage() {
             {showFileChanges && (
               <>
                 <PanelResizeHandle className="w-1 bg-slate-200 dark:bg-slate-700 hover:bg-blue-400 dark:hover:bg-blue-500 cursor-col-resize transition-colors active:bg-blue-500" />
-                <Panel defaultSize="30%" minSize="20%" maxSize="50%">
+                <Panel defaultSize="30%" minSize="20%" maxSize={isVSCodePanelOpen ? "80%" : "65%"}>
                   <FileChangesPanel
                     workingDirectory={workingDirectory}
                     onOpenDiff={(file) => setSelectedDiffFile(file)}
-                    onClose={() => setShowFileChanges(false)}
+                    onClose={() => setFileChangesPanelVisible(false)}
+                    onVSCodeOpenChange={setIsVSCodePanelOpen}
                   />
                 </Panel>
               </>

--- a/frontend/src/components/file-changes/FileChangesList.tsx
+++ b/frontend/src/components/file-changes/FileChangesList.tsx
@@ -1,8 +1,5 @@
 import { useTranslation } from "react-i18next";
-import {
-  DocumentIcon,
-  CodeBracketIcon,
-} from "@heroicons/react/24/outline";
+import { DocumentIcon, CodeBracketIcon } from "@heroicons/react/24/outline";
 import type { FileChange } from "../../types/fileChanges";
 
 interface FileChangesListProps {
@@ -13,8 +10,27 @@ interface FileChangesListProps {
 }
 
 const CODE_EXTENSIONS = new Set([
-  "ts", "tsx", "js", "jsx", "py", "rs", "go", "java", "c", "cpp", "h",
-  "html", "css", "scss", "json", "yaml", "yml", "toml", "md", "sh", "bash",
+  "ts",
+  "tsx",
+  "js",
+  "jsx",
+  "py",
+  "rs",
+  "go",
+  "java",
+  "c",
+  "cpp",
+  "h",
+  "html",
+  "css",
+  "scss",
+  "json",
+  "yaml",
+  "yml",
+  "toml",
+  "md",
+  "sh",
+  "bash",
 ]);
 
 function isCodeFile(path: string): boolean {
@@ -24,9 +40,13 @@ function isCodeFile(path: string): boolean {
 
 function FileIcon({ path }: { path: string }) {
   if (isCodeFile(path)) {
-    return <CodeBracketIcon className="w-4 h-4 text-slate-400 dark:text-slate-500 flex-shrink-0" />;
+    return (
+      <CodeBracketIcon className="w-4 h-4 text-slate-400 dark:text-slate-500 flex-shrink-0" />
+    );
   }
-  return <DocumentIcon className="w-4 h-4 text-slate-400 dark:text-slate-500 flex-shrink-0" />;
+  return (
+    <DocumentIcon className="w-4 h-4 text-slate-400 dark:text-slate-500 flex-shrink-0" />
+  );
 }
 
 function StatusBadge({ status }: { status: FileChange["status"] }) {
@@ -34,7 +54,8 @@ function StatusBadge({ status }: { status: FileChange["status"] }) {
   const styles = {
     modified:
       "bg-yellow-100 dark:bg-yellow-900/30 text-yellow-700 dark:text-yellow-400",
-    added: "bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-400",
+    added:
+      "bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-400",
     deleted: "bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-400",
   };
   const labels = {
@@ -113,12 +134,12 @@ export function FileChangesList({
         <button
           key={file.path}
           onClick={() => onFileClick(file)}
-          className="w-full flex items-center gap-2 px-3 py-1.5 hover:bg-slate-50 dark:hover:bg-slate-800/50 border-b border-slate-100 dark:border-slate-800 text-left group transition-colors duration-150"
+          className="w-full flex items-center gap-2 px-3 py-1.5 hover:bg-slate-100 dark:hover:bg-slate-700/60 border-b border-slate-100 dark:border-slate-800 text-left transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-inset"
           title={file.path}
         >
           <FileIcon path={file.path} />
           <StatusBadge status={file.status} />
-          <span className="flex-1 text-xs text-slate-600 dark:text-slate-300 truncate font-mono group-hover:text-slate-800 dark:group-hover:text-slate-100">
+          <span className="flex-1 text-xs text-slate-600 dark:text-slate-300 truncate font-mono">
             {truncatePath(file.path)}
           </span>
           <span className="text-xs font-mono flex-shrink-0 space-x-1">

--- a/frontend/src/components/file-changes/FileChangesPanel.tsx
+++ b/frontend/src/components/file-changes/FileChangesPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
 import { FileChangesHeader } from "./FileChangesHeader";
 import { FileChangesList } from "./FileChangesList";
 import { VSCodeEditor } from "./VSCodeEditor";
@@ -10,12 +10,14 @@ interface FileChangesPanelProps {
   workingDirectory: string | undefined;
   onOpenDiff: (file: FileChange) => void;
   onClose: () => void;
+  onVSCodeOpenChange?: (isOpen: boolean) => void;
 }
 
 export function FileChangesPanel({
   workingDirectory,
   onOpenDiff,
   onClose,
+  onVSCodeOpenChange,
 }: FileChangesPanelProps) {
   const { files, isLoading, error, refresh } = useFileChanges(workingDirectory);
   const vscode = useVSCode();
@@ -35,6 +37,11 @@ export function FileChangesPanel({
     await vscode.stop();
     setShowVSCode(false);
   }, [vscode]);
+
+  useEffect(() => {
+    onVSCodeOpenChange?.(showVSCode);
+    return () => onVSCodeOpenChange?.(false);
+  }, [onVSCodeOpenChange, showVSCode]);
 
   return (
     <div className="h-full flex flex-col bg-white dark:bg-slate-900 border-l border-slate-200 dark:border-slate-700">

--- a/frontend/src/components/file-changes/FileDiffModal.tsx
+++ b/frontend/src/components/file-changes/FileDiffModal.tsx
@@ -1,7 +1,11 @@
 import { useState, useEffect, useCallback } from "react";
 import { Dialog, Transition } from "@headlessui/react";
 import { Fragment } from "react";
-import { XMarkIcon } from "@heroicons/react/24/outline";
+import {
+  ArrowsPointingInIcon,
+  ArrowsPointingOutIcon,
+  XMarkIcon,
+} from "@heroicons/react/24/outline";
 import { useTranslation } from "react-i18next";
 import ReactDiffViewer, { DiffMethod } from "react-diff-viewer-continued";
 import type { FileChange, GitDiffResponse } from "../../types/fileChanges";
@@ -31,6 +35,7 @@ export function FileDiffModal({
   const [error, setError] = useState<string | null>(null);
   const [viewMode, setViewMode] = useState<ViewMode>("diff");
   const [diffView, setDiffView] = useState<DiffView>("unified");
+  const [isFullscreen, setIsFullscreen] = useState(false);
 
   const fetchDiff = useCallback(async () => {
     if (!file || !workingDirectory) return;
@@ -61,6 +66,7 @@ export function FileDiffModal({
       setDiffData(null);
       setError(null);
       setViewMode("diff");
+      setIsFullscreen(false);
     }
   }, [isOpen, file, fetchDiff]);
 
@@ -84,7 +90,13 @@ export function FileDiffModal({
         </Transition.Child>
 
         <div className="fixed inset-0 overflow-y-auto">
-          <div className="flex min-h-full items-center justify-center p-4">
+          <div
+            className={
+              isFullscreen
+                ? "flex min-h-full items-stretch justify-stretch p-2 sm:p-4"
+                : "flex min-h-full items-center justify-center p-4"
+            }
+          >
             <Transition.Child
               as={Fragment}
               enter="ease-out duration-200"
@@ -95,8 +107,12 @@ export function FileDiffModal({
               leaveTo="opacity-0 scale-95"
             >
               <Dialog.Panel
-                className="w-full max-w-5xl transform overflow-hidden rounded-xl bg-white dark:bg-slate-800 shadow-xl transition-all flex flex-col"
-                style={{ maxHeight: "85vh" }}
+                className={`w-full transform overflow-hidden bg-white dark:bg-slate-800 shadow-xl transition-all flex flex-col ${
+                  isFullscreen
+                    ? "max-w-none h-[calc(100vh-1rem)] sm:h-[calc(100vh-2rem)] rounded-lg"
+                    : "max-w-5xl rounded-xl"
+                }`}
+                style={{ maxHeight: isFullscreen ? "none" : "85vh" }}
               >
                 {/* Header */}
                 <div className="flex items-center justify-between px-4 py-3 border-b border-slate-200 dark:border-slate-700 flex-shrink-0">
@@ -117,8 +133,7 @@ export function FileDiffModal({
                         ? "+"
                         : file.status === "deleted"
                           ? "-"
-                          : "~"}
-                      {" "}
+                          : "~"}{" "}
                       {file.status === "added"
                         ? t("fileChanges.status.added")
                         : file.status === "deleted"
@@ -138,12 +153,30 @@ export function FileDiffModal({
                       )}
                     </span>
                   </div>
-                  <button
-                    onClick={onClose}
-                    className="p-1 rounded-lg hover:bg-slate-100 dark:hover:bg-slate-700 text-slate-400 hover:text-slate-600 dark:hover:text-slate-300"
-                  >
-                    <XMarkIcon className="w-5 h-5" />
-                  </button>
+                  <div className="flex items-center gap-1">
+                    <button
+                      onClick={() => setIsFullscreen((value) => !value)}
+                      className="p-1 rounded-lg hover:bg-slate-100 dark:hover:bg-slate-700 text-slate-400 hover:text-slate-600 dark:hover:text-slate-300"
+                      title={
+                        isFullscreen
+                          ? t("fileChanges.diff.exitFullscreen")
+                          : t("fileChanges.diff.fullscreen")
+                      }
+                    >
+                      {isFullscreen ? (
+                        <ArrowsPointingInIcon className="w-5 h-5" />
+                      ) : (
+                        <ArrowsPointingOutIcon className="w-5 h-5" />
+                      )}
+                    </button>
+                    <button
+                      onClick={onClose}
+                      className="p-1 rounded-lg hover:bg-slate-100 dark:hover:bg-slate-700 text-slate-400 hover:text-slate-600 dark:hover:text-slate-300"
+                      title={t("chat.dismiss")}
+                    >
+                      <XMarkIcon className="w-5 h-5" />
+                    </button>
+                  </div>
                 </div>
 
                 {/* Toolbar */}

--- a/frontend/src/hooks/useFileChanges.ts
+++ b/frontend/src/hooks/useFileChanges.ts
@@ -20,31 +20,44 @@ export function useFileChanges(
   const [error, setError] = useState<string | null>(null);
   const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
 
-  const refresh = useCallback(() => {
-    setLastUpdated(new Date());
-  }, []);
+  const fetchStatus = useCallback(
+    async (showLoading = true) => {
+      if (!workingDirectory) return;
 
-  const fetchStatus = useCallback(async () => {
-    if (!workingDirectory) return;
-
-    setIsLoading(true);
-    setError(null);
-
-    try {
-      const url = getGitStatusUrl(workingDirectory);
-      const response = await fetch(url);
-      if (!response.ok) {
-        throw new Error(`HTTP ${response.status}`);
+      if (showLoading) {
+        setIsLoading(true);
       }
-      const data: GitStatusResponse = await response.json();
-      setFiles(data.files);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to load changes");
-    } finally {
-      setIsLoading(false);
-      setLastUpdated(new Date());
-    }
-  }, [workingDirectory]);
+      if (showLoading) {
+        setError(null);
+      }
+
+      try {
+        const url = getGitStatusUrl(workingDirectory);
+        const response = await fetch(url);
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}`);
+        }
+        const data: GitStatusResponse = await response.json();
+        setFiles(data.files);
+      } catch (err) {
+        if (showLoading) {
+          setError(
+            err instanceof Error ? err.message : "Failed to load changes",
+          );
+        }
+      } finally {
+        if (showLoading) {
+          setIsLoading(false);
+        }
+        setLastUpdated(new Date());
+      }
+    },
+    [workingDirectory],
+  );
+
+  const refresh = useCallback(() => {
+    fetchStatus(true);
+  }, [fetchStatus]);
 
   // Reset and fetch when workingDirectory changes
   // Note: fetchStatus changes identity when workingDirectory changes (useCallback dep),
@@ -62,7 +75,7 @@ export function useFileChanges(
     if (!workingDirectory) return;
 
     const interval = setInterval(() => {
-      if (document.visibilityState === "visible") fetchStatus();
+      if (document.visibilityState === "visible") fetchStatus(false);
     }, POLL_INTERVAL);
     return () => clearInterval(interval);
   }, [workingDirectory, fetchStatus]);

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -218,6 +218,8 @@
     "loading": "Loading changes...",
     "error": "Failed to load changes",
     "refresh": "Refresh",
+    "showPanel": "Show file changes",
+    "hidePanel": "Hide file changes",
     "openInVSCode": "Open VS Code",
     "closeVSCode": "Close VS Code",
     "startingVSCode": "Starting VS Code...",
@@ -229,6 +231,8 @@
       "unifiedView": "Unified View",
       "fullFile": "Full File",
       "diffView": "Diff",
+      "fullscreen": "Fullscreen",
+      "exitFullscreen": "Exit fullscreen",
       "noDiff": "No differences found"
     },
     "status": {

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -215,6 +215,8 @@
     "loading": "変更を読み込み中...",
     "error": "変更の読み込みに失敗しました",
     "refresh": "更新",
+    "showPanel": "ファイル変更を表示",
+    "hidePanel": "ファイル変更を非表示",
     "openInVSCode": "VS Codeを開く",
     "closeVSCode": "VS Codeを閉じる",
     "startingVSCode": "VS Codeを起動中...",
@@ -226,6 +228,8 @@
       "unifiedView": "統合表示",
       "fullFile": "ファイル全体",
       "diffView": "差分表示",
+      "fullscreen": "全画面",
+      "exitFullscreen": "全画面を終了",
       "noDiff": "差分は見つかりませんでした"
     },
     "status": {

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -215,6 +215,8 @@
     "loading": "변경 사항 로딩 중...",
     "error": "변경 사항 로딩 실패",
     "refresh": "새로고침",
+    "showPanel": "파일 변경 표시",
+    "hidePanel": "파일 변경 숨기기",
     "openInVSCode": "VS Code 열기",
     "closeVSCode": "VS Code 닫기",
     "startingVSCode": "VS Code 시작 중...",
@@ -226,6 +228,8 @@
       "unifiedView": "통합 보기",
       "fullFile": "전체 파일",
       "diffView": "차이점 보기",
+      "fullscreen": "전체 화면",
+      "exitFullscreen": "전체 화면 종료",
       "noDiff": "차이점을 찾을 수 없습니다"
     },
     "status": {

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -218,6 +218,8 @@
     "loading": "正在加载变更...",
     "error": "加载变更失败",
     "refresh": "刷新",
+    "showPanel": "显示文件变更",
+    "hidePanel": "隐藏文件变更",
     "openInVSCode": "打开 VS Code",
     "closeVSCode": "关闭 VS Code",
     "startingVSCode": "正在启动 VS Code...",
@@ -229,6 +231,8 @@
       "unifiedView": "合并视图",
       "fullFile": "完整文件",
       "diffView": "差异视图",
+      "fullscreen": "全屏",
+      "exitFullscreen": "退出全屏",
       "noDiff": "未发现差异"
     },
     "status": {


### PR DESCRIPTION
## Summary
- add a toolbar toggle so the file changes panel can be reopened after closing
- make the changes list hover state quieter while preserving focus-visible styling
- allow the VS Code panel to expand wider and ensure code-server opens the requested project folder
- add fullscreen support to the file diff modal
- make background file-change polling silent to avoid no-change state flicker

## Verification
- frontend: npm run typecheck
- backend: npm run typecheck
- targeted eslint on changed frontend/backend files
- browser smoke test for panel toggle, diff fullscreen, and VS Code iframe start/stop