### PR TITLE
fix: 切换项目创建新Tab而非中断会话 (#229)

### DIFF
--- a/frontend/src/components/ChatPage.tsx
+++ b/frontend/src/components/ChatPage.tsx
@@ -1390,9 +1390,25 @@ export function ChatPage() {
     navigate({ search: searchParams.toString() });
   }, [navigate]);
 
+  // Issue #229: Switch project in iframe creates new tab instead of interrupting current session
   const handleBackToProjects = useCallback(() => {
-    navigate("/");
-  }, [navigate]);
+    // Check if embedded in iframe (Open ACE workspace)
+    if (window.parent !== window) {
+      // Send message to parent window to create a new tab for project selection
+      // This prevents interrupting the current thinking session
+      const workspaceType = isRemoteWorkspace ? "remote" : "local";
+      const machineId = remoteMachineId || undefined;
+      console.log('[qwen-code-webui] Sending switch-project request to parent:', { workspaceType, machineId });
+      window.parent.postMessage({
+        type: 'qwen-code-switch-project-request',
+        workspaceType,
+        machineId,
+      }, '*');
+    } else {
+      // Not embedded in iframe, navigate directly
+      navigate("/");
+    }
+  }, [navigate, isRemoteWorkspace, remoteMachineId]);
 
   // Handle global keyboard shortcuts
   useEffect(() => {


### PR DESCRIPTION
## 问题描述

Issue open-ace/open-ace#229: 远程工作区中，当会话正在 thinking 执行任务时，点击【切换项目】按钮会直接中断当前会话，无任何提醒。

## 问题根因

iframe 内切换项目直接调用 `navigate("/")` 重新加载 URL，导致 WebSocket/SSE 连接断开，当前正在 thinking 的会话被中断。

## 修复方案

检测 iframe 环境并发送消息给 Open ACE 创建新 Tab：
- `handleBackToProjects` 检测是否嵌入 iframe
- 发送 `qwen-code-switch-project-request` 消息
- 保留 `workspaceType` 和 `machineId` 参数

## 修改内容

- `frontend/src/components/ChatPage.tsx`
  - 修改 `handleBackToProjects` 函数，增加 iframe 检测和消息发送逻辑

## 关联 PR

此 PR 需配合 Open ACE 的修改一起使用：
- Open ACE PR: https://github.com/open-ace/open-ace/pull/592

## 关联 Issue

- open-ace/open-ace#229