### PR TITLE
feat: integrate Open ACE HA model pool for qwen-code model selection

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qwen-code-webui",
-  "version": "0.2.32",
+  "version": "0.2.33",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qwen-code-webui",
-      "version": "0.2.32",
+      "version": "0.2.33",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.11",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qwen-code-webui",
-  "version": "0.2.32",
+  "version": "0.2.33",
   "type": "module",
   "description": "Web-based interface for the Qwen Code CLI with streaming chat interface",
   "keywords": [

--- a/frontend/src/api/openace.ts
+++ b/frontend/src/api/openace.ts
@@ -5,6 +5,7 @@
  * Falls back to local qwen-code-webui API when not integrated.
  */
 
+import type { ModelConfig } from "@shared/types";
 import { getToken, getOpenAceUrl } from "../utils/token";
 
 // Open-ACE API base URL - can be configured via environment or detected from URL
@@ -123,6 +124,13 @@ export interface CheckPathResponse {
   canWrite?: boolean;
   canCreate?: boolean;
   error?: string;
+}
+
+export interface SessionModelsResponse {
+  success: boolean;
+  models: ModelConfig[];
+  empty_reason?: string | null;
+  ha_pool_token?: string;
 }
 
 /**
@@ -304,6 +312,35 @@ export function getOpenAceSessionApi(sessionId?: string, action?: string): strin
   return buildOpenAceUrl(endpoint);
 }
 
+export async function fetchSessionModels(request: {
+  workspaceType: "local" | "remote";
+  machineId?: string;
+  sessionId?: string | null;
+}): Promise<SessionModelsResponse> {
+  let url = buildOpenAceUrl(
+    `/api/workspace/session-models?workspace_type=${encodeURIComponent(request.workspaceType)}`
+  );
+  if (request.machineId) {
+    url += `&machine_id=${encodeURIComponent(request.machineId)}`;
+  }
+  if (request.sessionId) {
+    url += `&session_id=${encodeURIComponent(request.sessionId)}`;
+  }
+
+  const response = await fetch(url, {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch session models: ${response.statusText}`);
+  }
+
+  return response.json();
+}
+
 // -------------------------------------------------------
 // Remote Machine & Workspace types
 // -------------------------------------------------------
@@ -372,7 +409,8 @@ export async function createRemoteSession(
   projectPath: string,
   model?: string,
   cliTool?: string,
-  permissionMode?: string
+  permissionMode?: string,
+  haPoolToken?: string
 ): Promise<{ success: boolean; session: RemoteSession }> {
   const url = buildOpenAceUrl("/api/remote/sessions");
 
@@ -387,6 +425,7 @@ export async function createRemoteSession(
       model: model || undefined,
       cli_tool: cliTool || undefined,
       permission_mode: permissionMode || undefined,
+      ha_pool_token: haPoolToken || undefined,
     }),
   });
 
@@ -664,4 +703,3 @@ export function createRemoteSessionStream(
   };
   return es;
 }
-

--- a/frontend/src/api/openace.ts
+++ b/frontend/src/api/openace.ts
@@ -317,15 +317,14 @@ export async function fetchSessionModels(request: {
   machineId?: string;
   sessionId?: string | null;
 }): Promise<SessionModelsResponse> {
-  let url = buildOpenAceUrl(
-    `/api/workspace/session-models?workspace_type=${encodeURIComponent(request.workspaceType)}`
-  );
+  const params = new URLSearchParams({ workspace_type: request.workspaceType });
   if (request.machineId) {
-    url += `&machine_id=${encodeURIComponent(request.machineId)}`;
+    params.set("machine_id", request.machineId);
   }
   if (request.sessionId) {
-    url += `&session_id=${encodeURIComponent(request.sessionId)}`;
+    params.set("session_id", request.sessionId);
   }
+  const url = buildOpenAceUrl(`/api/workspace/session-models?${params}`);
 
   const response = await fetch(url, {
     method: "GET",

--- a/frontend/src/components/ChatPage.tsx
+++ b/frontend/src/components/ChatPage.tsx
@@ -390,6 +390,9 @@ export function ChatPage() {
     }
   }, [isRemoteWorkspace, remoteMachineId, workingDirectory, selectedModel, isLoadedConversation, sessionId, remotePermissionMode, remoteChat.session, modelsLoading, haPoolToken]);
 
+  // Detect when remote session can't start due to missing haPoolToken in integrated mode
+  const missingPoolToken = isRemoteWorkspace && integratedMode && !isLoadedConversation && !modelsLoading && !haPoolToken && !remoteChat.session && !startSessionCalledRef.current;
+
   // Track the model used when the remote session was created
   const remoteSessionModelRef = useRef<string | null>(null);
 
@@ -1545,6 +1548,12 @@ export function ChatPage() {
                     </button>
                   )}
                 </div>
+              )}
+              {/* Missing HA pool token — cannot start remote session */}
+              {missingPoolToken && (
+                <p className="text-xs text-amber-600 dark:text-amber-400 mt-1">
+                  {modelEmptyReason || t("chat.noModelsAvailable")}
+                </p>
               )}
             </div>
           </div>

