### PR TITLE
feat: improve file changes panel UI

### DIFF
--- a/frontend/src/components/ChatPage.tsx
+++ b/frontend/src/components/ChatPage.tsx
@@ -1600,7 +1600,6 @@ export function ChatPage() {
                 onClick={toggleExpandThinking}
               />
             )}
-            {!isHistoryView && <HistoryButton onClick={handleHistoryClick} />}
             {!isHistoryView && (
               <button
                 onClick={handleToggleFileChangesPanel}
@@ -1629,6 +1628,7 @@ export function ChatPage() {
                 />
               </button>
             )}
+            {!isHistoryView && <HistoryButton onClick={handleHistoryClick} />}
             <SettingsButton onClick={handleSettingsClick} />
           </div>
         </div>
@@ -1804,7 +1804,6 @@ export function ChatPage() {
                   <FileChangesPanel
                     workingDirectory={workingDirectory}
                     onOpenDiff={(file) => setSelectedDiffFile(file)}
-                    onClose={() => setFileChangesPanelVisible(false)}
                     onVSCodeOpenChange={setIsVSCodePanelOpen}
                     remoteWorkspace={isRemoteWorkspace}
                     machineId={remoteMachineId || undefined}

--- a/frontend/src/components/file-changes/FileChangesHeader.tsx
+++ b/frontend/src/components/file-changes/FileChangesHeader.tsx
@@ -2,7 +2,6 @@ import { useTranslation } from "react-i18next";
 import {
   CodeBracketSquareIcon,
   ArrowPathIcon,
-  XMarkIcon,
 } from "@heroicons/react/24/outline";
 
 interface FileChangesHeaderProps {
@@ -12,7 +11,6 @@ interface FileChangesHeaderProps {
   actionsDisabled?: boolean;
   onRefresh: () => void;
   onToggleVSCode: () => void;
-  onClose: () => void;
 }
 
 export function FileChangesHeader({
@@ -22,7 +20,6 @@ export function FileChangesHeader({
   actionsDisabled = false,
   onRefresh,
   onToggleVSCode,
-  onClose,
 }: FileChangesHeaderProps) {
   const { t } = useTranslation();
   const disabledTitle = t("fileChanges.remoteUnsupported");
@@ -58,21 +55,14 @@ export function FileChangesHeader({
         <button
           onClick={onToggleVSCode}
           disabled={actionsDisabled}
-          className={`p-1 rounded hover:bg-slate-100 dark:hover:bg-slate-700 ${
+          className={`p-1 rounded transition-all ${
             vscodeRunning
-              ? "text-blue-500 hover:text-blue-700 dark:text-blue-400"
-              : "text-slate-400 hover:text-slate-600 dark:hover:text-slate-300"
+              ? "bg-blue-500 dark:bg-blue-600 text-white shadow-sm"
+              : "hover:bg-slate-100 dark:hover:bg-slate-700 text-slate-400 hover:text-slate-600 dark:hover:text-slate-300"
           } disabled:opacity-50`}
           title={vscodeTitle}
         >
           <CodeBracketSquareIcon className="w-4 h-4" />
-        </button>
-        <button
-          onClick={onClose}
-          className="p-1 rounded hover:bg-slate-100 dark:hover:bg-slate-700 text-slate-400 hover:text-slate-600 dark:hover:text-slate-300"
-          title={t("chat.dismiss")}
-        >
-          <XMarkIcon className="w-4 h-4" />
         </button>
       </div>
     </div>

--- a/frontend/src/components/file-changes/FileChangesPanel.tsx
+++ b/frontend/src/components/file-changes/FileChangesPanel.tsx
@@ -1,5 +1,4 @@
 import { useState, useCallback, useEffect, useMemo } from "react";
-import { useTranslation } from "react-i18next";
 import { FileChangesHeader } from "./FileChangesHeader";
 import { FileChangesList } from "./FileChangesList";
 import { VSCodeEditor } from "./VSCodeEditor";
@@ -11,7 +10,6 @@ import type { FileChange } from "../../types/fileChanges";
 interface FileChangesPanelProps {
   workingDirectory: string | undefined;
   onOpenDiff: (file: FileChange) => void;
-  onClose: () => void;
   onVSCodeOpenChange?: (isOpen: boolean) => void;
   remoteWorkspace?: boolean;
   machineId?: string;
@@ -20,12 +18,10 @@ interface FileChangesPanelProps {
 export function FileChangesPanel({
   workingDirectory,
   onOpenDiff,
-  onClose,
   onVSCodeOpenChange,
   remoteWorkspace = false,
   machineId,
 }: FileChangesPanelProps) {
-  const { t } = useTranslation();
   const { files, isLoading, error, refresh } = useFileChanges(
     workingDirectory,
     true,
@@ -86,7 +82,6 @@ export function FileChangesPanel({
         vscodeRunning={showVSCode && activeVSCode.isRunning}
         onRefresh={refresh}
         onToggleVSCode={handleToggleVSCode}
-        onClose={onClose}
       />
       {showVSCode ? (
         <VSCodeEditor


### PR DESCRIPTION
## Summary

改进文件变更面板的 UI 体验。

## Changes

- **移除关闭按钮**：FileChangesPanel 头部不再显示关闭按钮，面板显示/隐藏由顶部工具栏按钮控制
- **VSCode 开关状态区分**：开启时显示蓝色背景 + 白色图标 + 阴影效果，关闭时灰色图标 + 透明背景
- **按钮顺序调整**：文件变更按钮移至历史按钮左侧，工具栏顺序为 `[项目] → [WebUI] → [思考] → [文件变更] → [历史] → [设置]`

## Screenshots

| 修改前 | 修改后 |
|--------|--------|
| 头部有关闭按钮 | 头部无关闭按钮，更简洁 |
| VSCode 开关颜色区分不明显 | 开启时有明显蓝色背景高亮 |
| 文件按钮在历史按钮右侧 | 文件按钮在历史按钮左侧 |