### PR TITLE
Fix duplicate createRequire import causing SyntaxError in ESM bundle

### DIFF
--- a/backend/utils/cliProcessRegistry.ts
+++ b/backend/utils/cliProcessRegistry.ts
@@ -1,9 +1,7 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 import type { ChildProcess } from "node:child_process";
-import { createRequire } from "node:module";
 import { logger } from "./logger.ts";
 
-const require = createRequire(import.meta.url);
 const childProcess = require("node:child_process") as typeof import("node:child_process");
 
 type AbortSource =


### PR DESCRIPTION
## Problem

The server failed to start with:

```
SyntaxError: Identifier 'createRequire' has already been declared
```

## Root Cause

`cliProcessRegistry.ts` independently imported `createRequire` from `node:module`, but the esbuild build banner already injects the same import at the bundle top. Two identical ESM import declarations in the same scope caused the SyntaxError.

## Fix

Remove the redundant `createRequire` import and local `require` assignment from `cliProcessRegistry.ts`, relying on the banner-provided global `require` instead.

## Verification

- ✅ Build succeeds
- ✅ Module loads without SyntaxError
- ✅ All 80 tests pass (9 test files)