--- a/frontend/src/components/ChatPage.tsx
+++ b/frontend/src/components/ChatPage.tsx
@@ -105,6 +105,14 @@ export function ChatPage() {
   const isRemoteWorkspace = searchParams.get("workspaceType") === "remote";
   const remoteMachineId = searchParams.get("machineId") || "";
   const remoteMachineName = searchParams.get("machineName") || "";
+  const integratedMode = isIntegratedMode();
+
+  // Get current view, sessionId, and toolName from query parameters
+  const currentView = searchParams.get("view");
+  const sessionId = searchParams.get("sessionId");
+  const toolName = searchParams.get("toolName");
+  const isHistoryView = currentView === "history";
+  const isLoadedConversation = !!sessionId && !isHistoryView;
 
   // Model selection
   const {
@@ -112,7 +120,14 @@ export function ChatPage() {
     selectedModel,
     setSelectedModel,
     loading: modelsLoading,
-  } = useModel();
+    emptyReason: modelEmptyReason,
+    haPoolToken,
+  } = useModel({
+    integratedMode,
+    workspaceType: isRemoteWorkspace ? "remote" : "local",
+    machineId: isRemoteWorkspace && !isLoadedConversation ? remoteMachineId : undefined,
+    sessionId: isRemoteWorkspace && isLoadedConversation ? sessionId : undefined,
+  });
 
   // Apply URL settings on mount (Issue #70: Workspace restoration)
   useEffect(() => {
@@ -193,13 +208,6 @@ export function ChatPage() {
     // Normalize Windows paths (remove leading slash from /C:/... format)
     return normalizeWindowsPath(decodedPath);
   })();
-
-  // Get current view, sessionId, and toolName from query parameters
-  const currentView = searchParams.get("view");
-  const sessionId = searchParams.get("sessionId");
-  const toolName = searchParams.get("toolName");
-  const isHistoryView = currentView === "history";
-  const isLoadedConversation = !!sessionId && !isHistoryView;
 
   const { processStreamLine } = useClaudeStreaming();
   const { abortRequest, createAbortHandler } = useAbortController();
@@ -364,15 +372,23 @@ export function ChatPage() {
   useEffect(() => {
     if (!isRemoteWorkspace || !remoteMachineId || remoteChat.session) return;
     if (startSessionCalledRef.current) return;
+    if (modelsLoading) return;
 
     if (isLoadedConversation && sessionId) {
       startSessionCalledRef.current = true;
       remoteChat.connectSession(sessionId);
-    } else if (workingDirectory) {
+    } else if (workingDirectory && haPoolToken) {
       startSessionCalledRef.current = true;
-      remoteChat.startSession(remoteMachineId, workingDirectory, selectedModel || undefined, undefined, remotePermissionMode);
+      remoteChat.startSession(
+        remoteMachineId,
+        workingDirectory,
+        selectedModel || undefined,
+        undefined,
+        remotePermissionMode,
+        haPoolToken
+      );
     }
-  }, [isRemoteWorkspace, remoteMachineId, workingDirectory, selectedModel, isLoadedConversation, sessionId, remotePermissionMode, remoteChat.session]);
+  }, [isRemoteWorkspace, remoteMachineId, workingDirectory, selectedModel, isLoadedConversation, sessionId, remotePermissionMode, remoteChat.session, modelsLoading, haPoolToken]);
 
   // Track the model used when the remote session was created
   const remoteSessionModelRef = useRef<string | null>(null);
@@ -1539,6 +1555,8 @@ export function ChatPage() {
                 selectedModel={selectedModel}
                 onSelectModel={setSelectedModel}
                 loading={modelsLoading}
+                emptyReason={modelEmptyReason}
+                integratedMode={integratedMode}
               />
             )}
             <ProjectSwitchButton onClick={handleBackToProjects} />

