### PR TITLE
fix: 远程工作区切换项目时发送消息给父窗口而非直接导航 (#161)

### DIFF
--- a/frontend/src/components/ChatPage.tsx
+++ b/frontend/src/components/ChatPage.tsx
@@ -431,8 +431,24 @@ export function ChatPage() {
   }, [navigate]);
 
   const handleBackToProjects = useCallback(() => {
-    navigate("/");
-  }, [navigate]);
+    const workspaceType = searchParams.get("workspaceType");
+    const machineId = searchParams.get("machineId");
+
+    // 如果在 iframe 中且是远程工作区，发送消息给父窗口
+    if (window.parent !== window && workspaceType === "remote") {
+      window.parent.postMessage(
+        {
+          type: "qwen-code-switch-project-request",
+          workspaceType: workspaceType,
+          machineId: machineId || undefined,
+        },
+        "*",
+      );
+    } else {
+      // 本地工作区或独立模式，直接导航
+      navigate("/");
+    }
+  }, [navigate, searchParams]);
 
   // Handle global keyboard shortcuts
   useEffect(() => {


### PR DESCRIPTION
## 问题描述

在远程工作区的 iframe 中点击【切换项目】按钮后，当前实现直接调用 `navigate("/")` 导航回本地项目选择器，显示的是本地工作区的项目列表，而非远程机器的项目列表。

## 根本原因

qwen-code-webui 作为 iframe 嵌入到 Open-ACE 远程工作区时，点击切换项目按钮会直接导航到本地项目选择页面，而不是通知父窗口（Open-ACE）来处理项目切换。

Open-ACE 端已实现消息接收逻辑（PR #592 / Issue #229），监听 `qwen-code-switch-project-request` 消息，但 qwen-code-webui 端未发送此消息。

## 修复方案

修改 `handleBackToProjects` 函数：
1. 从 URL 参数获取 `workspaceType` 和 `machineId`
2. 检测是否在 iframe 中运行（`window.parent !== window`）
3. 如果是远程工作区（`workspaceType === 'remote'`），发送 `qwen-code-switch-project-request` 消息给父窗口
4. 否则保持原有本地导航行为

## 修改文件

- `frontend/src/components/ChatPage.tsx`

## 验证结果

构建产物中已确认包含修复代码：
- 消息类型 `qwen-code-switch-project-request` ✓
- 条件检查 `workspaceType === 'remote' && window.parent !== window` ✓
- 发送 `postMessage` ✓

## 关联 Issue

Fixes #161

🤖 Generated with Qwen Code (2-shotted by Qwen-Coder)