### PR TITLE
feat: 远程工作区支持文件变更面板和 VSCode 编辑器

### DIFF
--- a/frontend/src/api/openace.ts
+++ b/frontend/src/api/openace.ts
@@ -702,3 +702,160 @@ export function createRemoteSessionStream(
   };
   return es;
 }
+
+// -------------------------------------------------------
+// Remote Git API functions
+// -------------------------------------------------------
+
+/**
+ * Fetch git status from a remote machine via Open-ACE proxy.
+ * Only called in remote workspace mode (workspaceType=remote).
+ */
+export async function fetchRemoteGitStatus(
+  machineId: string,
+  projectPath: string
+): Promise<{ success: boolean; result?: { files: any[] }; error?: string }> {
+  const url = buildOpenAceUrl(
+    `/api/remote/machines/${machineId}/git/status?path=${encodeURIComponent(projectPath)}`
+  );
+
+  const response = await fetch(url, {
+    method: "GET",
+    headers: { "Content-Type": "application/json" },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch remote git status: ${response.statusText}`);
+  }
+
+  return response.json();
+}
+
+/**
+ * Fetch git diff for a file from a remote machine via Open-ACE proxy.
+ * Only called in remote workspace mode (workspaceType=remote).
+ */
+export async function fetchRemoteGitDiff(
+  machineId: string,
+  projectPath: string,
+  file: string
+): Promise<{
+  success: boolean;
+  result?: { file: string; diff: string; originalContent: string; modifiedContent: string };
+  error?: string;
+}> {
+  const url = buildOpenAceUrl(
+    `/api/remote/machines/${machineId}/git/diff?path=${encodeURIComponent(projectPath)}&file=${encodeURIComponent(file)}`
+  );
+
+  const response = await fetch(url, {
+    method: "GET",
+    headers: { "Content-Type": "application/json" },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch remote git diff: ${response.statusText}`);
+  }
+
+  return response.json();
+}
+
+/**
+ * Read a file from a remote machine via Open-ACE proxy.
+ * Only called in remote workspace mode (workspaceType=remote).
+ */
+export async function fetchRemoteGitFile(
+  machineId: string,
+  projectPath: string,
+  file: string
+): Promise<{ success: boolean; result?: { file: string; content: string }; error?: string }> {
+  const url = buildOpenAceUrl(
+    `/api/remote/machines/${machineId}/git/file?path=${encodeURIComponent(projectPath)}&file=${encodeURIComponent(file)}`
+  );
+
+  const response = await fetch(url, {
+    method: "GET",
+    headers: { "Content-Type": "application/json" },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch remote file: ${response.statusText}`);
+  }
+
+  return response.json();
+}
+
+// -------------------------------------------------------
+// Remote VSCode (code-server) API functions
+// -------------------------------------------------------
+
+/**
+ * Start a code-server instance on a remote machine.
+ * Only called in remote workspace mode (workspaceType=remote).
+ */
+export async function startRemoteVSCode(
+  machineId: string,
+  projectPath: string
+): Promise<{ success: boolean; vscode_id?: string; status?: string; error?: string }> {
+  const url = buildOpenAceUrl("/api/remote/vscode/start");
+
+  const response = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ machine_id: machineId, project_path: projectPath }),
+  });
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw new Error(error.error || `Failed to start VSCode: ${response.statusText}`);
+  }
+
+  return response.json();
+}
+
+/**
+ * Stop a code-server instance on a remote machine.
+ */
+export async function stopRemoteVSCode(
+  vscodeId: string,
+  machineId: string
+): Promise<{ success: boolean }> {
+  const url = buildOpenAceUrl("/api/remote/vscode/stop");
+
+  const response = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ vscode_id: vscodeId, machine_id: machineId }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to stop VSCode: ${response.statusText}`);
+  }
+
+  return response.json();
+}
+
+/**
+ * Get the status of a code-server instance.
+ */
+export async function getRemoteVSCodeStatus(
+  vscodeId: string
+): Promise<{
+  success: boolean;
+  status: string;
+  url?: string;
+  error?: string;
+}> {
+  const url = buildOpenAceUrl(`/api/remote/vscode/${vscodeId}/status`);
+
+  const response = await fetch(url, {
+    method: "GET",
+    headers: { "Content-Type": "application/json" },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to get VSCode status: ${response.statusText}`);
+  }
+
+  return response.json();
+}

--- a/frontend/src/api/openace.ts
+++ b/frontend/src/api/openace.ts
@@ -716,7 +716,7 @@ export async function fetchRemoteGitStatus(
   projectPath: string
 ): Promise<{ success: boolean; result?: { files: any[] }; error?: string }> {
   const url = buildOpenAceUrl(
-    `/api/remote/machines/${machineId}/git/status?path=${encodeURIComponent(projectPath)}`
+    `/api/remote/machines/${encodeURIComponent(machineId)}/git/status?path=${encodeURIComponent(projectPath)}`
   );
 
   const response = await fetch(url, {
@@ -745,7 +745,7 @@ export async function fetchRemoteGitDiff(
   error?: string;
 }> {
   const url = buildOpenAceUrl(
-    `/api/remote/machines/${machineId}/git/diff?path=${encodeURIComponent(projectPath)}&file=${encodeURIComponent(file)}`
+    `/api/remote/machines/${encodeURIComponent(machineId)}/git/diff?path=${encodeURIComponent(projectPath)}&file=${encodeURIComponent(file)}`
   );
 
   const response = await fetch(url, {
@@ -770,7 +770,7 @@ export async function fetchRemoteGitFile(
   file: string
 ): Promise<{ success: boolean; result?: { file: string; content: string }; error?: string }> {
   const url = buildOpenAceUrl(
-    `/api/remote/machines/${machineId}/git/file?path=${encodeURIComponent(projectPath)}&file=${encodeURIComponent(file)}`
+    `/api/remote/machines/${encodeURIComponent(machineId)}/git/file?path=${encodeURIComponent(projectPath)}&file=${encodeURIComponent(file)}`
   );
 
   const response = await fetch(url, {

--- a/frontend/src/components/ChatPage.tsx
+++ b/frontend/src/components/ChatPage.tsx
@@ -1807,6 +1807,7 @@ export function ChatPage() {
                     onClose={() => setFileChangesPanelVisible(false)}
                     onVSCodeOpenChange={setIsVSCodePanelOpen}
                     remoteWorkspace={isRemoteWorkspace}
+                    machineId={remoteMachineId || undefined}
                   />
                 </Panel>
               </>
@@ -1820,6 +1821,8 @@ export function ChatPage() {
           file={selectedDiffFile}
           workingDirectory={workingDirectory || ""}
           onClose={() => setSelectedDiffFile(null)}
+          remoteWorkspace={isRemoteWorkspace}
+          machineId={remoteMachineId || undefined}
         />
 
         {/* Settings Modal */}

--- a/frontend/src/components/file-changes/FileChangesPanel.tsx
+++ b/frontend/src/components/file-changes/FileChangesPanel.tsx
@@ -5,6 +5,7 @@ import { FileChangesList } from "./FileChangesList";
 import { VSCodeEditor } from "./VSCodeEditor";
 import { useFileChanges } from "../../hooks/useFileChanges";
 import { useVSCode } from "../../hooks/useVSCode";
+import { useRemoteVSCode } from "../../hooks/useRemoteVSCode";
 import type { FileChange } from "../../types/fileChanges";
 
 interface FileChangesPanelProps {
@@ -13,6 +14,7 @@ interface FileChangesPanelProps {
   onClose: () => void;
   onVSCodeOpenChange?: (isOpen: boolean) => void;
   remoteWorkspace?: boolean;
+  machineId?: string;
 }
 
 export function FileChangesPanel({
@@ -21,31 +23,51 @@ export function FileChangesPanel({
   onClose,
   onVSCodeOpenChange,
   remoteWorkspace = false,
+  machineId,
 }: FileChangesPanelProps) {
   const { t } = useTranslation();
   const { files, isLoading, error, refresh } = useFileChanges(
     workingDirectory,
-    !remoteWorkspace,
+    true,
+    remoteWorkspace,
+    machineId,
   );
-  const vscode = useVSCode();
+  // Local and remote VSCode hooks - choose based on mode
+  const localVSCode = useVSCode();
+  const remoteVSCode = useRemoteVSCode();
   const [showVSCode, setShowVSCode] = useState(false);
 
-  const handleToggleVSCode = useCallback(async () => {
-    if (remoteWorkspace) return;
+  // Get the active VSCode state based on mode
+  const activeVSCode = remoteWorkspace
+    ? { isRunning: remoteVSCode.isRunning, isLoading: remoteVSCode.isLoading, error: remoteVSCode.error, url: remoteVSCode.url }
+    : { isRunning: localVSCode.isRunning, isLoading: localVSCode.isLoading, error: localVSCode.error, url: localVSCode.url };
 
+  const handleToggleVSCode = useCallback(async () => {
     if (showVSCode) {
-      await vscode.stop();
+      if (remoteWorkspace) {
+        await remoteVSCode.stop(machineId || "");
+      } else {
+        await localVSCode.stop();
+      }
       setShowVSCode(false);
     } else if (workingDirectory) {
       setShowVSCode(true);
-      await vscode.start(workingDirectory);
+      if (remoteWorkspace && machineId) {
+        await remoteVSCode.start(machineId, workingDirectory);
+      } else {
+        await localVSCode.start(workingDirectory);
+      }
     }
-  }, [remoteWorkspace, showVSCode, workingDirectory, vscode]);
+  }, [remoteWorkspace, showVSCode, workingDirectory, machineId, localVSCode, remoteVSCode]);
 
   const handleCloseVSCode = useCallback(async () => {
-    await vscode.stop();
+    if (remoteWorkspace) {
+      await remoteVSCode.stop(machineId || "");
+    } else {
+      await localVSCode.stop();
+    }
     setShowVSCode(false);
-  }, [vscode]);
+  }, [remoteWorkspace, machineId, localVSCode, remoteVSCode]);
 
   useEffect(() => {
     onVSCodeOpenChange?.(showVSCode);
@@ -57,17 +79,16 @@ export function FileChangesPanel({
       <FileChangesHeader
         fileCount={files.length}
         isLoading={isLoading}
-        vscodeRunning={showVSCode && vscode.isRunning}
-        actionsDisabled={remoteWorkspace}
+        vscodeRunning={showVSCode && activeVSCode.isRunning}
         onRefresh={refresh}
         onToggleVSCode={handleToggleVSCode}
         onClose={onClose}
       />
       {showVSCode ? (
         <VSCodeEditor
-          url={vscode.url}
-          isLoading={vscode.isLoading}
-          error={vscode.error}
+          url={activeVSCode.url}
+          isLoading={activeVSCode.isLoading}
+          error={activeVSCode.error}
           onClose={handleCloseVSCode}
         />
       ) : (
@@ -75,9 +96,6 @@ export function FileChangesPanel({
           files={files}
           isLoading={isLoading}
           error={error}
-          emptyMessage={
-            remoteWorkspace ? t("fileChanges.remoteUnsupported") : undefined
-          }
           onFileClick={onOpenDiff}
         />
       )}

--- a/frontend/src/components/file-changes/FileChangesPanel.tsx
+++ b/frontend/src/components/file-changes/FileChangesPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect } from "react";
+import { useState, useCallback, useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { FileChangesHeader } from "./FileChangesHeader";
 import { FileChangesList } from "./FileChangesList";
@@ -37,10 +37,14 @@ export function FileChangesPanel({
   const remoteVSCode = useRemoteVSCode();
   const [showVSCode, setShowVSCode] = useState(false);
 
-  // Get the active VSCode state based on mode
-  const activeVSCode = remoteWorkspace
-    ? { isRunning: remoteVSCode.isRunning, isLoading: remoteVSCode.isLoading, error: remoteVSCode.error, url: remoteVSCode.url }
-    : { isRunning: localVSCode.isRunning, isLoading: localVSCode.isLoading, error: localVSCode.error, url: localVSCode.url };
+  // Get the active VSCode state based on mode (memoized to avoid unnecessary re-renders)
+  const activeVSCode = useMemo(
+    () =>
+      remoteWorkspace
+        ? { isRunning: remoteVSCode.isRunning, isLoading: remoteVSCode.isLoading, error: remoteVSCode.error, url: remoteVSCode.url }
+        : { isRunning: localVSCode.isRunning, isLoading: localVSCode.isLoading, error: localVSCode.error, url: localVSCode.url },
+    [remoteWorkspace, remoteVSCode, localVSCode],
+  );
 
   const handleToggleVSCode = useCallback(async () => {
     if (showVSCode) {

--- a/frontend/src/components/file-changes/FileDiffModal.tsx
+++ b/frontend/src/components/file-changes/FileDiffModal.tsx
@@ -10,6 +10,7 @@ import { useTranslation } from "react-i18next";
 import ReactDiffViewer, { DiffMethod } from "react-diff-viewer-continued";
 import type { FileChange, GitDiffResponse } from "../../types/fileChanges";
 import { getGitDiffUrl } from "../../config/api";
+import { fetchRemoteGitDiff } from "../../api/openace";
 import { useSettings } from "../../hooks/useSettings";
 
 interface FileDiffModalProps {
@@ -17,6 +18,8 @@ interface FileDiffModalProps {
   file: FileChange | null;
   workingDirectory: string;
   onClose: () => void;
+  remoteWorkspace?: boolean;
+  machineId?: string;
 }
 
 type ViewMode = "diff" | "file";
@@ -27,6 +30,8 @@ export function FileDiffModal({
   file,
   workingDirectory,
   onClose,
+  remoteWorkspace = false,
+  machineId,
 }: FileDiffModalProps) {
   const { t } = useTranslation();
   const { theme } = useSettings();
@@ -39,24 +44,41 @@ export function FileDiffModal({
 
   const fetchDiff = useCallback(async () => {
     if (!file || !workingDirectory) return;
+    // Remote mode requires machineId
+    if (remoteWorkspace && !machineId) return;
 
     setLoading(true);
     setError(null);
     try {
-      const url = getGitDiffUrl(workingDirectory, file.path);
-      const response = await fetch(url);
-      if (response.ok) {
-        const data: GitDiffResponse = await response.json();
-        setDiffData(data);
+      if (remoteWorkspace && machineId) {
+        // Remote mode: fetch via Open-ACE proxy
+        const data = await fetchRemoteGitDiff(machineId, workingDirectory, file.path);
+        if (!data.success) {
+          throw new Error(data.error || "Failed to load remote diff");
+        }
+        setDiffData({
+          file: data.result?.file || file.path,
+          diff: data.result?.diff || "",
+          originalContent: data.result?.originalContent || "",
+          modifiedContent: data.result?.modifiedContent || "",
+        });
       } else {
-        setError(`Failed to load diff (HTTP ${response.status})`);
+        // Local mode: use local git API (unchanged behavior)
+        const url = getGitDiffUrl(workingDirectory, file.path);
+        const response = await fetch(url);
+        if (response.ok) {
+          const data: GitDiffResponse = await response.json();
+          setDiffData(data);
+        } else {
+          setError(`Failed to load diff (HTTP ${response.status})`);
+        }
       }
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to load diff");
     } finally {
       setLoading(false);
     }
-  }, [file, workingDirectory]);
+  }, [file, workingDirectory, remoteWorkspace, machineId]);
 
   useEffect(() => {
     if (isOpen && file) {

--- a/frontend/src/hooks/useFileChanges.ts
+++ b/frontend/src/hooks/useFileChanges.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from "react";
 import type { FileChange, GitStatusResponse } from "../types/fileChanges";
 import { getGitStatusUrl } from "../config/api";
+import { fetchRemoteGitStatus } from "../api/openace";
 
 interface FileChangesResult {
   files: FileChange[];
@@ -15,6 +16,8 @@ const POLL_INTERVAL = 5000;
 export function useFileChanges(
   workingDirectory: string | undefined,
   enabled = true,
+  remoteWorkspace = false,
+  machineId?: string,
 ): FileChangesResult {
   const [files, setFiles] = useState<FileChange[]>([]);
   const [isLoading, setIsLoading] = useState(false);
@@ -24,6 +27,8 @@ export function useFileChanges(
   const fetchStatus = useCallback(
     async (showLoading = true) => {
       if (!enabled || !workingDirectory) return;
+      // Remote mode requires machineId
+      if (remoteWorkspace && !machineId) return;
 
       if (showLoading) {
         setIsLoading(true);
@@ -33,13 +38,23 @@ export function useFileChanges(
       }
 
       try {
-        const url = getGitStatusUrl(workingDirectory);
-        const response = await fetch(url);
-        if (!response.ok) {
-          throw new Error(`HTTP ${response.status}`);
+        if (remoteWorkspace && machineId) {
+          // Remote mode: fetch via Open-ACE proxy
+          const data = await fetchRemoteGitStatus(machineId, workingDirectory);
+          if (!data.success) {
+            throw new Error(data.error || "Failed to load remote changes");
+          }
+          setFiles(data.result?.files || []);
+        } else {
+          // Local mode: use local git API (unchanged behavior)
+          const url = getGitStatusUrl(workingDirectory);
+          const response = await fetch(url);
+          if (!response.ok) {
+            throw new Error(`HTTP ${response.status}`);
+          }
+          const data: GitStatusResponse = await response.json();
+          setFiles(data.files);
         }
-        const data: GitStatusResponse = await response.json();
-        setFiles(data.files);
       } catch (err) {
         if (showLoading) {
           setError(
@@ -53,7 +68,7 @@ export function useFileChanges(
         setLastUpdated(new Date());
       }
     },
-    [enabled, workingDirectory],
+    [enabled, workingDirectory, remoteWorkspace, machineId],
   );
 
   const refresh = useCallback(() => {

--- a/frontend/src/hooks/useRemoteVSCode.ts
+++ b/frontend/src/hooks/useRemoteVSCode.ts
@@ -96,6 +96,7 @@ export function useRemoteVSCode(): RemoteVSCodeState {
         console.warn("Failed to stop remote VSCode:", err);
       }
     }
+    if (!mountedRef.current) return;
     setIsRunning(false);
     setUrl(null);
     setError(null);

--- a/frontend/src/hooks/useRemoteVSCode.ts
+++ b/frontend/src/hooks/useRemoteVSCode.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef } from "react";
+import { useState, useCallback, useEffect, useRef } from "react";
 import {
   startRemoteVSCode,
   stopRemoteVSCode,
@@ -23,6 +23,15 @@ export function useRemoteVSCode(): RemoteVSCodeState {
   const [error, setError] = useState<string | null>(null);
   const [url, setUrl] = useState<string | null>(null);
   const vscodeIdRef = useRef<string | null>(null);
+  // Track whether the component is still mounted to avoid setState after unmount
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
 
   const start = useCallback(async (machineId: string, workingDirectory: string) => {
     setIsLoading(true);
@@ -40,12 +49,17 @@ export function useRemoteVSCode(): RemoteVSCodeState {
       // Poll status until code-server is ready
       const startTime = Date.now();
       while (Date.now() - startTime < STATUS_POLL_TIMEOUT) {
+        if (!mountedRef.current) return;
+
         const status = await getRemoteVSCodeStatus(result.vscode_id!);
 
+        if (!mountedRef.current) return;
+
         if (status.status === "running" && status.url) {
-          setIsRunning(true);
           // Build the full URL with the folder query param
-          const fullUrl = `${status.url}&folder=${encodeURIComponent(workingDirectory)}`;
+          const separator = status.url.includes("?") ? "&" : "?";
+          const fullUrl = `${status.url}${separator}folder=${encodeURIComponent(workingDirectory)}`;
+          setIsRunning(true);
           setUrl(fullUrl);
           setIsLoading(false);
           return;
@@ -61,13 +75,16 @@ export function useRemoteVSCode(): RemoteVSCodeState {
 
       throw new Error("VSCode startup timed out");
     } catch (err) {
+      if (!mountedRef.current) return;
       if (err instanceof DOMException && err.name === "AbortError") {
         setError("VSCode startup timed out");
       } else {
         setError(err instanceof Error ? err.message : "Failed to start VSCode");
       }
     } finally {
-      setIsLoading(false);
+      if (mountedRef.current) {
+        setIsLoading(false);
+      }
     }
   }, []);
 
@@ -75,8 +92,8 @@ export function useRemoteVSCode(): RemoteVSCodeState {
     if (vscodeIdRef.current) {
       try {
         await stopRemoteVSCode(vscodeIdRef.current, machineId);
-      } catch {
-        // Ignore errors on stop
+      } catch (err) {
+        console.warn("Failed to stop remote VSCode:", err);
       }
     }
     setIsRunning(false);

--- a/frontend/src/hooks/useRemoteVSCode.ts
+++ b/frontend/src/hooks/useRemoteVSCode.ts
@@ -1,0 +1,89 @@
+import { useState, useCallback, useRef } from "react";
+import {
+  startRemoteVSCode,
+  stopRemoteVSCode,
+  getRemoteVSCodeStatus,
+} from "../api/openace";
+
+interface RemoteVSCodeState {
+  isRunning: boolean;
+  isLoading: boolean;
+  error: string | null;
+  url: string | null;
+  start: (machineId: string, workingDirectory: string) => Promise<void>;
+  stop: (machineId: string) => Promise<void>;
+}
+
+const STATUS_POLL_INTERVAL = 2000;
+const STATUS_POLL_TIMEOUT = 60000; // 60s max wait for code-server to start
+
+export function useRemoteVSCode(): RemoteVSCodeState {
+  const [isRunning, setIsRunning] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [url, setUrl] = useState<string | null>(null);
+  const vscodeIdRef = useRef<string | null>(null);
+
+  const start = useCallback(async (machineId: string, workingDirectory: string) => {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const result = await startRemoteVSCode(machineId, workingDirectory);
+
+      if (!result.success || !result.vscode_id) {
+        throw new Error(result.error || "Failed to start VSCode");
+      }
+
+      vscodeIdRef.current = result.vscode_id;
+
+      // Poll status until code-server is ready
+      const startTime = Date.now();
+      while (Date.now() - startTime < STATUS_POLL_TIMEOUT) {
+        const status = await getRemoteVSCodeStatus(result.vscode_id!);
+
+        if (status.status === "running" && status.url) {
+          setIsRunning(true);
+          // Build the full URL with the folder query param
+          const fullUrl = `${status.url}&folder=${encodeURIComponent(workingDirectory)}`;
+          setUrl(fullUrl);
+          setIsLoading(false);
+          return;
+        }
+
+        if (status.status === "error") {
+          throw new Error(status.error || "VSCode failed to start");
+        }
+
+        // Wait before polling again
+        await new Promise((resolve) => setTimeout(resolve, STATUS_POLL_INTERVAL));
+      }
+
+      throw new Error("VSCode startup timed out");
+    } catch (err) {
+      if (err instanceof DOMException && err.name === "AbortError") {
+        setError("VSCode startup timed out");
+      } else {
+        setError(err instanceof Error ? err.message : "Failed to start VSCode");
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  const stop = useCallback(async (machineId: string) => {
+    if (vscodeIdRef.current) {
+      try {
+        await stopRemoteVSCode(vscodeIdRef.current, machineId);
+      } catch {
+        // Ignore errors on stop
+      }
+    }
+    setIsRunning(false);
+    setUrl(null);
+    setError(null);
+    vscodeIdRef.current = null;
+  }, []);
+
+  return { isRunning, isLoading, error, url, start, stop };
+}


### PR DESCRIPTION
## Summary

为 qwen-code-webui 添加远程工作区的文件变更面板和 VSCode 编辑器支持。

配合 open-ace PR: https://github.com/open-ace/open-ace/pull/611

## Changes
- 新增远程 git API 函数 (`fetchRemoteGitStatus/Diff/File`)
- 新增远程 VSCode API 函数 (`startRemoteVSCode/stop/getStatus`)
- 修改 `useFileChanges` hook 支持远程 git 状态轮询
- 新建 `useRemoteVSCode` hook 管理远程 code-server 生命周期
- 更新 `FileChangesPanel` 和 `FileDiffModal` 支持远程模式
- `ChatPage` 传递 `machineId` 给文件变更组件

## 非集成模式保护
所有改动由 `isRemoteWorkspace` (URL 参数 `workspaceType=remote`) 控制。非集成模式下该参数为 `false`，现有本地代码路径完全不受影响。