### PR TITLE
Handle remote file changes panel gracefully

### DIFF
--- a/frontend/src/components/ChatPage.tsx
+++ b/frontend/src/components/ChatPage.tsx
@@ -1757,6 +1757,7 @@ export function ChatPage() {
                     onOpenDiff={(file) => setSelectedDiffFile(file)}
                     onClose={() => setFileChangesPanelVisible(false)}
                     onVSCodeOpenChange={setIsVSCodePanelOpen}
+                    remoteWorkspace={isRemoteWorkspace}
                   />
                 </Panel>
               </>

--- a/frontend/src/components/file-changes/FileChangesHeader.tsx
+++ b/frontend/src/components/file-changes/FileChangesHeader.tsx
@@ -9,6 +9,7 @@ interface FileChangesHeaderProps {
   fileCount: number;
   isLoading: boolean;
   vscodeRunning: boolean;
+  actionsDisabled?: boolean;
   onRefresh: () => void;
   onToggleVSCode: () => void;
   onClose: () => void;
@@ -18,11 +19,18 @@ export function FileChangesHeader({
   fileCount,
   isLoading,
   vscodeRunning,
+  actionsDisabled = false,
   onRefresh,
   onToggleVSCode,
   onClose,
 }: FileChangesHeaderProps) {
   const { t } = useTranslation();
+  const disabledTitle = t("fileChanges.remoteUnsupported");
+  const vscodeTitle = actionsDisabled
+    ? disabledTitle
+    : vscodeRunning
+      ? t("fileChanges.closeVSCode")
+      : t("fileChanges.openInVSCode");
 
   return (
     <div className="flex items-center justify-between px-3 py-2 border-b border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 flex-shrink-0">
@@ -39,9 +47,9 @@ export function FileChangesHeader({
       <div className="flex items-center gap-1">
         <button
           onClick={onRefresh}
-          disabled={isLoading}
+          disabled={isLoading || actionsDisabled}
           className="p-1 rounded hover:bg-slate-100 dark:hover:bg-slate-700 text-slate-400 hover:text-slate-600 dark:hover:text-slate-300 disabled:opacity-50"
-          title={t("fileChanges.refresh")}
+          title={actionsDisabled ? disabledTitle : t("fileChanges.refresh")}
         >
           <ArrowPathIcon
             className={`w-4 h-4 ${isLoading ? "animate-spin" : ""}`}
@@ -49,16 +57,13 @@ export function FileChangesHeader({
         </button>
         <button
           onClick={onToggleVSCode}
+          disabled={actionsDisabled}
           className={`p-1 rounded hover:bg-slate-100 dark:hover:bg-slate-700 ${
             vscodeRunning
               ? "text-blue-500 hover:text-blue-700 dark:text-blue-400"
               : "text-slate-400 hover:text-slate-600 dark:hover:text-slate-300"
-          }`}
-          title={
-            vscodeRunning
-              ? t("fileChanges.closeVSCode")
-              : t("fileChanges.openInVSCode")
-          }
+          } disabled:opacity-50`}
+          title={vscodeTitle}
         >
           <CodeBracketSquareIcon className="w-4 h-4" />
         </button>

--- a/frontend/src/components/file-changes/FileChangesList.tsx
+++ b/frontend/src/components/file-changes/FileChangesList.tsx
@@ -6,6 +6,7 @@ interface FileChangesListProps {
   files: FileChange[];
   isLoading: boolean;
   error: string | null;
+  emptyMessage?: string;
   onFileClick: (file: FileChange) => void;
 }
 
@@ -91,6 +92,7 @@ export function FileChangesList({
   files,
   isLoading,
   error,
+  emptyMessage,
   onFileClick,
 }: FileChangesListProps) {
   const { t } = useTranslation();
@@ -122,7 +124,7 @@ export function FileChangesList({
     return (
       <div className="flex-1 flex items-center justify-center p-4">
         <p className="text-xs text-slate-400 dark:text-slate-500">
-          {t("fileChanges.noChanges")}
+          {emptyMessage || t("fileChanges.noChanges")}
         </p>
       </div>
     );

--- a/frontend/src/components/file-changes/FileChangesPanel.tsx
+++ b/frontend/src/components/file-changes/FileChangesPanel.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback, useEffect } from "react";
+import { useTranslation } from "react-i18next";
 import { FileChangesHeader } from "./FileChangesHeader";
 import { FileChangesList } from "./FileChangesList";
 import { VSCodeEditor } from "./VSCodeEditor";
@@ -11,6 +12,7 @@ interface FileChangesPanelProps {
   onOpenDiff: (file: FileChange) => void;
   onClose: () => void;
   onVSCodeOpenChange?: (isOpen: boolean) => void;
+  remoteWorkspace?: boolean;
 }
 
 export function FileChangesPanel({
@@ -18,12 +20,19 @@ export function FileChangesPanel({
   onOpenDiff,
   onClose,
   onVSCodeOpenChange,
+  remoteWorkspace = false,
 }: FileChangesPanelProps) {
-  const { files, isLoading, error, refresh } = useFileChanges(workingDirectory);
+  const { t } = useTranslation();
+  const { files, isLoading, error, refresh } = useFileChanges(
+    workingDirectory,
+    !remoteWorkspace,
+  );
   const vscode = useVSCode();
   const [showVSCode, setShowVSCode] = useState(false);
 
   const handleToggleVSCode = useCallback(async () => {
+    if (remoteWorkspace) return;
+
     if (showVSCode) {
       await vscode.stop();
       setShowVSCode(false);
@@ -31,7 +40,7 @@ export function FileChangesPanel({
       setShowVSCode(true);
       await vscode.start(workingDirectory);
     }
-  }, [showVSCode, workingDirectory, vscode]);
+  }, [remoteWorkspace, showVSCode, workingDirectory, vscode]);
 
   const handleCloseVSCode = useCallback(async () => {
     await vscode.stop();
@@ -49,6 +58,7 @@ export function FileChangesPanel({
         fileCount={files.length}
         isLoading={isLoading}
         vscodeRunning={showVSCode && vscode.isRunning}
+        actionsDisabled={remoteWorkspace}
         onRefresh={refresh}
         onToggleVSCode={handleToggleVSCode}
         onClose={onClose}
@@ -65,6 +75,9 @@ export function FileChangesPanel({
           files={files}
           isLoading={isLoading}
           error={error}
+          emptyMessage={
+            remoteWorkspace ? t("fileChanges.remoteUnsupported") : undefined
+          }
           onFileClick={onOpenDiff}
         />
       )}

--- a/frontend/src/hooks/useFileChanges.ts
+++ b/frontend/src/hooks/useFileChanges.ts
@@ -14,6 +14,7 @@ const POLL_INTERVAL = 5000;
 
 export function useFileChanges(
   workingDirectory: string | undefined,
+  enabled = true,
 ): FileChangesResult {
   const [files, setFiles] = useState<FileChange[]>([]);
   const [isLoading, setIsLoading] = useState(false);
@@ -22,7 +23,7 @@ export function useFileChanges(
 
   const fetchStatus = useCallback(
     async (showLoading = true) => {
-      if (!workingDirectory) return;
+      if (!enabled || !workingDirectory) return;
 
       if (showLoading) {
         setIsLoading(true);
@@ -52,7 +53,7 @@ export function useFileChanges(
         setLastUpdated(new Date());
       }
     },
-    [workingDirectory],
+    [enabled, workingDirectory],
   );
 
   const refresh = useCallback(() => {
@@ -65,20 +66,20 @@ export function useFileChanges(
   useEffect(() => {
     setFiles([]);
     setError(null);
-    if (workingDirectory) {
+    if (enabled && workingDirectory) {
       fetchStatus();
     }
-  }, [workingDirectory, fetchStatus]);
+  }, [enabled, workingDirectory, fetchStatus]);
 
   // Polling (pause when tab is hidden)
   useEffect(() => {
-    if (!workingDirectory) return;
+    if (!enabled || !workingDirectory) return;
 
     const interval = setInterval(() => {
       if (document.visibilityState === "visible") fetchStatus(false);
     }, POLL_INTERVAL);
     return () => clearInterval(interval);
-  }, [workingDirectory, fetchStatus]);
+  }, [enabled, workingDirectory, fetchStatus]);
 
   return { files, isLoading, error, refresh, lastUpdated };
 }

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -220,6 +220,7 @@
     "refresh": "Refresh",
     "showPanel": "Show file changes",
     "hidePanel": "Hide file changes",
+    "remoteUnsupported": "File changes are not supported for remote workspaces yet",
     "openInVSCode": "Open VS Code",
     "closeVSCode": "Close VS Code",
     "startingVSCode": "Starting VS Code...",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -217,6 +217,7 @@
     "refresh": "更新",
     "showPanel": "ファイル変更を表示",
     "hidePanel": "ファイル変更を非表示",
+    "remoteUnsupported": "リモートワークスペースではファイル変更リストはまだサポートされていません",
     "openInVSCode": "VS Codeを開く",
     "closeVSCode": "VS Codeを閉じる",
     "startingVSCode": "VS Codeを起動中...",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -217,6 +217,7 @@
     "refresh": "새로고침",
     "showPanel": "파일 변경 표시",
     "hidePanel": "파일 변경 숨기기",
+    "remoteUnsupported": "원격 워크스페이스에서는 파일 변경 목록이 아직 지원되지 않습니다",
     "openInVSCode": "VS Code 열기",
     "closeVSCode": "VS Code 닫기",
     "startingVSCode": "VS Code 시작 중...",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -220,6 +220,7 @@
     "refresh": "刷新",
     "showPanel": "显示文件变更",
     "hidePanel": "隐藏文件变更",
+    "remoteUnsupported": "远程工作区暂不支持文件变更列表",
     "openInVSCode": "打开 VS Code",
     "closeVSCode": "关闭 VS Code",
     "startingVSCode": "正在启动 VS Code...",


### PR DESCRIPTION
## Summary
- skip local git file-change polling for remote workspaces to avoid HTTP 403 from local project validation
- show an explicit remote-workspace unsupported empty state in the file changes panel
- disable refresh and local VS Code launch actions for remote workspaces

## Verification
- frontend: npm run typecheck
- git diff --check
- targeted eslint on changed file-changes components, useFileChanges, and ChatPage (0 errors; existing ChatPage hook dependency warnings remain)