### PR TITLE
Fix remote Stop to wait for abort confirmation

### DIFF
--- a/frontend/src/api/openace.ts
+++ b/frontend/src/api/openace.ts
@@ -528,7 +528,8 @@ export async function getRemoteSessionStatus(
  * Abort the current in-progress request without stopping the session
  */
 export async function abortRemoteRequest(
-  sessionId: string
+  sessionId: string,
+  reason = "user"
 ): Promise<{ success: boolean }> {
   const url = buildOpenAceUrl(`/api/remote/sessions/${sessionId}/abort`);
 
@@ -537,6 +538,7 @@ export async function abortRemoteRequest(
     headers: {
       "Content-Type": "application/json",
     },
+    body: JSON.stringify({ reason }),
   });
 
   if (!response.ok) {

--- a/frontend/src/components/ChatPage.tsx
+++ b/frontend/src/components/ChatPage.tsx
@@ -1891,6 +1891,7 @@ export function ChatPage() {
               <ChatInput
                 input={input}
                 isLoading={effectiveIsLoading}
+                isStopping={isRemoteWorkspace && remoteChat.isStopping}
                 currentRequestId={currentRequestId}
                 onInputChange={setInput}
                 onSubmit={() => sendMessage()}

--- a/frontend/src/components/ChatPage.tsx
+++ b/frontend/src/components/ChatPage.tsx
@@ -334,7 +334,7 @@ export function ChatPage() {
               notificationTriggeredRef.current = true;
               commandLoopShowRef.current?.(request);
               // Auto-abort the remote request
-              remoteChat.abortCurrentRequest();
+              remoteChat.abortCurrentRequest("system");
               // Clear sessionId on fatal session errors
               if (request.errorOutput?.toLowerCase().includes("input closed")) {
                 setCurrentSessionId(null);
@@ -944,7 +944,7 @@ export function ChatPage() {
 
   const handleAbort = useCallback(() => {
     if (isRemoteWorkspace && remoteChat.session) {
-      void remoteChat.abortCurrentRequest();
+      void remoteChat.abortCurrentRequest("user");
       return;
     }
     void abortLocalRequest(currentRequestId, { reason: "user" });
@@ -967,7 +967,7 @@ export function ChatPage() {
     // Abort any in-flight request to prevent stale messages
     clearAbortRef.current = true;
     if (isRemoteWorkspace && remoteChat.session) {
-      void remoteChat.abortCurrentRequest();
+      void remoteChat.abortCurrentRequest("system");
     } else {
       void abortLocalRequest(currentRequestId, { reason: "system", resetState: true });
     }
@@ -1368,8 +1368,7 @@ export function ChatPage() {
         void abortLocalRequest(currentRequestId, { reason: "system" });
         aborted = true;
       } else if (isRemoteWorkspace && remoteChat.session) {
-        remoteChat.abortCurrentRequest();
-        resetRequestState();
+        remoteChat.abortCurrentRequest("timeout");
         aborted = true;
       }
 

--- a/frontend/src/components/ChatPage.tsx
+++ b/frontend/src/components/ChatPage.tsx
@@ -1380,7 +1380,7 @@ export function ChatPage() {
         aborted,
       });
     },
-    [abortLocalRequest, isLoading, currentRequestId, resetRequestState, isRemoteWorkspace, remoteChat],
+    [abortLocalRequest, isLoading, currentRequestId, isRemoteWorkspace, remoteChat],
   );
   thinkingTimeoutRef.current = handleThinkingTimeout;
 

--- a/frontend/src/components/chat/ChatInput.tsx
+++ b/frontend/src/components/chat/ChatInput.tsx
@@ -1,5 +1,5 @@
 import React, { useRef, useEffect, useState, useCallback } from "react";
-import { StopIcon } from "@heroicons/react/24/solid";
+import { ArrowPathIcon, StopIcon } from "@heroicons/react/24/solid";
 import { useTranslation } from "react-i18next";
 import { UI_CONSTANTS, KEYBOARD_SHORTCUTS } from "../../utils/constants";
 import { useEnterBehavior } from "../../hooks/useSettings";
@@ -52,6 +52,7 @@ interface PlanPermissionData {
 interface ChatInputProps {
   input: string;
   isLoading: boolean;
+  isStopping?: boolean;
   currentRequestId: string | null;
   onInputChange: (value: string) => void;
   onSubmit: () => void;
@@ -74,6 +75,7 @@ interface ChatInputProps {
 export function ChatInput({
   input,
   isLoading,
+  isStopping = false,
   currentRequestId,
   onInputChange,
   onSubmit,
@@ -420,9 +422,14 @@ export function ChatInput({
                 type="button"
                 onClick={onAbort}
                 className="p-2 bg-red-100 hover:bg-red-200 dark:bg-red-900/20 dark:hover:bg-red-900/30 text-red-600 dark:text-red-400 rounded-lg transition-all duration-200 shadow-sm hover:shadow-md"
-                title={t("chat.stop")}
+                title={isStopping ? t("chat.stopping") : t("chat.stop")}
+                aria-label={isStopping ? t("chat.stopping") : t("chat.stop")}
               >
-                <StopIcon className="w-4 h-4" />
+                {isStopping ? (
+                  <ArrowPathIcon className="w-4 h-4 animate-spin" />
+                ) : (
+                  <StopIcon className="w-4 h-4" />
+                )}
               </button>
             )}
             <button

--- a/frontend/src/hooks/useRemoteChat.test.ts
+++ b/frontend/src/hooks/useRemoteChat.test.ts
@@ -1,0 +1,203 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  abortRemoteRequest,
+  createRemoteSession,
+  createRemoteSessionStream,
+  getRemoteSessionStatus,
+  pauseRemoteSession,
+  resumeRemoteSession,
+  sendPermissionResponse,
+  sendRemoteMessage,
+  stopRemoteSession,
+  switchRemoteModel,
+} from "../api/openace";
+import { useRemoteChat } from "./useRemoteChat";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback?: string) => fallback ?? _key,
+  }),
+}));
+
+vi.mock("../api/openace", () => ({
+  createRemoteSession: vi.fn(),
+  sendRemoteMessage: vi.fn(),
+  stopRemoteSession: vi.fn(),
+  abortRemoteRequest: vi.fn(),
+  getRemoteSessionStatus: vi.fn(),
+  createRemoteSessionStream: vi.fn(),
+  sendPermissionResponse: vi.fn(),
+  switchRemoteModel: vi.fn(),
+  pauseRemoteSession: vi.fn(),
+  resumeRemoteSession: vi.fn(),
+}));
+
+describe("useRemoteChat", () => {
+  const streamCallbacks: {
+    onLine?: (line: string) => void;
+    onError?: (err: Event) => void;
+    onDone?: () => void;
+  } = {};
+
+  const streamingContext = {
+    setCurrentThinkingMessage: vi.fn(),
+    setCurrentAssistantMessage: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+    streamCallbacks.onLine = undefined;
+    streamCallbacks.onError = undefined;
+    streamCallbacks.onDone = undefined;
+
+    vi.mocked(createRemoteSession).mockResolvedValue({
+      session: {
+        session_id: "remote-session-1",
+        status: "active",
+        model: "test-model",
+      },
+    } as never);
+    vi.mocked(sendRemoteMessage).mockResolvedValue({ success: true } as never);
+    vi.mocked(abortRemoteRequest).mockResolvedValue({ success: true } as never);
+    vi.mocked(stopRemoteSession).mockResolvedValue({ success: true } as never);
+    vi.mocked(getRemoteSessionStatus).mockResolvedValue({
+      success: true,
+      session: {
+        session_id: "remote-session-1",
+        status: "active",
+        model: "test-model",
+      },
+    } as never);
+    vi.mocked(sendPermissionResponse).mockResolvedValue({ success: true } as never);
+    vi.mocked(switchRemoteModel).mockResolvedValue({ success: true } as never);
+    vi.mocked(pauseRemoteSession).mockResolvedValue({ success: true } as never);
+    vi.mocked(resumeRemoteSession).mockResolvedValue({ success: true } as never);
+    vi.mocked(createRemoteSessionStream).mockImplementation(
+      ((_sessionId, onLine, onError, onDone) => {
+        streamCallbacks.onLine = onLine;
+        streamCallbacks.onError = onError;
+        streamCallbacks.onDone = onDone;
+        return { close: vi.fn() } as unknown as EventSource;
+      }) as typeof createRemoteSessionStream
+    );
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("keeps remote Stop in stopping state until an aborted event arrives", async () => {
+    const { result } = renderHook(() =>
+      useRemoteChat({
+        onStreamLine: vi.fn(),
+        streamingContext: streamingContext as never,
+      })
+    );
+
+    await act(async () => {
+      await result.current.startSession("machine-1", "/workspace", "test-model");
+    });
+
+    await act(async () => {
+      await result.current.sendMessage("hello");
+    });
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.isStopping).toBe(false);
+
+    await act(async () => {
+      await result.current.abortCurrentRequest("user");
+    });
+
+    expect(abortRemoteRequest).toHaveBeenCalledWith("remote-session-1", "user");
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.isStopping).toBe(true);
+
+    act(() => {
+      streamCallbacks.onLine?.(
+        JSON.stringify({
+          type: "request_state",
+          data: { type: "aborted", reason: "user" },
+        })
+      );
+    });
+
+    expect(result.current.isStopping).toBe(false);
+    expect(result.current.isLoading).toBe(false);
+    expect(streamingContext.setCurrentThinkingMessage).toHaveBeenCalledWith(null);
+    expect(streamingContext.setCurrentAssistantMessage).toHaveBeenCalledWith(null);
+  });
+
+  it("surfaces abort_failed without pretending the request stopped", async () => {
+    const { result } = renderHook(() =>
+      useRemoteChat({
+        onStreamLine: vi.fn(),
+        streamingContext: streamingContext as never,
+      })
+    );
+
+    await act(async () => {
+      await result.current.startSession("machine-1", "/workspace", "test-model");
+    });
+
+    await act(async () => {
+      await result.current.sendMessage("hello");
+    });
+
+    await act(async () => {
+      await result.current.abortCurrentRequest("timeout");
+    });
+
+    act(() => {
+      streamCallbacks.onLine?.(
+        JSON.stringify({
+          type: "request_state",
+          data: {
+            type: "abort_failed",
+            reason: "timeout",
+            message: "interrupt failed",
+          },
+        })
+      );
+    });
+
+    expect(result.current.isStopping).toBe(false);
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.error).toBe("interrupt failed");
+  });
+
+  it("times out if remote abort is never confirmed", async () => {
+    vi.useFakeTimers();
+
+    const { result } = renderHook(() =>
+      useRemoteChat({
+        onStreamLine: vi.fn(),
+        streamingContext: streamingContext as never,
+      })
+    );
+
+    await act(async () => {
+      await result.current.startSession("machine-1", "/workspace", "test-model");
+    });
+
+    await act(async () => {
+      await result.current.sendMessage("hello");
+    });
+
+    await act(async () => {
+      await result.current.abortCurrentRequest("user");
+    });
+
+    expect(result.current.isStopping).toBe(true);
+
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+
+    expect(result.current.isStopping).toBe(false);
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.error).toBe("Remote stop was not confirmed");
+  });
+});

--- a/frontend/src/hooks/useRemoteChat.ts
+++ b/frontend/src/hooks/useRemoteChat.ts
@@ -37,11 +37,19 @@ export interface RemoteChatOptions {
   onQuotaExceeded?: (quotaStatus: unknown) => void;
 }
 
+type RemoteRequestStateEvent = {
+  type: "aborted" | "abort_failed";
+  reason?: string;
+  message?: string;
+};
+
 export function useRemoteChat(options?: RemoteChatOptions) {
   const [session, setSession] = useState<RemoteSession | null>(null);
   const [isLoading, setIsLoading] = useState(false);
+  const [isStopping, setIsStopping] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const eventSourceRef = useRef<EventSource | null>(null);
+  const abortAckTimerRef = useRef<number | null>(null);
   const sendingRef = useRef(false);
   const { t } = useTranslation();
 
@@ -57,6 +65,13 @@ export function useRemoteChat(options?: RemoteChatOptions) {
     }
     if (opts?.streamingContext?.setCurrentAssistantMessage) {
       opts.streamingContext.setCurrentAssistantMessage(null);
+    }
+  }, []);
+
+  const clearAbortAckTimer = useCallback(() => {
+    if (abortAckTimerRef.current !== null) {
+      window.clearTimeout(abortAckTimerRef.current);
+      abortAckTimerRef.current = null;
     }
   }, []);
 
