### PR TITLE
Fix Stop abort flow for lingering CLI sessions

### DIFF
--- a/backend/app.ts
+++ b/backend/app.ts
@@ -30,6 +30,7 @@ import {
 } from "./handlers/quota.ts";
 import { logger } from "./utils/logger.ts";
 import { readBinaryFile } from "./utils/fs.ts";
+import { abortAllTrackedCliRequests } from "./utils/cliProcessRegistry.ts";
 import { handleDeleteProjectRequest } from "./handlers/projects.ts";
 import {
   handleGitStatusRequest,
@@ -80,6 +81,7 @@ export function createApp(
     for (const [, ac] of requestAbortControllers) {
       ac.abort();
     }
+    abortAllTrackedCliRequests();
     requestAbortControllers.clear();
     for (const [, pending] of pendingPermissions) {
       pending.resolve({ behavior: "deny", message: "Server shutting down" });

--- a/backend/handlers/abort.test.ts
+++ b/backend/handlers/abort.test.ts
@@ -35,12 +35,16 @@ describe("handleAbortRequest", () => {
     const ctx = createMockContext("req-1");
     const abortController = new AbortController();
     requestAbortControllers.set("req-1", abortController);
+    const spy = vi.spyOn(abortController, "abort");
 
     handleAbortRequest(ctx, requestAbortControllers);
 
+    expect(signalTrackedCliAbort).toHaveBeenCalledWith("req-1", "user");
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(signalTrackedCliAbort).mock.invocationCallOrder[0])
+      .toBeLessThan(spy.mock.invocationCallOrder[0]);
     expect(abortController.signal.aborted).toBe(true);
     expect(requestAbortControllers.has("req-1")).toBe(true);
-    expect(signalTrackedCliAbort).toHaveBeenCalledWith("req-1", "user");
     expect(ctx.json).toHaveBeenCalledWith({ success: true, message: "Request aborted" });
   });
 

--- a/backend/handlers/abort.test.ts
+++ b/backend/handlers/abort.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { handleAbortRequest } from "./abort.ts";
+import { signalTrackedCliAbort } from "../utils/cliProcessRegistry.ts";
+
+vi.mock("../utils/logger.ts", () => ({
+  logger: {
+    api: {
+      debug: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("../utils/cliProcessRegistry.ts", () => ({
+  signalTrackedCliAbort: vi.fn(),
+}));
+
+function createMockContext(requestId: string | undefined) {
+  return {
+    req: {
+      param: vi.fn().mockReturnValue(requestId),
+    },
+    json: vi.fn().mockImplementation((data, status?: number) => ({ data, status })),
+  } as unknown as Parameters<typeof handleAbortRequest>[0];
+}
+
+describe("handleAbortRequest", () => {
+  let requestAbortControllers: Map<string, AbortController>;
+
+  beforeEach(() => {
+    requestAbortControllers = new Map();
+    vi.clearAllMocks();
+  });
+
+  it("aborts the request without eagerly deleting controller state", () => {
+    const ctx = createMockContext("req-1");
+    const abortController = new AbortController();
+    requestAbortControllers.set("req-1", abortController);
+
+    handleAbortRequest(ctx, requestAbortControllers);
+
+    expect(abortController.signal.aborted).toBe(true);
+    expect(requestAbortControllers.has("req-1")).toBe(true);
+    expect(signalTrackedCliAbort).toHaveBeenCalledWith("req-1", "user");
+    expect(ctx.json).toHaveBeenCalledWith({ success: true, message: "Request aborted" });
+  });
+
+  it("returns 404 for unknown requests", () => {
+    const ctx = createMockContext("missing");
+
+    handleAbortRequest(ctx, requestAbortControllers);
+
+    expect(ctx.json).toHaveBeenCalledWith(
+      { error: "Request not found or already completed" },
+      404,
+    );
+  });
+});

--- a/backend/handlers/abort.ts
+++ b/backend/handlers/abort.ts
@@ -1,5 +1,6 @@
 import { Context } from "hono";
 import { logger } from "../utils/logger.ts";
+import { signalTrackedCliAbort } from "../utils/cliProcessRegistry.ts";
 
 /**
  * Handles POST /api/abort/:requestId requests
@@ -26,7 +27,7 @@ export function handleAbortRequest(
   const abortController = requestAbortControllers.get(requestId);
   if (abortController) {
     abortController.abort();
-    requestAbortControllers.delete(requestId);
+    signalTrackedCliAbort(requestId, "user");
 
     logger.api.debug(`Aborted request: ${requestId}`);
 

--- a/backend/handlers/abort.ts
+++ b/backend/handlers/abort.ts
@@ -26,8 +26,8 @@ export function handleAbortRequest(
 
   const abortController = requestAbortControllers.get(requestId);
   if (abortController) {
-    abortController.abort();
     signalTrackedCliAbort(requestId, "user");
+    abortController.abort();
 
     logger.api.debug(`Aborted request: ${requestId}`);
 

--- a/backend/handlers/chat.test.ts
+++ b/backend/handlers/chat.test.ts
@@ -2,19 +2,11 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { Context } from "hono";
 import { handleChatRequest } from "./chat";
 import type { ChatRequest } from "../../shared/types";
-import { query } from "@qwen-code/sdk";
+const mockQuery = vi.fn();
 
-// Define minimal mock types for Qwen Code SDK to maintain type safety in tests
-type MockQwenCode = {
-  query: typeof vi.fn;
-};
-
-vi.mock(
-  "@qwen-code/sdk",
-  (): MockQwenCode => ({
-    query: vi.fn(),
-  }),
-);
+vi.mock("../utils/qwenSdk.ts", () => ({
+  loadQwenQuery: vi.fn(async () => mockQuery),
+}));
 
 // Mock logger
 vi.mock("../utils/logger", () => ({
@@ -34,8 +26,6 @@ vi.mock("../utils/sessionBridge.ts", () => ({
     Promise.resolve(sessionId),
   ),
 }));
-
-const mockQuery = vi.mocked(query);
 
 describe("Chat Handler - Permission Mode Tests", () => {
   let mockContext: Context;
@@ -500,10 +490,7 @@ describe("Chat Handler - Permission Mode Tests", () => {
       expect(doneResponse).toEqual({ type: "done" });
     });
 
-    // TODO: Re-enable when AbortError is properly exported from Claude SDK
-    it.skip("should handle abort errors when using permissionMode", async () => {
-      // Test currently skipped because AbortError is not exported from Claude SDK
-      // When AbortError becomes available, update this test accordingly
+    it("should emit aborted messages when the SDK aborts", async () => {
       const chatRequest: ChatRequest = {
         message: "Abort test",
         requestId: "test-abort",
@@ -538,13 +525,12 @@ describe("Chat Handler - Permission Mode Tests", () => {
       }
 
       const lines = allChunks.trim().split("\n");
-      expect(lines).toHaveLength(1);
+      expect(lines).toHaveLength(2);
 
-      const errorResponse = JSON.parse(lines[0]);
-      expect(errorResponse).toEqual({
-        type: "error",
-        error: "Operation aborted",
-      });
+      const abortedResponse = JSON.parse(lines[0]);
+      const doneResponse = JSON.parse(lines[1]);
+      expect(abortedResponse).toEqual({ type: "aborted" });
+      expect(doneResponse).toEqual({ type: "done" });
     });
   });
 

--- a/backend/handlers/chat.ts
+++ b/backend/handlers/chat.ts
@@ -1,9 +1,17 @@
 import { Context } from "hono";
-import { query, type PermissionMode, type AuthType, type PermissionResult } from "@qwen-code/sdk";
+import type { PermissionMode, AuthType, PermissionResult } from "@qwen-code/sdk";
 import type { ChatRequest, StreamResponse } from "../../shared/types.ts";
 import { logger } from "../utils/logger.ts";
 import { checkLoop, type LoopState } from "../utils/loopDetector.ts";
 import { bridgeSession } from "../utils/sessionBridge.ts";
+import {
+  finalizeTrackedCliRequest,
+  registerTrackedCliRequest,
+  runWithTrackedCliRequest,
+  signalTrackedCliAbort,
+  updateTrackedCliSessionId,
+} from "../utils/cliProcessRegistry.ts";
+import { loadQwenQuery } from "../utils/qwenSdk.ts";
 import type { PendingPermission } from "./permission.ts";
 import type { ServerResponse } from "node:http";
 
@@ -47,6 +55,16 @@ const CLI_CONTROL_REQUEST_TIMEOUT_MS = 30_000;
 const AUTO_APPROVE_MS = CLI_CONTROL_REQUEST_TIMEOUT_MS - 5_000; // 25 s
 /** Backend fallback — fires a few seconds after frontend should have acted. */
 const SAFETY_AUTO_APPROVE_MS = CLI_CONTROL_REQUEST_TIMEOUT_MS - 2_000; // 28 s
+
+function isAbortLikeError(error: unknown): boolean {
+  if (error instanceof DOMException && error.name === "AbortError") {
+    return true;
+  }
+  if (!(error instanceof Error)) {
+    return false;
+  }
+  return error.name === "AbortError" || error.message === "Operation aborted";
+}
 
 /**
  * Maps UI permission mode to Qwen SDK permission mode
@@ -102,7 +120,8 @@ async function executeQwenCommand(
   model?: string,
   authType?: AuthType,
 ): Promise<void> {
-  let abortController: AbortController;
+  let abortController: AbortController | undefined;
+  let onAbort: (() => void) | undefined;
   const localPendingIds = new Set<string>();
   // Read-only tools approved by the user during this request — auto-approved on
   // subsequent calls within the same streaming session. Scope is limited to a
@@ -128,6 +147,13 @@ async function executeQwenCommand(
     // Create and store AbortController for this request
     abortController = new AbortController();
     requestAbortControllers.set(requestId, abortController);
+    registerTrackedCliRequest(requestId, { sessionId, cliPath });
+    const query = await loadQwenQuery();
+
+    onAbort = () => {
+      signalTrackedCliAbort(requestId, "internal_abort");
+    };
+    abortController.signal.addEventListener("abort", onAbort, { once: true });
 
     // Log permission mode for debugging
     const mappedPermissionMode = permissionMode ? mapPermissionMode(permissionMode) : undefined;
@@ -162,7 +188,7 @@ async function executeQwenCommand(
       _options: { signal: AbortSignal; suggestions?: unknown[] | null },
     ): Promise<PermissionResult> => {
       // Defense 1: check main query abort (not SDK's per-request signal)
-      if (abortController.signal.aborted) {
+      if (abortController!.signal.aborted) {
         return { behavior: "deny", message: "Request aborted" };
       }
 
@@ -262,10 +288,10 @@ async function executeQwenCommand(
             Array.isArray(q.options) &&
             q.options.length >= 2 &&
             q.options.length <= 4 &&
-            q.options.every((o) =>
+            q.options.every((o: unknown) =>
               typeof o === "object" &&
               o !== null &&
-              typeof o.label === "string"
+              typeof (o as { label?: unknown }).label === "string"
             ) &&
             typeof q.multiSelect === "boolean"
           )
@@ -273,7 +299,7 @@ async function executeQwenCommand(
           questions = rawQuestions.map((q) => ({
             question: String(q.question),
             header: String(q.header).substring(0, 12), // Limit header to 12 chars
-            options: q.options.map((o) => ({
+            options: q.options.map((o: { label: string; description?: string }) => ({
               label: String(o.label),
               description: o.description ? String(o.description) : undefined,
             })),
@@ -335,12 +361,12 @@ async function executeQwenCommand(
           localPendingIds.delete(permissionId);
           safeResolve({ behavior: "deny", message: "Request aborted" });
         };
-        abortController.signal.addEventListener("abort", onAbort, { once: true });
+        abortController!.signal.addEventListener("abort", onAbort, { once: true });
 
         pendingPermissions.set(permissionId, {
           resolve: (result, scope) => {
             clearTimeout(safetyTimer);
-            abortController.signal.removeEventListener("abort", onAbort);
+            abortController!.signal.removeEventListener("abort", onAbort);
             localPendingIds.delete(permissionId);
             if (result.behavior === "allow") {
               if (scope === "specific" && toolName === "run_shell_command" && input?.command && typeof input.command === "string") {
@@ -352,73 +378,79 @@ async function executeQwenCommand(
             }
             safeResolve(result);
           },
-          abortSignal: abortController.signal,
+          abortSignal: abortController!.signal,
         });
       });
     };
 
-    for await (const sdkMessage of query({
-      prompt: processedMessage,
-      options: {
-        abortController,
-        pathToQwenExecutable: cliPath,
-        ...(sessionId ? { resume: sessionId } : {}),
-        ...(allowedTools ? { allowedTools } : {}),
-        ...(workingDirectory ? { cwd: workingDirectory } : {}),
-        ...(mappedPermissionMode ? { permissionMode: mappedPermissionMode } : {}),
-        ...(model ? { model } : {}),
-        ...(authType ? { authType } : {}),
-        stderr: (message: string) => {
-          logger.chat.info("CLI stderr: {message}", { message });
+    await runWithTrackedCliRequest(requestId, async () => {
+      for await (const sdkMessage of query({
+        prompt: processedMessage,
+        options: {
+          abortController: abortController!,
+          pathToQwenExecutable: cliPath,
+          ...(sessionId ? { resume: sessionId } : {}),
+          ...(allowedTools ? { allowedTools } : {}),
+          ...(workingDirectory ? { cwd: workingDirectory } : {}),
+          ...(mappedPermissionMode ? { permissionMode: mappedPermissionMode } : {}),
+          ...(model ? { model } : {}),
+          ...(authType ? { authType } : {}),
+          stderr: (message: string) => {
+            logger.chat.info("CLI stderr: {message}", { message });
+          },
+          canUseTool,
+          timeout: { canUseTool: SESSION_TIMEOUT_MS, controlRequest: SESSION_TIMEOUT_MS },
         },
-        canUseTool,
-        timeout: { canUseTool: SESSION_TIMEOUT_MS, controlRequest: SESSION_TIMEOUT_MS },
-      },
-    })) {
-      messageCount++;
-      if (firstMessageLatencyMs === null) {
-        firstMessageLatencyMs = Date.now() - startTime;
-        logger.chat.info(
-          "[DIAG] First SDK message received requestId={requestId} latencyMs={latencyMs}",
-          { requestId, latencyMs: firstMessageLatencyMs },
-        );
-      }
+      })) {
+        messageCount++;
+        if (firstMessageLatencyMs === null) {
+          firstMessageLatencyMs = Date.now() - startTime;
+          logger.chat.info(
+            "[DIAG] First SDK message received requestId={requestId} latencyMs={latencyMs}",
+            { requestId, latencyMs: firstMessageLatencyMs },
+          );
+        }
+        const sdkSessionId = (sdkMessage as Record<string, unknown>).session_id;
+        if (typeof sdkSessionId === "string") {
+          updateTrackedCliSessionId(requestId, sdkSessionId);
+        }
 
-      // Backend loop detection — failsafe if frontend detection fails.
-      // Each agent (main session or fork) maintains its own LoopState
-      // so parallel fork agents don't accumulate toward the same counter (#140).
-      const rawForkId = (sdkMessage as Record<string, unknown>).parent_tool_use_id;
-      const forkId = typeof rawForkId === "string" ? rawForkId : undefined;
-      const ls = forkId
-        ? (agentLoopStates.get(forkId) ?? { errorCount: 0, lastFingerprint: "", firstErrorTime: 0 })
-        : loopState;
-      if (forkId && !agentLoopStates.has(forkId)) {
-        agentLoopStates.set(forkId, ls);
-      }
-      const loopResult = checkLoop(sdkMessage, ls);
-      if (loopResult) {
-        logger.chat.error(
-          "Loop detected: fingerprint={fingerprint}, count={count}, aborting CLI",
-          { fingerprint: loopResult.fingerprint, count: loopResult.count },
-        );
-        abortController.abort();
-        const errorMessage = loopResult.fingerprint === "input_closed"
-          ? "CLI session ended unexpectedly. Please send a new message."
-          : `Auto-aborted: loop detected (${loopResult.fingerprint}, ${loopResult.count}x)`;
+        // Backend loop detection — failsafe if frontend detection fails.
+        // Each agent (main session or fork) maintains its own LoopState
+        // so parallel fork agents don't accumulate toward the same counter (#140).
+        const rawForkId = (sdkMessage as Record<string, unknown>).parent_tool_use_id;
+        const forkId = typeof rawForkId === "string" ? rawForkId : undefined;
+        const ls = forkId
+          ? (agentLoopStates.get(forkId) ?? { errorCount: 0, lastFingerprint: "", firstErrorTime: 0 })
+          : loopState;
+        if (forkId && !agentLoopStates.has(forkId)) {
+          agentLoopStates.set(forkId, ls);
+        }
+        const loopResult = checkLoop(sdkMessage, ls);
+        if (loopResult) {
+          logger.chat.error(
+            "Loop detected: fingerprint={fingerprint}, count={count}, aborting CLI",
+            { fingerprint: loopResult.fingerprint, count: loopResult.count },
+          );
+          abortController!.abort();
+          const errorMessage = loopResult.fingerprint === "input_closed"
+            ? "CLI session ended unexpectedly. Please send a new message."
+            : `Auto-aborted: loop detected (${loopResult.fingerprint}, ${loopResult.count}x)`;
+          if (!enqueue({
+            type: "error",
+            error: errorMessage,
+          })) break;
+          break;
+        }
+
+        logger.chat.debug("Qwen SDK Message: {sdkMessage}", { sdkMessage });
+
         if (!enqueue({
-          type: "error",
-          error: errorMessage,
+          type: "claude_json",
+          data: sdkMessage,
         })) break;
-        break;
       }
-
-      logger.chat.debug("Qwen SDK Message: {sdkMessage}", { sdkMessage });
-
-      if (!enqueue({
-        type: "claude_json",
-        data: sdkMessage,
-      })) break;
-    }
+    });
 
     if (!enqueue({ type: "done" })) return;
 
@@ -433,6 +465,11 @@ async function executeQwenCommand(
       },
     );
   } catch (error) {
+    if (abortController?.signal.aborted || isAbortLikeError(error)) {
+      enqueue({ type: "aborted" });
+      enqueue({ type: "done" });
+      return;
+    }
     logger.chat.error(
       "[DIAG] Chat request ERROR requestId={requestId} durationMs={durationMs} "
       + "messageCount={messageCount} error={error}",
@@ -450,12 +487,16 @@ async function executeQwenCommand(
     enqueue({ type: "done" });
   } finally {
     _activeChatCount--;
+    if (abortController && onAbort) {
+      abortController.signal.removeEventListener("abort", onAbort);
+    }
     // Ensure CLI subprocess is killed on any exit path (issue #84)
     const ac = requestAbortControllers.get(requestId);
     if (ac) {
       ac.abort();
       requestAbortControllers.delete(requestId);
     }
+    finalizeTrackedCliRequest(requestId);
     // Clean up session mapping so a new request can start for this session
     if (sessionId && activeSessions.get(sessionId) === requestId) {
       activeSessions.delete(sessionId);

--- a/backend/package.json
+++ b/backend/package.json
@@ -45,6 +45,7 @@
     "build:static": "node scripts/copy-frontend.js",
     "start": "node dist/cli/node.js",
     "test": "vitest --run --reporter=verbose",
+    "test:integration:stop-abort": "node scripts/verify-stop-abort.js",
     "lint": "eslint \"**/*.ts\" --ignore-pattern dist/",
     "format": "prettier --write \"**/*.ts\"",
     "format:check": "prettier --check \"**/*.ts\"",

--- a/backend/scripts/verify-stop-abort.js
+++ b/backend/scripts/verify-stop-abort.js
@@ -1,0 +1,232 @@
+#!/usr/bin/env node
+
+import { spawn, execFileSync } from "node:child_process";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const backendRoot = resolve(__dirname, "..");
+const fakeCliPath = resolve(backendRoot, "test-fixtures/fake-qwen-cli.mjs");
+
+function sleep(ms) {
+  return new Promise((resolvePromise) => setTimeout(resolvePromise, ms));
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function countTraceLines(traceFile) {
+  if (!existsSync(traceFile)) return 0;
+  const content = readFileSync(traceFile, "utf8").trim();
+  if (!content) return 0;
+  return content.split("\n").length;
+}
+
+function findFakeCliProcesses(sessionId) {
+  const output = execFileSync("ps", ["-Ao", "pid=,command="], {
+    encoding: "utf8",
+  });
+
+  return output
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const match = line.match(/^(\d+)\s+(.*)$/);
+      if (!match) return null;
+      return { pid: Number(match[1]), command: match[2] };
+    })
+    .filter((entry) => entry !== null)
+    .filter((entry) =>
+      entry.command.includes(fakeCliPath)
+      && entry.command.includes(`--session-id ${sessionId}`)
+    );
+}
+
+async function waitForServer(port, backendProcess) {
+  const deadline = Date.now() + 20_000;
+  while (Date.now() < deadline) {
+    if (backendProcess.exitCode !== null) {
+      throw new Error(`Backend exited early with code ${backendProcess.exitCode}`);
+    }
+
+    try {
+      const response = await fetch(`http://127.0.0.1:${port}/api/version`);
+      if (response.ok) return;
+    } catch {
+      // Keep polling until the server is reachable.
+    }
+
+    await sleep(250);
+  }
+
+  throw new Error("Timed out waiting for backend server to start");
+}
+
+async function terminateBackend(processHandle) {
+  if (processHandle.exitCode !== null) return;
+
+  processHandle.kill("SIGINT");
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    if (processHandle.exitCode !== null) return;
+    await sleep(100);
+  }
+
+  processHandle.kill("SIGKILL");
+}
+
+async function main() {
+  const tempDir = mkdtempSync(join(tmpdir(), "qwen-stop-abort-"));
+  const traceFile = join(tempDir, "trace.log");
+  writeFileSync(traceFile, "");
+
+  const port = 3200 + Math.floor(Math.random() * 500);
+  const requestId = `verify-stop-${Date.now()}`;
+  let backendProcess = null;
+
+  try {
+    backendProcess = spawn(
+      "./node_modules/.bin/tsx",
+      [
+        "cli/node.ts",
+        "--debug",
+        "--port",
+        String(port),
+        "--host",
+        "127.0.0.1",
+        "--qwen-path",
+        fakeCliPath,
+      ],
+      {
+        cwd: backendRoot,
+        env: {
+          ...process.env,
+          FAKE_QWEN_TRACE_FILE: traceFile,
+        },
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+
+    let backendStdout = "";
+    let backendStderr = "";
+    backendProcess.stdout.on("data", (chunk) => {
+      backendStdout += chunk.toString();
+    });
+    backendProcess.stderr.on("data", (chunk) => {
+      backendStderr += chunk.toString();
+    });
+
+    await waitForServer(port, backendProcess);
+
+    const response = await fetch(`http://127.0.0.1:${port}/api/chat`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        message: "verify stop behavior",
+        requestId,
+        permissionMode: "default",
+      }),
+    });
+
+    assert(response.ok, `Chat request failed with ${response.status}`);
+    assert(response.body, "Chat response did not include a body");
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let lineBuffer = "";
+    let abortSent = false;
+    let sawAborted = false;
+    let sawDone = false;
+    let sessionId = null;
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      lineBuffer += decoder.decode(value, { stream: true });
+      const lines = lineBuffer.split("\n");
+      lineBuffer = lines.pop() || "";
+
+      for (const line of lines) {
+        if (!line.trim()) continue;
+        const message = JSON.parse(line);
+
+        if (message.type === "claude_json" && message.data?.session_id) {
+          sessionId = message.data.session_id;
+          if (!abortSent) {
+            await sleep(1_000);
+            const linesBeforeAbort = countTraceLines(traceFile);
+            assert(linesBeforeAbort > 0, "Fake CLI never started writing to the trace file");
+
+            const cliProcesses = findFakeCliProcesses(sessionId);
+            assert(cliProcesses.length > 0, "Fake CLI process was not running before abort");
+
+            const abortResponse = await fetch(
+              `http://127.0.0.1:${port}/api/abort/${requestId}`,
+              {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+              },
+            );
+            assert(abortResponse.ok, `Abort request failed with ${abortResponse.status}`);
+            abortSent = true;
+          }
+        } else if (message.type === "aborted") {
+          sawAborted = true;
+        } else if (message.type === "done") {
+          sawDone = true;
+        }
+      }
+    }
+
+    assert(abortSent, "Abort endpoint was never triggered during the integration run");
+    assert(sessionId, "Did not observe a CLI session id in the stream");
+    assert(sawAborted, "Stream did not emit an aborted terminal message");
+    assert(sawDone, "Stream did not emit a done terminal message");
+
+    await sleep(6_500);
+    const traceAfterAbort = countTraceLines(traceFile);
+    await sleep(2_000);
+    const traceStableCheck = countTraceLines(traceFile);
+
+    assert(
+      traceAfterAbort === traceStableCheck,
+      `Trace file kept growing after abort (${traceAfterAbort} -> ${traceStableCheck})`,
+    );
+    assert(
+      findFakeCliProcesses(sessionId).length === 0,
+      "Fake CLI process still exists after watchdog escalation window",
+    );
+
+    console.log("Stop abort integration verification passed.");
+  } catch (error) {
+    console.error("Stop abort integration verification failed.");
+    if (backendProcess) {
+      console.error("Backend exit code:", backendProcess.exitCode);
+    }
+    throw error;
+  } finally {
+    if (backendProcess) {
+      await terminateBackend(backendProcess);
+    }
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/backend/test-fixtures/fake-qwen-cli.mjs
+++ b/backend/test-fixtures/fake-qwen-cli.mjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+
+const args = process.argv.slice(2);
+
+if (args.includes("--version")) {
+  console.log("fake-qwen-cli 0.0.1");
+  process.exit(0);
+}
+
+process.on("SIGTERM", () => {
+  // Intentionally ignore SIGTERM so the WebUI watchdog must escalate to SIGKILL.
+  fs.appendFileSync(process.env.FAKE_QWEN_TRACE_FILE, `sigterm:${Date.now()}\n`);
+});
+
+const traceFile = process.env.FAKE_QWEN_TRACE_FILE;
+let sessionId = "fake-session";
+let writer = null;
+
+function send(message) {
+  process.stdout.write(`${JSON.stringify(message)}\n`);
+}
+
+function startWriter() {
+  if (writer) return;
+  writer = setInterval(() => {
+    fs.appendFileSync(traceFile, `tick:${Date.now()}\n`);
+  }, 250);
+}
+
+const chunks = [];
+
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => {
+  chunks.push(chunk);
+  const content = chunks.join("");
+  const lines = content.split("\n");
+  chunks.length = 0;
+  chunks.push(lines.pop() || "");
+
+  for (const line of lines) {
+    if (!line.trim()) continue;
+    const message = JSON.parse(line);
+
+    if (message.type === "control_request") {
+      send({
+        type: "control_response",
+        response: {
+          subtype: "success",
+          request_id: message.request_id,
+          response: {},
+        },
+      });
+      continue;
+    }
+
+    if (message.type === "user") {
+      sessionId = message.session_id || sessionId;
+      send({
+        type: "assistant",
+        uuid: "fake-assistant-1",
+        session_id: sessionId,
+        parent_tool_use_id: null,
+        message: {
+          content: [
+            {
+              type: "text",
+              text: "fake cli working",
+            },
+          ],
+        },
+      });
+      startWriter();
+    }
+  }
+});
+
+process.stdin.on("end", () => {
+  // Keep running even after stdin closes so abort verification can confirm
+  // that the WebUI forcibly reaps the CLI process.
+});

--- a/backend/utils/cliProcessRegistry.test.ts
+++ b/backend/utils/cliProcessRegistry.test.ts
@@ -1,0 +1,98 @@
+import { EventEmitter } from "node:events";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  __cliProcessRegistryTestUtils,
+  finalizeTrackedCliRequest,
+  registerTrackedCliRequest,
+  signalTrackedCliAbort,
+} from "./cliProcessRegistry.ts";
+
+vi.mock("./logger.ts", () => ({
+  logger: {
+    chat: {
+      debug: vi.fn(),
+      error: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+    },
+  },
+}));
+
+class FakeChildProcess extends EventEmitter {
+  pid: number;
+  exitCode: number | null = null;
+  signalCode: NodeJS.Signals | null = null;
+
+  constructor(pid: number) {
+    super();
+    this.pid = pid;
+  }
+}
+
+describe("cliProcessRegistry", () => {
+  let alivePids: Set<number>;
+  let killSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    alivePids = new Set<number>();
+    __cliProcessRegistryTestUtils.reset();
+
+    killSpy = vi.spyOn(process, "kill").mockImplementation(((pid: number, signal?: number | NodeJS.Signals) => {
+      if (signal === 0 || signal === undefined) {
+        if (!alivePids.has(pid)) {
+          throw new Error(`process ${pid} missing`);
+        }
+        return true;
+      }
+
+      if (!alivePids.has(pid)) {
+        throw new Error(`process ${pid} missing`);
+      }
+
+      if (signal === "SIGKILL") {
+        alivePids.delete(pid);
+      }
+      return true;
+    }) as typeof process.kill);
+  });
+
+  afterEach(() => {
+    killSpy.mockRestore();
+    vi.useRealTimers();
+    __cliProcessRegistryTestUtils.reset();
+  });
+
+  it("escalates to SIGKILL when a tracked CLI survives SIGTERM", () => {
+    registerTrackedCliRequest("req-1", { sessionId: "session-1" });
+
+    const child = new FakeChildProcess(4242);
+    alivePids.add(child.pid);
+    __cliProcessRegistryTestUtils.attachChildToRequest("req-1", child as unknown as import("node:child_process").ChildProcess);
+
+    signalTrackedCliAbort("req-1", "user");
+
+    expect(killSpy).toHaveBeenCalledWith(4242, "SIGTERM");
+
+    vi.advanceTimersByTime(5_000);
+
+    expect(killSpy).toHaveBeenCalledWith(4242, "SIGKILL");
+  });
+
+  it("clears abort timers when the tracked CLI exits before escalation", () => {
+    registerTrackedCliRequest("req-2");
+
+    const child = new FakeChildProcess(5252);
+    alivePids.add(child.pid);
+    __cliProcessRegistryTestUtils.attachChildToRequest("req-2", child as unknown as import("node:child_process").ChildProcess);
+
+    signalTrackedCliAbort("req-2", "user");
+    alivePids.delete(child.pid);
+    child.emit("close");
+
+    vi.advanceTimersByTime(5_000);
+
+    expect(killSpy).toHaveBeenCalledTimes(1);
+    finalizeTrackedCliRequest("req-2");
+  });
+});

--- a/backend/utils/cliProcessRegistry.ts
+++ b/backend/utils/cliProcessRegistry.ts
@@ -1,0 +1,309 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import type { ChildProcess } from "node:child_process";
+import { createRequire } from "node:module";
+import { logger } from "./logger.ts";
+
+const require = createRequire(import.meta.url);
+const childProcess = require("node:child_process") as typeof import("node:child_process");
+
+type AbortSource =
+  | "user"
+  | "stream_disconnect"
+  | "request_superseded"
+  | "server_shutdown"
+  | "internal_abort";
+
+interface TrackedRequest {
+  requestId: string;
+  sessionId?: string;
+  cliPath?: string;
+  children: Map<number, ChildProcess>;
+  abortSource?: AbortSource;
+  forceKillTimer?: ReturnType<typeof setTimeout>;
+  requestEnded?: boolean;
+}
+
+const FORCE_KILL_AFTER_MS = 5_000;
+const trackedRequests = new Map<string, TrackedRequest>();
+const requestContext = new AsyncLocalStorage<{ requestId: string }>();
+
+let patchInstalled = false;
+let originalSpawn = childProcess.spawn;
+let originalFork = childProcess.fork;
+
+function isSdkCliSpawn(command: string, args: readonly string[]): boolean {
+  return (
+    args.includes("--channel=SDK")
+    && args.includes("--input-format")
+    && args.includes("stream-json")
+    && args.includes("--output-format")
+  );
+}
+
+function isSdkCliFork(modulePath: string, args: readonly string[]): boolean {
+  return modulePath.includes("cli.js") && args.includes("--channel=SDK");
+}
+
+function isPidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function findSessionCliPids(sessionId: string, cliPath?: string): number[] {
+  try {
+    const output = childProcess.execFileSync(
+      "ps",
+      ["-Ao", "pid=,command="],
+      { encoding: "utf8" },
+    );
+    const matches = output
+      .split("\n")
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map((line) => {
+        const match = line.match(/^(\d+)\s+(.*)$/);
+        if (!match) return null;
+        return { pid: Number(match[1]), command: match[2] };
+      })
+      .filter((entry): entry is { pid: number; command: string } => !!entry)
+      .filter(({ command }) =>
+        (!cliPath || command.includes(cliPath))
+        && (
+          command.includes(`--session-id ${sessionId}`)
+          || command.includes(`--resume ${sessionId}`)
+        )
+      )
+      .map(({ pid }) => pid);
+
+    return matches;
+  } catch (error) {
+    logger.chat.warn(
+      "[DIAG] Failed to scan process list for sessionId={sessionId}: {error}",
+      { sessionId, error },
+    );
+    return [];
+  }
+}
+
+function sendSignal(child: ChildProcess, signal: NodeJS.Signals, requestId: string): void {
+  const pid = child.pid;
+  if (!pid) return;
+
+  try {
+    process.kill(pid, signal);
+    logger.chat.warn(
+      "[DIAG] Sent signal={signal} to CLI pid={pid} requestId={requestId}",
+      { signal, pid, requestId },
+    );
+  } catch (error) {
+    logger.chat.warn(
+      "[DIAG] Failed to send signal={signal} to CLI pid={pid} requestId={requestId}: {error}",
+      { signal, pid, requestId, error },
+    );
+  }
+}
+
+function maybeClearForceKillTimer(state: TrackedRequest): void {
+  if (state.children.size > 0 || !state.forceKillTimer) return;
+  clearTimeout(state.forceKillTimer);
+  state.forceKillTimer = undefined;
+  if (state.requestEnded) {
+    trackedRequests.delete(state.requestId);
+  }
+}
+
+function attachChildToRequest(requestId: string, child: ChildProcess): void {
+  const pid = child.pid;
+  if (!pid) return;
+
+  const state = trackedRequests.get(requestId);
+  if (!state) return;
+
+  if (state.children.has(pid)) return;
+  state.children.set(pid, child);
+
+  logger.chat.info(
+    "[DIAG] Tracking CLI pid={pid} requestId={requestId} sessionId={sessionId}",
+    { pid, requestId, sessionId: state.sessionId },
+  );
+
+  const cleanup = () => {
+    const current = trackedRequests.get(requestId);
+    if (!current) return;
+    current.children.delete(pid);
+    maybeClearForceKillTimer(current);
+  };
+
+  child.once("close", cleanup);
+  child.once("exit", cleanup);
+
+  if (state.abortSource) {
+    sendSignal(child, "SIGTERM", requestId);
+  }
+}
+
+function installChildProcessPatch(): void {
+  if (patchInstalled) return;
+  patchInstalled = true;
+
+  originalSpawn = childProcess.spawn;
+  originalFork = childProcess.fork;
+  const originalSpawnAny = originalSpawn as (...args: any[]) => ChildProcess;
+  const originalForkAny = originalFork as (...args: any[]) => ChildProcess;
+
+  childProcess.spawn = ((...args: any[]) => {
+    const [command, spawnArgs] = args;
+    const child = originalSpawnAny(...args);
+    const requestId = requestContext.getStore()?.requestId;
+    if (requestId && Array.isArray(spawnArgs) && isSdkCliSpawn(String(command), spawnArgs)) {
+      attachChildToRequest(requestId, child);
+    }
+    return child;
+  }) as unknown as typeof childProcess.spawn;
+
+  childProcess.fork = ((...args: any[]) => {
+    const [modulePath, forkArgs] = args;
+    const child = originalForkAny(...args);
+    const requestId = requestContext.getStore()?.requestId;
+    if (requestId && Array.isArray(forkArgs) && isSdkCliFork(String(modulePath), forkArgs)) {
+      attachChildToRequest(requestId, child);
+    }
+    return child;
+  }) as unknown as typeof childProcess.fork;
+}
+
+export function registerTrackedCliRequest(
+  requestId: string,
+  options: { sessionId?: string; cliPath?: string } = {},
+): void {
+  installChildProcessPatch();
+  trackedRequests.set(requestId, {
+    requestId,
+    sessionId: options.sessionId,
+    cliPath: options.cliPath,
+    children: new Map(),
+  });
+}
+
+export function updateTrackedCliSessionId(requestId: string, sessionId: string): void {
+  const state = trackedRequests.get(requestId);
+  if (!state) return;
+  state.sessionId = sessionId;
+}
+
+export function runWithTrackedCliRequest<T>(requestId: string, fn: () => T): T {
+  return requestContext.run({ requestId }, fn);
+}
+
+export function signalTrackedCliAbort(
+  requestId: string,
+  source: AbortSource,
+): void {
+  const state = trackedRequests.get(requestId);
+  if (!state) return;
+
+  if (!state.abortSource) {
+    state.abortSource = source;
+    logger.chat.warn(
+      "[DIAG] CLI abort requested requestId={requestId} source={source} trackedChildren={trackedChildren}",
+      { requestId, source, trackedChildren: state.children.size },
+    );
+  }
+
+  for (const child of state.children.values()) {
+    sendSignal(child, "SIGTERM", requestId);
+  }
+
+  if (state.sessionId) {
+    for (const pid of findSessionCliPids(state.sessionId, state.cliPath)) {
+      try {
+        process.kill(pid, "SIGTERM");
+        logger.chat.warn(
+          "[DIAG] Sent fallback signal=SIGTERM to CLI pid={pid} requestId={requestId}",
+          { pid, requestId },
+        );
+      } catch (error) {
+        logger.chat.warn(
+          "[DIAG] Failed fallback SIGTERM pid={pid} requestId={requestId}: {error}",
+          { pid, requestId, error },
+        );
+      }
+    }
+  }
+
+  if (state.forceKillTimer) return;
+
+  state.forceKillTimer = setTimeout(() => {
+    const current = trackedRequests.get(requestId);
+    if (!current) return;
+
+    current.forceKillTimer = undefined;
+    for (const [pid, child] of current.children) {
+      if (!isPidAlive(pid)) continue;
+      sendSignal(child, "SIGKILL", requestId);
+    }
+    if (current.sessionId) {
+      for (const pid of findSessionCliPids(current.sessionId, current.cliPath)) {
+        if (!isPidAlive(pid)) continue;
+        try {
+          process.kill(pid, "SIGKILL");
+          logger.chat.warn(
+            "[DIAG] Sent fallback signal=SIGKILL to CLI pid={pid} requestId={requestId}",
+            { pid, requestId },
+          );
+        } catch (error) {
+          logger.chat.warn(
+            "[DIAG] Failed fallback SIGKILL pid={pid} requestId={requestId}: {error}",
+            { pid, requestId, error },
+          );
+        }
+      }
+    }
+    if (current.requestEnded) {
+      trackedRequests.delete(requestId);
+    }
+  }, FORCE_KILL_AFTER_MS);
+
+  if (state.forceKillTimer.unref) {
+    state.forceKillTimer.unref();
+  }
+}
+
+export function finalizeTrackedCliRequest(requestId: string): void {
+  const state = trackedRequests.get(requestId);
+  if (!state) return;
+
+  if (state.forceKillTimer) {
+    state.requestEnded = true;
+    return;
+  }
+
+  trackedRequests.delete(requestId);
+}
+
+export function abortAllTrackedCliRequests(): void {
+  for (const requestId of trackedRequests.keys()) {
+    signalTrackedCliAbort(requestId, "server_shutdown");
+  }
+}
+
+export const __cliProcessRegistryTestUtils = {
+  attachChildToRequest,
+  isSdkCliSpawn,
+  isSdkCliFork,
+  reset(): void {
+    for (const state of trackedRequests.values()) {
+      if (state.forceKillTimer) {
+        clearTimeout(state.forceKillTimer);
+      }
+    }
+    trackedRequests.clear();
+  },
+  getTrackedRequest(requestId: string): TrackedRequest | undefined {
+    return trackedRequests.get(requestId);
+  },
+};

--- a/backend/utils/qwenSdk.ts
+++ b/backend/utils/qwenSdk.ts
@@ -1,0 +1,4 @@
+export async function loadQwenQuery(): Promise<typeof import("@qwen-code/sdk").query> {
+  const sdk = await import("@qwen-code/sdk");
+  return sdk.query;
+}

--- a/frontend/src/components/ChatPage.tsx
+++ b/frontend/src/components/ChatPage.tsx
@@ -542,6 +542,38 @@ export function ChatPage() {
 
   // Ref to suppress error message when abort is triggered by /clear
   const clearAbortRef = useRef(false);
+  const activeFetchAbortControllerRef = useRef<AbortController | null>(null);
+  const activeLocalAbortReasonRef = useRef<"user" | "stall" | "system" | null>(null);
+
+  const abortLocalFetch = useCallback((reason: "user" | "stall" | "system") => {
+    activeLocalAbortReasonRef.current = reason;
+    const controller = activeFetchAbortControllerRef.current;
+    if (controller && !controller.signal.aborted) {
+      controller.abort();
+    }
+  }, []);
+
+  const abortLocalRequest = useCallback(
+    async (
+      requestId: string | null,
+      options: { resetState?: boolean; reason: "user" | "system" } = { reason: "user" },
+    ) => {
+      if (!requestId || !isLoading) return;
+
+      abortLocalFetch(options.reason);
+
+      try {
+        await abortRequest(requestId, true);
+      } catch (error) {
+        console.error("Failed to abort request:", error);
+      } finally {
+        if (options.resetState) {
+          resetRequestState();
+        }
+      }
+    },
+    [abortLocalFetch, abortRequest, isLoading, resetRequestState],
+  );
 
   // Show input notification when AI finishes responding (isLoading changes from true to false)
   useEffect(() => {
@@ -652,7 +684,13 @@ export function ChatPage() {
       // Stream stall detection: abort fetch if no data received for 120s.
       // Backend sends heartbeat every 15s, so 120s = 8 missed heartbeats.
       const fetchAbortController = new AbortController();
-      const stallDetector = createStallDetector(fetchAbortController);
+      activeFetchAbortControllerRef.current = fetchAbortController;
+      activeLocalAbortReasonRef.current = null;
+      const stallDetector = createStallDetector(fetchAbortController, undefined, () => {
+        if (activeFetchAbortControllerRef.current === fetchAbortController) {
+          activeLocalAbortReasonRef.current = "stall";
+        }
+      });
 
       try {
         const response = await fetch(getChatUrl(), {
@@ -712,6 +750,7 @@ export function ChatPage() {
           },
           onAbortRequest: async () => {
             shouldAbort = true;
+            abortLocalFetch("system");
             await createAbortHandler(requestId)();
           },
           // Auto-rejection loop detection
@@ -725,6 +764,7 @@ export function ChatPage() {
             shouldAbort = true;
             showCommandLoopRequest(request);
             // Auto-abort the request
+            abortLocalFetch("system");
             createAbortHandler(requestId)();
             // Clear sessionId on fatal session errors
             if (request.errorOutput?.toLowerCase().includes("input closed")) {
@@ -809,13 +849,15 @@ export function ChatPage() {
           error instanceof DOMException && error.name === "AbortError"
           && fetchAbortController.signal.aborted
         ) {
-          addMessage({
-            type: "chat",
-            role: "assistant",
-            content: t("chat.errorStreamStall"),
-            timestamp: Date.now(),
-          });
-          setCurrentSessionId(null);
+          if (activeLocalAbortReasonRef.current === "stall") {
+            addMessage({
+              type: "chat",
+              role: "assistant",
+              content: t("chat.errorStreamStall"),
+              timestamp: Date.now(),
+            });
+            setCurrentSessionId(null);
+          }
         } else if (!clearAbortRef.current) {
           console.error("Failed to send message:", error);
           const errorText = error instanceof Error
@@ -833,6 +875,10 @@ export function ChatPage() {
         }
       } finally {
         stallDetector.dispose();
+        if (activeFetchAbortControllerRef.current === fetchAbortController) {
+          activeFetchAbortControllerRef.current = null;
+          activeLocalAbortReasonRef.current = null;
+        }
 
         // Release the reader to free the HTTP connection.
         // Without this, the browser keeps connections open and eventually
@@ -888,6 +934,7 @@ export function ChatPage() {
       resetRequestState,
       processStreamLine,
       handlePermissionError,
+      abortLocalFetch,
       createAbortHandler,
       showInputNotification,
       isRemoteWorkspace,
@@ -897,12 +944,11 @@ export function ChatPage() {
 
   const handleAbort = useCallback(() => {
     if (isRemoteWorkspace && remoteChat.session) {
-      remoteChat.abortCurrentRequest();
-      resetRequestState();
+      void remoteChat.abortCurrentRequest();
       return;
     }
-    abortRequest(currentRequestId, isLoading, resetRequestState);
-  }, [abortRequest, currentRequestId, isLoading, resetRequestState, isRemoteWorkspace, remoteChat.abortCurrentRequest, remoteChat.session]);
+    void abortLocalRequest(currentRequestId, { reason: "user" });
+  }, [abortLocalRequest, currentRequestId, isRemoteWorkspace, remoteChat.abortCurrentRequest, remoteChat.session]);
 
   // Slash command execution handler
   const handleExecuteSlashCommand = useCallback(
@@ -921,9 +967,9 @@ export function ChatPage() {
     // Abort any in-flight request to prevent stale messages
     clearAbortRef.current = true;
     if (isRemoteWorkspace && remoteChat.session) {
-      remoteChat.abortCurrentRequest();
+      void remoteChat.abortCurrentRequest();
     } else {
-      abortRequest(currentRequestId, isLoading, resetRequestState);
+      void abortLocalRequest(currentRequestId, { reason: "system", resetState: true });
     }
     resetRequestState();
     setMessages([]);
@@ -938,14 +984,14 @@ export function ChatPage() {
       content: t("slashCommands.contextCleared"),
       timestamp: Date.now(),
     });
-  }, [setMessages, setCurrentSessionId, setHasShownInitMessage, setHasReceivedInit, addMessage, t, navigate, abortRequest, currentRequestId, isLoading, resetRequestState, isRemoteWorkspace, remoteChat.abortCurrentRequest, remoteChat.session]);
+  }, [setMessages, setCurrentSessionId, setHasShownInitMessage, setHasReceivedInit, addMessage, t, navigate, abortLocalRequest, currentRequestId, resetRequestState, isRemoteWorkspace, remoteChat.abortCurrentRequest, remoteChat.session]);
 
   // Permission request handlers
   // Abort backend request when permission response HTTP POST fails,
   // preventing stuck canUseTool promises that block the stream forever.
   const handlePermissionAbort = useCallback(async () => {
-    await abortRequest(currentRequestId, isLoading, resetRequestState);
-  }, [abortRequest, currentRequestId, isLoading, resetRequestState]);
+    await abortLocalRequest(currentRequestId, { reason: "system" });
+  }, [abortLocalRequest, currentRequestId]);
 
   const handlePermissionAllow = useCallback(async () => {
     if (!permissionRequest) return;
@@ -1293,14 +1339,13 @@ export function ChatPage() {
     closeCommandLoopRequest();
     // Abort current request if loading
     if (isLoading && currentRequestId) {
-      abortRequest(currentRequestId, isLoading, resetRequestState);
+      void abortLocalRequest(currentRequestId, { reason: "system" });
     }
   }, [
+    abortLocalRequest,
     closeCommandLoopRequest,
     isLoading,
     currentRequestId,
-    abortRequest,
-    resetRequestState,
   ]);
 
   // Thinking timeout handler — abort and show notification
@@ -1320,7 +1365,7 @@ export function ChatPage() {
 
       // Abort the request
       if (isLoading && currentRequestId) {
-        abortRequest(currentRequestId, isLoading, resetRequestState);
+        void abortLocalRequest(currentRequestId, { reason: "system" });
         aborted = true;
       } else if (isRemoteWorkspace && remoteChat.session) {
         remoteChat.abortCurrentRequest();
@@ -1336,7 +1381,7 @@ export function ChatPage() {
         aborted,
       });
     },
-    [isLoading, currentRequestId, abortRequest, resetRequestState, isRemoteWorkspace, remoteChat],
+    [abortLocalRequest, isLoading, currentRequestId, resetRequestState, isRemoteWorkspace, remoteChat],
   );
   thinkingTimeoutRef.current = handleThinkingTimeout;
 

--- a/frontend/src/hooks/chat/useAbortController.ts
+++ b/frontend/src/hooks/chat/useAbortController.ts
@@ -4,28 +4,30 @@ import { getAbortUrl, getPermissionRespondUrl } from "../../config/api";
 export function useAbortController() {
   // Helper function to perform abort request
   const performAbortRequest = useCallback(async (requestId: string) => {
-    await fetch(getAbortUrl(requestId), {
+    const response = await fetch(getAbortUrl(requestId), {
       method: "POST",
       headers: { "Content-Type": "application/json" },
     });
+
+    if (response.status === 404) {
+      return response;
+    }
+
+    if (!response.ok) {
+      throw new Error(`Failed to abort request: ${response.status} ${response.statusText}`);
+    }
+
+    return response;
   }, []);
 
   const abortRequest = useCallback(
     async (
       requestId: string | null,
       isLoading: boolean,
-      onAbortComplete: () => void,
     ) => {
       if (!requestId || !isLoading) return;
 
-      try {
-        await performAbortRequest(requestId);
-      } catch (error) {
-        console.error("Failed to abort request:", error);
-      } finally {
-        // Clean up state after successful abort or error
-        onAbortComplete();
-      }
+      return performAbortRequest(requestId);
     },
     [performAbortRequest],
   );

--- a/frontend/src/utils/streamStallDetector.ts
+++ b/frontend/src/utils/streamStallDetector.ts
@@ -14,6 +14,7 @@ export interface StallDetector {
 export function createStallDetector(
   abortController: AbortController,
   timeoutMs: number = 120_000,
+  onAbort?: () => void,
 ): StallDetector {
   let stallTimerId: ReturnType<typeof setTimeout> | null = null;
   let lastDataTime = Date.now();
@@ -37,6 +38,7 @@ export function createStallDetector(
       return;
     }
     console.warn(`[Stream stall] No data for ${timeoutMs / 1000}s, aborting fetch`);
+    onAbort?.();
     abortController.abort();
   };
 


### PR DESCRIPTION
## Summary
- keep the active local chat stream abortable from ChatPage instead of only resetting UI state
- return an explicit aborted terminal message and add backend watchdog cleanup for lingering CLI processes
- add regression coverage and a fake CLI fixture used to reproduce lingering subprocess behavior

## Testing
- npm run typecheck (backend)
- npm run typecheck (frontend)
- npm test -- abort.test.ts cliProcessRegistry.test.ts chat.test.ts

Closes #167