--- a/frontend/src/components/ChatPage.tsx
+++ b/frontend/src/components/ChatPage.tsx
@@ -120,6 +120,7 @@ export function ChatPage() {
     selectedModel,
     setSelectedModel,
     loading: modelsLoading,
+    error: modelError,
     emptyReason: modelEmptyReason,
     haPoolToken,
   } = useModel({
@@ -1550,9 +1551,14 @@ export function ChatPage() {
                 </div>
               )}
               {/* Missing HA pool token — cannot start remote session */}
-              {missingPoolToken && (
+              {missingPoolToken && modelError && (
+                <p className="text-xs text-red-500 dark:text-red-400 mt-1">
+                  {modelError}
+                </p>
+              )}
+              {missingPoolToken && !modelError && (
                 <p className="text-xs text-amber-600 dark:text-amber-400 mt-1">
-                  {modelEmptyReason || t("chat.noModelsAvailable")}
+                  {t("chat.missingPoolToken")}
                 </p>
               )}
             </div>

--- a/frontend/src/components/chat/ModelSelector.tsx
+++ b/frontend/src/components/chat/ModelSelector.tsx
@@ -8,6 +8,8 @@ interface ModelSelectorProps {
   selectedModel: string | null;
   onSelectModel: (modelId: string | null) => void;
   loading?: boolean;
+  emptyReason?: string | null;
+  integratedMode?: boolean;
 }
 
 export function ModelSelector({
@@ -15,6 +17,8 @@ export function ModelSelector({
   selectedModel,
   onSelectModel,
   loading,
+  emptyReason,
+  integratedMode,
 }: ModelSelectorProps) {
   const { t } = useTranslation();
   const [isOpen, setIsOpen] = useState(false);
@@ -53,7 +57,23 @@ export function ModelSelector({
   };
 
   if (models.length === 0 && !loading) {
-    return null;
+    if (!integratedMode) {
+      return null;
+    }
+    return (
+      <div className="relative" ref={dropdownRef}>
+        <button
+          type="button"
+          className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-lg bg-slate-100 dark:bg-slate-800/80 border border-slate-200 dark:border-slate-700 text-slate-500 dark:text-slate-400 cursor-not-allowed max-w-[260px]"
+          aria-label={emptyReason || t("chat.selectModel")}
+          disabled
+          title={emptyReason || "No models available"}
+        >
+          <span className="truncate">{emptyReason || "No models available"}</span>
+          <ChevronDownIcon className="w-3.5 h-3.5 flex-shrink-0" />
+        </button>
+      </div>
+    );
   }
 
   return (

--- a/frontend/src/components/chat/ModelSelector.tsx
+++ b/frontend/src/components/chat/ModelSelector.tsx
@@ -65,11 +65,11 @@ export function ModelSelector({
         <button
           type="button"
           className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-lg bg-slate-100 dark:bg-slate-800/80 border border-slate-200 dark:border-slate-700 text-slate-500 dark:text-slate-400 cursor-not-allowed max-w-[260px]"
-          aria-label={emptyReason || t("chat.selectModel")}
+          aria-label={emptyReason || t("chat.noModelsAvailable")}
           disabled
-          title={emptyReason || "No models available"}
+          title={emptyReason || t("chat.noModelsAvailable")}
         >
-          <span className="truncate">{emptyReason || "No models available"}</span>
+          <span className="truncate">{emptyReason || t("chat.noModelsAvailable")}</span>
           <ChevronDownIcon className="w-3.5 h-3.5 flex-shrink-0" />
         </button>
       </div>

--- a/frontend/src/hooks/useModel.ts
+++ b/frontend/src/hooks/useModel.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from "react";
 import type { ModelConfig } from "../../../shared/types";
 import { getModelsUrl } from "../config/api";
+import { fetchSessionModels } from "../api/openace";
 
 interface UseModelReturn {
   models: ModelConfig[];
@@ -8,16 +9,25 @@ interface UseModelReturn {
   setSelectedModel: (modelId: string | null) => void;
   loading: boolean;
   error: string | null;
+  emptyReason: string | null;
+  haPoolToken: string | null;
 }
 
 const STORAGE_KEY = "qwen-selected-model";
+
+interface UseModelOptions {
+  integratedMode?: boolean;
+  workspaceType?: "local" | "remote";
+  machineId?: string;
+  sessionId?: string | null;
+}
 
 /**
  * Hook for managing model selection
  * - Fetches available models from API
  * - Persists selected model to localStorage
  */
-export function useModel(): UseModelReturn {
+export function useModel(options: UseModelOptions = {}): UseModelReturn {
   const [models, setModels] = useState<ModelConfig[]>([]);
   const [selectedModel, setSelectedModelState] = useState<string | null>(() => {
     // Initialize from localStorage
@@ -29,29 +39,46 @@ export function useModel(): UseModelReturn {
   });
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [emptyReason, setEmptyReason] = useState<string | null>(null);
+  const [haPoolToken, setHaPoolToken] = useState<string | null>(null);
 
-  // Fetch models on mount
   useEffect(() => {
     const fetchModels = async () => {
       try {
         setLoading(true);
-        const response = await fetch(getModelsUrl());
-        if (!response.ok) {
-          throw new Error(`Failed to fetch models: ${response.status}`);
+        if (options.integratedMode) {
+          const data = await fetchSessionModels({
+            workspaceType: options.workspaceType || "local",
+            machineId: options.machineId,
+            sessionId: options.sessionId,
+          });
+          setModels(data.models || []);
+          setEmptyReason(data.empty_reason || null);
+          setHaPoolToken(data.ha_pool_token || null);
+        } else {
+          const response = await fetch(getModelsUrl());
+          if (!response.ok) {
+            throw new Error(`Failed to fetch models: ${response.status}`);
+          }
+          const data = await response.json();
+          setModels(data.models || []);
+          setEmptyReason(null);
+          setHaPoolToken(null);
         }
-        const data = await response.json();
-        setModels(data.models || []);
         setError(null);
       } catch (err) {
         console.error("Failed to fetch models:", err);
         setError(err instanceof Error ? err.message : "Failed to fetch models");
+        setModels([]);
+        setEmptyReason(null);
+        setHaPoolToken(null);
       } finally {
         setLoading(false);
       }
     };
 
     fetchModels();
-  }, []);
+  }, [options.integratedMode, options.machineId, options.sessionId, options.workspaceType]);
 
   // Set default model when models are loaded
   useEffect(() => {
@@ -93,5 +120,7 @@ export function useModel(): UseModelReturn {
     setSelectedModel,
     loading,
     error,
+    emptyReason,
+    haPoolToken,
   };
 }

--- a/frontend/src/hooks/useRemoteChat.ts
+++ b/frontend/src/hooks/useRemoteChat.ts
@@ -117,7 +117,8 @@ export function useRemoteChat(options?: RemoteChatOptions) {
       projectPath: string,
       model?: string,
       cliTool?: string,
-      permissionMode?: string
+      permissionMode?: string,
+      haPoolToken?: string
     ) => {
       setIsLoading(true);
       setError(null);
@@ -129,7 +130,8 @@ export function useRemoteChat(options?: RemoteChatOptions) {
           projectPath,
           model,
           cliTool,
-          permissionMode
+          permissionMode,
+          haPoolToken
         );
 
         setSession(response.session);

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -67,6 +67,7 @@
     "autoEdit": "auto-edit",
     "yoloMode": "yolo mode",
     "loading": "Loading...",
+    "missingPoolToken": "Cannot start session: missing credentials",
     "noModelsAvailable": "No models available",
     "selectModel": "Select model",
     "startConversation": "Start a conversation with Qwen",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -67,6 +67,7 @@
     "autoEdit": "auto-edit",
     "yoloMode": "yolo mode",
     "loading": "Loading...",
+    "noModelsAvailable": "No models available",
     "selectModel": "Select model",
     "startConversation": "Start a conversation with Qwen",
     "typeToBegin": "Type your message below to begin",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -67,6 +67,7 @@
     "autoEdit": "自動編集",
     "yoloMode": "YOLOモード",
     "loading": "読み込み中...",
+    "noModelsAvailable": "利用可能なモデルなし",
     "selectModel": "モデルを選択",
     "startConversation": "Qwenとの会話を開始",
     "typeToBegin": "下にメッセージを入力して開始",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -67,6 +67,7 @@
     "autoEdit": "自動編集",
     "yoloMode": "YOLOモード",
     "loading": "読み込み中...",
+    "missingPoolToken": "セッションを開始できません：資格情報がありません",
     "noModelsAvailable": "利用可能なモデルなし",
     "selectModel": "モデルを選択",
     "startConversation": "Qwenとの会話を開始",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -67,6 +67,7 @@
     "autoEdit": "자동 편집",
     "yoloMode": "YOLO 모드",
     "loading": "로딩 중...",
+    "missingPoolToken": "세션을 시작할 수 없음: 자격 증명 누락",
     "noModelsAvailable": "사용 가능한 모델 없음",
     "selectModel": "모델 선택",
     "startConversation": "Qwen과 대화 시작",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -67,6 +67,7 @@
     "autoEdit": "자동 편집",
     "yoloMode": "YOLO 모드",
     "loading": "로딩 중...",
+    "noModelsAvailable": "사용 가능한 모델 없음",
     "selectModel": "모델 선택",
     "startConversation": "Qwen과 대화 시작",
     "typeToBegin": "아래에 메시지를 입력하여 시작하세요",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -67,6 +67,7 @@
     "autoEdit": "自动编辑",
     "yoloMode": "YOLO 模式",
     "loading": "加载中...",
+    "noModelsAvailable": "暂无可用模型",
     "selectModel": "选择模型",
     "startConversation": "开始与 Qwen 对话",
     "typeToBegin": "在下方输入消息开始",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -67,6 +67,7 @@
     "autoEdit": "自动编辑",
     "yoloMode": "YOLO 模式",
     "loading": "加载中...",
+    "missingPoolToken": "无法启动会话：缺少凭据",
     "noModelsAvailable": "暂无可用模型",
     "selectModel": "选择模型",
     "startConversation": "开始与 Qwen 对话",


### PR DESCRIPTION
## Summary

Implements the qwen-code-webui frontend changes for [open-ace/open-ace#604](https://github.com/open-ace/open-ace/issues/604) — integrated mode model selection backed by the full HA API key pool.

## Changes

### `useModel` hook (`frontend/src/hooks/useModel.ts`)
- Accepts `integratedMode`, `workspaceType`, `machineId`, and `sessionId` options
- In integrated mode, fetches models from `GET /api/workspace/session-models` instead of `/api/models`
- Exposes `emptyReason` and `haPoolToken` from the session-models response
- Standalone mode is **unchanged** — still reads `/api/models`

### API layer (`frontend/src/api/openace.ts`)
- New `fetchSessionModels()` function calling `GET /api/workspace/session-models`
- `createRemoteSession()` now accepts and passes `ha_pool_token`
- New `SessionModelsResponse` type

### ChatPage (`frontend/src/components/ChatPage.tsx`)
- Detects integrated mode and wires workspace type / machine ID / session ID into `useModel`
- Remote session start waits for models to finish loading (`modelsLoading`) and for `haPoolToken` before creating a session
- Passes `haPoolToken` through to `remoteChat.startSession()`

### ModelSelector (`frontend/src/components/chat/ModelSelector.tsx`)
- In integrated mode with no models, shows a **disabled** selector with the server-provided `emptyReason` instead of hiding the selector entirely
- Standalone mode with no models still hides the selector (unchanged)

### Remote chat hook (`frontend/src/hooks/useRemoteChat.ts`)
- `startSession()` passes `haPoolToken` through to `createRemoteSession()`

## Behavior summary

| Scenario | Model source | Empty state |
|---|---|---|
| Standalone | `/api/models` (local settings) | Selector hidden |
| Integrated local | `/api/workspace/session-models?workspace_type=local` | Disabled selector with reason |
| Integrated remote (new) | `/api/workspace/session-models?workspace_type=remote&machine_id=...` | Disabled selector with reason |
| Integrated remote (reconnect) | `/api/workspace/session-models?workspace_type=remote&session_id=...` | Disabled selector with reason |

Closes open-ace/open-ace#604

🤖 Generated with [Claude Code](https://claude.com/claude-code)