@@ -77,13 +92,34 @@ export function useRemoteChat(options?: RemoteChatOptions) {
         return; // Don't forward to onStreamLine
       }
 
+      if (parsed.type === "request_state" && parsed.data) {
+        const requestState = parsed.data as RemoteRequestStateEvent;
+        if (requestState.type === "aborted") {
+          clearAbortAckTimer();
+          setIsStopping(false);
+          setIsLoading(false);
+          clearStreamingState();
+          return;
+        }
+        if (requestState.type === "abort_failed") {
+          clearAbortAckTimer();
+          setIsStopping(false);
+          setError(requestState.message || "Failed to stop remote request");
+          return;
+        }
+      }
+
       // Detect result events to clear loading state
       if (parsed.type === "claude_json" && parsed.data?.type === "result") {
+        clearAbortAckTimer();
+        setIsStopping(false);
         setIsLoading(false);
       }
 
       // Handle error events from the remote agent (e.g. CLI crash, send failure)
       if (parsed.type === "error") {
+        clearAbortAckTimer();
+        setIsStopping(false);
         setIsLoading(false);
         setError(parsed.data || "Unknown remote error");
         return; // Don't forward to onStreamLine
@@ -95,7 +131,7 @@ export function useRemoteChat(options?: RemoteChatOptions) {
     if (opts?.onStreamLine && opts.streamingContext) {
       opts.onStreamLine(line, opts.streamingContext);
     }
-  }, []);
+  }, [clearAbortAckTimer, clearStreamingState]);
 
   // Cleanup on unmount
   useEffect(() => {
@@ -104,8 +140,9 @@ export function useRemoteChat(options?: RemoteChatOptions) {
         eventSourceRef.current.close();
         eventSourceRef.current = null;
       }
+      clearAbortAckTimer();
     };
-  }, []);
+  }, [clearAbortAckTimer]);
 
   // ---------------------------------------------------------------------------
   // Actions
@@ -121,6 +158,8 @@ export function useRemoteChat(options?: RemoteChatOptions) {
       haPoolToken?: string
     ) => {
       setIsLoading(true);
+      clearAbortAckTimer();
+      setIsStopping(false);
       setError(null);
       setSession(null);
 
@@ -148,6 +187,8 @@ export function useRemoteChat(options?: RemoteChatOptions) {
             (err) => {
               console.error("[useRemoteChat] SSE error:", err);
               setError(t("chat.remoteDisconnected"));
+              clearAbortAckTimer();
+              setIsStopping(false);
               setIsLoading(false);
               clearStreamingState();
               setSession((prev) =>
@@ -156,6 +197,8 @@ export function useRemoteChat(options?: RemoteChatOptions) {
             },
             () => {
               console.log("[useRemoteChat] SSE done");
+              clearAbortAckTimer();
+              setIsStopping(false);
               setIsLoading(false);
               clearStreamingState();
               // If the session was active and SSE closed, it likely means
@@ -199,6 +242,8 @@ export function useRemoteChat(options?: RemoteChatOptions) {
       if (session) return; // already connected
 
       setIsLoading(true);
+      clearAbortAckTimer();
+      setIsStopping(false);
       setError(null);
 
       try {
@@ -275,6 +320,8 @@ export function useRemoteChat(options?: RemoteChatOptions) {
             (err) => {
               console.error("[useRemoteChat] SSE error:", err);
               setError(t("chat.remoteReconnectFailed"));
+              clearAbortAckTimer();
+              setIsStopping(false);
               setIsLoading(false);
               clearStreamingState();
               setSession((prev) =>
@@ -283,6 +330,8 @@ export function useRemoteChat(options?: RemoteChatOptions) {
             },
             () => {
               console.log("[useRemoteChat] SSE done");
+              clearAbortAckTimer();
+              setIsStopping(false);
               setIsLoading(false);
               clearStreamingState();
             },
@@ -310,6 +359,9 @@ export function useRemoteChat(options?: RemoteChatOptions) {
       // Prevent double-sends
       if (sendingRef.current) return;
       sendingRef.current = true;
+      clearAbortAckTimer();
+      setIsStopping(false);
+      setError(null);
       setIsLoading(true);
 
       try {
@@ -330,19 +382,28 @@ export function useRemoteChat(options?: RemoteChatOptions) {
         sendingRef.current = false;
       }
     },
-    [session]
+    [clearAbortAckTimer, session]
   );
 
-  const abortCurrentRequest = useCallback(async () => {
-    if (!session) return;
+  const abortCurrentRequest = useCallback(async (reason = "user") => {
+    if (!session || isStopping) return;
     try {
-      await abortRemoteRequest(session.session_id);
-      setIsLoading(false);
-      clearStreamingState();
+      setIsStopping(true);
+      setError(null);
+      await abortRemoteRequest(session.session_id, reason);
+      abortAckTimerRef.current = window.setTimeout(() => {
+        setIsStopping(false);
+        setError("Remote stop was not confirmed");
+      }, 5000);
     } catch (err) {
+      clearAbortAckTimer();
+      setIsStopping(false);
       console.error("[useRemoteChat] Failed to abort request:", err);
+      setError(
+        err instanceof Error ? err.message : "Failed to abort remote request"
+      );
     }
-  }, [session, clearStreamingState]);
+  }, [clearAbortAckTimer, isStopping, session]);
 
   const stopSessionHandler = useCallback(async () => {
     if (!session) return;
@@ -355,6 +416,9 @@ export function useRemoteChat(options?: RemoteChatOptions) {
 
     try {
       await stopRemoteSession(session.session_id);
+      clearAbortAckTimer();
+      setIsStopping(false);
+      setIsLoading(false);
       setSession((prev) => (prev ? { ...prev, status: "stopped" } : null));
     } catch (err) {
       setError(
@@ -375,10 +439,12 @@ export function useRemoteChat(options?: RemoteChatOptions) {
         console.error("[useRemoteChat] Failed to stop session during reset:", err);
       }
     }
+    clearAbortAckTimer();
     setSession(null);
     setError(null);
+    setIsStopping(false);
     setIsLoading(false);
-  }, [session]);
+  }, [clearAbortAckTimer, session]);
 
   const reconnect = useCallback(
     async (machineId: string, projectPath: string, model?: string) => {
@@ -452,6 +518,7 @@ export function useRemoteChat(options?: RemoteChatOptions) {
   return {
     session,
     isLoading,
+    isStopping,
     sendMessage,
     startSession,
     connectSession,

--- a/frontend/src/hooks/useRemoteChat.ts
+++ b/frontend/src/hooks/useRemoteChat.ts
@@ -425,7 +425,7 @@ export function useRemoteChat(options?: RemoteChatOptions) {
         err instanceof Error ? err.message : "Failed to stop remote session"
       );
     }
-  }, [session]);
+  }, [clearAbortAckTimer, session]);
 
   const resetSession = useCallback(async () => {
     if (session) {

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -59,6 +59,7 @@
   },
   "chat": {
     "processing": "Processing...",
+    "stopping": "Stopping...",
     "typeMessage": "Type message...",
     "send": "Send",
     "plan": "Plan",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -59,6 +59,7 @@
   },
   "chat": {
     "processing": "処理中...",
+    "stopping": "停止中...",
     "typeMessage": "メッセージを入力...",
     "send": "送信",
     "plan": "プラン",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -59,6 +59,7 @@
   },
   "chat": {
     "processing": "처리 중...",
+    "stopping": "중지하는 중...",
     "typeMessage": "메시지를 입력하세요...",
     "send": "전송",
     "plan": "계획",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -59,6 +59,7 @@
   },
   "chat": {
     "processing": "处理中...",
+    "stopping": "正在停止...",
     "typeMessage": "输入消息...",
     "send": "发送",
     "plan": "计划",


### PR DESCRIPTION
## Summary
- keep remote Stop in a stopping state until OpenACE confirms the request was aborted
- pass explicit abort reasons for user/system/timeout remote cancels
- add a timeout fallback so the UI no longer silently pretends the remote request stopped

## Testing
- cd frontend && npm run test:run -- src/hooks/useRemoteChat.test.ts
- cd frontend && npm run typecheck

Closes #169

Depends on open-ace/open-ace#665.