### PR TITLE
Clean up deprecated reactive permission flow

### DIFF
--- a/frontend/src/components/ChatPage.tsx
+++ b/frontend/src/components/ChatPage.tsx
@@ -1041,6 +1041,7 @@ export function ChatPage() {
   }, [
     permissionRequest,
     allowedTools,
+    allowToolPermanent,
     closePermissionRequest,
     resetDenialCounter,
     clearNotification,
@@ -1114,26 +1115,27 @@ export function ChatPage() {
     resetDenialCounter();
     clearNotification();
 
-    if (permissionRequest.permissionId) {
-      // Persist bare tool name so ALL run_shell_command calls are auto-approved
-      allowToolPermanent(permissionRequest.toolName, allowedTools);
-      try {
-        const resp = await sendPermissionResponse(permissionRequest.permissionId, "allow", {
-          updatedInput: permissionRequest.toolInput || {},
-          scope: "all",
-        });
-        if (!resp.ok) {
-          console.warn("Permission response failed:", resp.status);
-          await handlePermissionAbort();
-        }
-      } catch (error) {
-        console.error("Failed to send permission response:", error);
-        await handlePermissionAbort();
-      }
+    // Defensive guard: the UI only renders "allow all" for proactive requests.
+    if (!permissionRequest.permissionId) {
       closePermissionRequest();
       return;
     }
 
+    // Persist bare tool name so ALL run_shell_command calls are auto-approved
+    allowToolPermanent(permissionRequest.toolName, allowedTools);
+    try {
+      const resp = await sendPermissionResponse(permissionRequest.permissionId, "allow", {
+        updatedInput: permissionRequest.toolInput || {},
+        scope: "all",
+      });
+      if (!resp.ok) {
+        console.warn("Permission response failed:", resp.status);
+        await handlePermissionAbort();
+      }
+    } catch (error) {
+      console.error("Failed to send permission response:", error);
+      await handlePermissionAbort();
+    }
     closePermissionRequest();
   }, [
     permissionRequest,

--- a/frontend/src/components/ChatPage.tsx
+++ b/frontend/src/components/ChatPage.tsx
@@ -356,11 +356,33 @@ export function ChatPage() {
             },
           },
           onPermissionRequest: (event) => {
-            // Forward remote CLI permission request to the existing permission panel
             const req = event.request;
             if (req?.tool_name) {
-              const patterns = req.permission_suggestions?.map(s => s.rule) || [];
-              permissionErrorRef.current?.(req.tool_name, patterns, req.tool_use_id || "", event.request_id);
+              const toolInput = req.input || {};
+              const { toolName: extractedName, commands } = extractToolInfo(
+                req.tool_name,
+                toolInput,
+              );
+              const patterns =
+                req.permission_suggestions?.map((suggestion) => suggestion.rule) ||
+                generateToolPatterns(extractedName, commands);
+
+              notificationTriggeredRef.current = true;
+              if (patterns.includes(TOOL_NAMES.EXIT_PLAN_MODE)) {
+                showPlanModeRequest("");
+                showPlanNotification();
+                return;
+              }
+
+              showPermissionRequest(
+                extractedName,
+                patterns,
+                req.tool_use_id || "",
+                event.request_id,
+                undefined,
+                toolInput,
+              );
+              showPermissionNotification();
             }
           },
           onQuotaExceeded: (quotaStatus) => {
@@ -526,13 +548,7 @@ export function ChatPage() {
   // during the current streaming session (used to decide if input notification should fire)
   const notificationTriggeredRef = useRef(false);
 
-  // Ref for permission error handler — used by remote streamingContext to
-  // avoid declaration-order issues (handlePermissionError is defined below).
-  const permissionErrorRef = useRef<
-    ((toolName: string, patterns: string[], toolUseId: string, requestId?: string) => void) | null
-  >(null);
-
-  // Ref for thinking timeout handler — same pattern as permissionErrorRef
+  // Ref for thinking timeout handler
   const thinkingTimeoutRef = useRef<
     ((accumulatedContent: string, info: ThinkingTimeoutContext) => void) | null
   >(null);
@@ -596,25 +612,6 @@ export function ChatPage() {
       notificationTriggeredRef.current = false;
     }
   }, [effectiveIsLoading, showInputNotification]);
-
-  const handlePermissionError = useCallback(
-    (toolName: string, patterns: string[], toolUseId: string, requestId?: string) => {
-      notificationTriggeredRef.current = true;
-      // Check if this is an ExitPlanMode permission error
-      if (patterns.includes(TOOL_NAMES.EXIT_PLAN_MODE)) {
-        // For ExitPlanMode, show plan permission interface instead of regular permission
-        showPlanModeRequest(""); // Empty plan content since it was already displayed
-        // Show tab notification for plan approval
-        showPlanNotification();
-      } else {
-        showPermissionRequest(toolName, patterns, toolUseId, requestId);
-        // Show tab notification for permission request
-        showPermissionNotification();
-      }
-    },
-    [showPermissionRequest, showPlanModeRequest, showPermissionNotification, showPlanNotification],
-  );
-  permissionErrorRef.current = handlePermissionError;
 
   const sendMessage = useCallback(
     async (
@@ -933,7 +930,6 @@ export function ChatPage() {
       setCurrentAssistantMessage,
       resetRequestState,
       processStreamLine,
-      handlePermissionError,
       abortLocalFetch,
       createAbortHandler,
       showInputNotification,
@@ -1041,23 +1037,10 @@ export function ChatPage() {
       return;
     }
 
-    // Legacy reactive flow — abort + new request with expanded allowedTools
-    let updatedAllowedTools = allowedTools;
-    permissionRequest.patterns.forEach((pattern) => {
-      updatedAllowedTools = allowToolTemporary(pattern, updatedAllowedTools);
-    });
-
     closePermissionRequest();
-
-    if (currentSessionId) {
-      sendMessage("continue", updatedAllowedTools, true);
-    }
   }, [
     permissionRequest,
-    currentSessionId,
-    sendMessage,
     allowedTools,
-    allowToolTemporary,
     closePermissionRequest,
     resetDenialCounter,
     clearNotification,
@@ -1111,22 +1094,9 @@ export function ChatPage() {
       return;
     }
 
-    // Legacy reactive flow
-    // Accumulate all patterns into a single update to avoid React batching race
-    let updatedAllowedTools = allowedTools;
-    permissionRequest.patterns.forEach((pattern) => {
-      updatedAllowedTools = allowToolPermanent(pattern, updatedAllowedTools);
-    });
-
     closePermissionRequest();
-
-    if (currentSessionId) {
-      sendMessage("continue", updatedAllowedTools, true);
-    }
   }, [
     permissionRequest,
-    currentSessionId,
-    sendMessage,
     allowedTools,
     allowToolPermanent,
     closePermissionRequest,
@@ -1164,16 +1134,9 @@ export function ChatPage() {
       return;
     }
 
-    // Legacy reactive flow
-    const updatedAllowedTools = allowToolPermanent(permissionRequest.toolName, allowedTools);
     closePermissionRequest();
-    if (currentSessionId) {
-      sendMessage("continue", updatedAllowedTools, true);
-    }
   }, [
     permissionRequest,
-    currentSessionId,
-    sendMessage,
     allowedTools,
     allowToolPermanent,
     closePermissionRequest,
@@ -1226,25 +1189,9 @@ export function ChatPage() {
       return;
     }
 
-    // Legacy reactive flow
     closePermissionRequest();
-
-    if (currentSessionId) {
-      if (loopMessage) {
-        sendMessage(loopMessage, allowedTools, true);
-      } else {
-        sendMessage(
-          `The user denied the permission request for ${toolName}. Please stop retrying and ask the user what they would like to do instead.`,
-          allowedTools,
-          true
-        );
-      }
-    }
   }, [
     permissionRequest,
-    currentSessionId,
-    sendMessage,
-    allowedTools,
     closePermissionRequest,
     recordDenial,
     clearNotification,
@@ -1392,7 +1339,9 @@ export function ChatPage() {
         toolInput: permissionRequest.toolInput,
         onAllow: handlePermissionAllow,
         onAllowPermanent: handlePermissionAllowPermanent,
-        onAllowAll: handlePermissionAllowAll,
+        onAllowAll: permissionRequest.permissionId
+          ? handlePermissionAllowAll
+          : undefined,
         onDeny: handlePermissionDeny,
         autoApproveMs: permissionRequest.autoApproveMs,
       }

--- a/frontend/src/components/DemoPage.tsx
+++ b/frontend/src/components/DemoPage.tsx
@@ -135,12 +135,11 @@ export function DemoPage() {
     closePlanModeRequest,
   } = usePermissions();
 
-  const handlePermissionError = useCallback(
+  const handlePermissionRequest = useCallback(
     (toolName: string, patterns: string[], toolUseId: string) => {
-      // Check if this is an ExitPlanMode permission error
+      // Route ExitPlanMode requests to the plan approval UI
       if (patterns.includes(TOOL_NAMES.EXIT_PLAN_MODE)) {
-        // For ExitPlanMode, show plan permission interface instead of regular permission
-        showPlanModeRequest(""); // Empty plan content since it was already displayed
+        showPlanModeRequest("");
       } else {
         showPermissionRequest(toolName, patterns, toolUseId);
       }
@@ -319,7 +318,7 @@ export function DemoPage() {
     startRequest,
     resetRequestState,
     generateRequestId,
-    showPermissionRequest: handlePermissionError,
+    showPermissionRequest: handlePermissionRequest,
     onButtonFocus: handleButtonFocus,
     onButtonClick: handleButtonClick,
   });

--- a/frontend/src/hooks/chat/usePermissions.ts
+++ b/frontend/src/hooks/chat/usePermissions.ts
@@ -131,9 +131,9 @@ export function usePermissions(options: UsePermissionsOptions = {}) {
   const loopDetectionConfigRef = useRef(DEFAULT_LOOP_DETECTION_CONFIG);
 
   // Auto-rejection loop detection state (SDK-level rejections, e.g. stdin closed)
-  // Map-based per-agent counter: key = agentId:toolName (or just toolName for main session)
+  // Track the most recent rejected tool per agent so switching tools resets the loop counter.
   const autoRejectionStatesRef = useRef<
-    Map<string, { count: number; lastTime: number }>
+    Map<string, { toolName: string; count: number; lastTime: number }>
   >(new Map());
 
   // Command result loop detection state
@@ -442,7 +442,7 @@ export function usePermissions(options: UsePermissionsOptions = {}) {
       const now = Date.now();
 
       // Build a scoped key for agent isolation
-      const scopeKey = agentId ? `${agentId}:${toolName}` : toolName;
+      const scopeKey = agentId || "__main__";
 
       // "Input closed" is a session-level fatal error — always detect immediately
       // Match the full SDK error format to avoid false positives from benign "Operation Cancelled"
@@ -454,7 +454,7 @@ export function usePermissions(options: UsePermissionsOptions = {}) {
       // When this occurs the CLI process is dead, so the entire session tree
       // (including all fork agents) is unusable regardless of which agent reported it.
       if (isInputClosed) {
-        autoRejectionStatesRef.current.delete(scopeKey);
+        autoRejectionStatesRef.current.clear();
         return {
           isOpen: true,
           toolName,
@@ -471,10 +471,13 @@ export function usePermissions(options: UsePermissionsOptions = {}) {
       // Get or create per-key state
       const states = autoRejectionStatesRef.current;
       const existing = states.get(scopeKey);
-      const state = existing && now - existing.lastTime <= config.resetWindowMs
-        ? existing
-        : { count: 0, lastTime: now };
+      const isWithinWindow = existing && now - existing.lastTime <= config.resetWindowMs;
+      const state =
+        isWithinWindow && existing.toolName === toolName
+          ? existing
+          : { toolName, count: 0, lastTime: now };
 
+      state.toolName = toolName;
       state.count++;
       state.lastTime = now;
       states.set(scopeKey, state);

--- a/frontend/src/hooks/chat/usePlanApproval.test.ts
+++ b/frontend/src/hooks/chat/usePlanApproval.test.ts
@@ -1,372 +1,114 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import { renderHook, act } from "@testing-library/react";
-import { createExitPlanModeToolResult } from "../../utils/mockResponseGenerator";
+import { usePermissions } from "./usePermissions";
+import { createExitPlanModeToolUseWithId } from "../../utils/mockResponseGenerator";
 import { TOOL_NAMES } from "../../utils/toolNames";
 
-// Mock the message converter
-vi.mock("../useMessageConverter", () => ({
-  useMessageConverter: () => ({
-    createToolResultMessage: vi.fn((data) => ({
-      type: "tool_result",
-      toolName: TOOL_NAMES.EXIT_PLAN_MODE,
-      content: data.content || "Plan rejected",
-      summary: "Plan rejection",
-      toolUseId: data.tool_use_id,
-      timestamp: Date.now(),
-    })),
-  }),
-}));
+function usePlanApprovalWorkflow() {
+  const permissions = usePermissions();
 
-// Create a simple hook for testing plan rejection workflow
-function usePlanRejectionWorkflow() {
-  const sendToolResult = vi.fn();
-  const updatePermissionMode = vi.fn();
-  const closePlanModeRequest = vi.fn();
-
-  const handlePlanRejection = (toolUseId: string, sessionId: string) => {
-    // Create tool result message for plan rejection
-    const toolResultMessage = createExitPlanModeToolResult(
-      sessionId,
+  const handlePlanPermissionRequest = (planContent: string, toolUseId = "plan-123") => {
+    const assistantMessage = createExitPlanModeToolUseWithId(
+      "session-123",
       toolUseId,
+      planContent,
     );
-    sendToolResult(toolResultMessage);
+    const toolUse = assistantMessage.message.content.find(
+      (item) => item.type === "tool_use",
+    );
 
-    // Update UI state
-    updatePermissionMode("plan");
-    closePlanModeRequest();
+    if (toolUse?.type !== "tool_use" || toolUse.name !== TOOL_NAMES.EXIT_PLAN_MODE) {
+      throw new Error("Expected ExitPlanMode tool_use");
+    }
 
-    return {
-      success: true,
-      toolResultGenerated: true,
-      stateUpdated: true,
-    };
+    permissions.showPlanModeRequest(
+      typeof toolUse.input.plan === "string" ? toolUse.input.plan : "",
+    );
+
+    return toolUse;
   };
 
   return {
-    handlePlanRejection,
-    sendToolResult,
-    updatePermissionMode,
-    closePlanModeRequest,
+    ...permissions,
+    handlePlanPermissionRequest,
   };
 }
 
-describe("Plan Rejection Workflow Tests", () => {
-  describe("Tool Result Generation", () => {
-    it("should create correct tool_result message for plan rejection", () => {
-      const toolUseId = "exit-plan-123";
-      const sessionId = "session-456";
+describe("Plan Approval Workflow", () => {
+  it("creates an ExitPlanMode tool_use with the expected plan content", () => {
+    const assistantMessage = createExitPlanModeToolUseWithId(
+      "session-123",
+      "plan-456",
+      "1. Inspect files\n2. Update tests",
+    );
 
-      const toolResult = createExitPlanModeToolResult(sessionId, toolUseId);
-
-      expect(toolResult).toEqual({
-        type: "user",
-        message: {
-          role: "user",
-          content: [
-            {
-              type: "tool_result",
-              tool_use_id: toolUseId,
-              content: "Exit plan mode?",
-              is_error: true,
-            },
-          ],
+    expect(assistantMessage.type).toBe("assistant");
+    expect(assistantMessage.session_id).toBe("session-123");
+    expect(assistantMessage.message.content).toEqual([
+      {
+        type: "tool_use",
+        id: "plan-456",
+        name: TOOL_NAMES.EXIT_PLAN_MODE,
+        input: {
+          plan: "1. Inspect files\n2. Update tests",
         },
-        parent_tool_use_id: null,
-        session_id: sessionId,
-        uuid: expect.any(String),
-      });
+      },
+    ]);
+  });
+
+  it("opens plan approval directly from the proactive ExitPlanMode request", () => {
+    const { result } = renderHook(() => usePlanApprovalWorkflow());
+
+    let toolUse;
+    act(() => {
+      toolUse = result.current.handlePlanPermissionRequest(
+        "1. Inspect files\n2. Update tests",
+        "plan-789",
+      );
     });
 
-    it("should handle plan rejection with missing toolUseId gracefully", () => {
-      const toolUseId = "";
-      const sessionId = "session-456";
+    expect(toolUse).toEqual({
+      type: "tool_use",
+      id: "plan-789",
+      name: TOOL_NAMES.EXIT_PLAN_MODE,
+      input: {
+        plan: "1. Inspect files\n2. Update tests",
+      },
+    });
+    expect(result.current.permissionRequest).toBeNull();
+    expect(result.current.planModeRequest).toEqual({
+      isOpen: true,
+      planContent: "1. Inspect files\n2. Update tests",
+    });
+    expect(result.current.isPermissionMode).toBe(true);
+  });
 
-      const toolResult = createExitPlanModeToolResult(sessionId, toolUseId);
+  it("supports empty plan content without falling back to reactive tool_result handling", () => {
+    const { result } = renderHook(() => usePlanApprovalWorkflow());
 
-      expect(toolResult.message.content[0]).toEqual({
-        type: "tool_result",
-        tool_use_id: "",
-        content: "Exit plan mode?",
-        is_error: true,
-      });
+    act(() => {
+      result.current.handlePlanPermissionRequest("", "plan-empty");
     });
 
-    it("should handle plan rejection with missing sessionId", () => {
-      const toolUseId = "exit-plan-123";
-      const sessionId = "";
-
-      const toolResult = createExitPlanModeToolResult(sessionId, toolUseId);
-
-      expect(toolResult.session_id).toBe("");
-      expect(toolResult.type).toBe("user");
+    expect(result.current.permissionRequest).toBeNull();
+    expect(result.current.planModeRequest).toEqual({
+      isOpen: true,
+      planContent: "",
     });
   });
 
-  describe("State Management During Plan Rejection", () => {
-    it("should properly manage state when rejecting plan", () => {
-      const { result } = renderHook(() => usePlanRejectionWorkflow());
+  it("closes the plan approval dialog and exits permission mode", () => {
+    const { result } = renderHook(() => usePlanApprovalWorkflow());
 
-      const toolUseId = "plan-rejection-123";
-      const sessionId = "session-789";
-
-      let rejectionResult;
-      act(() => {
-        rejectionResult = result.current.handlePlanRejection(
-          toolUseId,
-          sessionId,
-        );
-      });
-
-      // Should have sent tool result
-      expect(result.current.sendToolResult).toHaveBeenCalledTimes(1);
-      expect(result.current.sendToolResult).toHaveBeenCalledWith({
-        type: "user",
-        message: {
-          role: "user",
-          content: [
-            {
-              type: "tool_result",
-              tool_use_id: toolUseId,
-              content: "Exit plan mode?",
-              is_error: true,
-            },
-          ],
-        },
-        parent_tool_use_id: null,
-        session_id: sessionId,
-        uuid: expect.any(String),
-      });
-
-      // Should have updated permission mode back to plan
-      expect(result.current.updatePermissionMode).toHaveBeenCalledWith("plan");
-
-      // Should have closed the plan mode request
-      expect(result.current.closePlanModeRequest).toHaveBeenCalledTimes(1);
-
-      // Should return successful result
-      expect(rejectionResult).toEqual({
-        success: true,
-        toolResultGenerated: true,
-        stateUpdated: true,
-      });
+    act(() => {
+      result.current.handlePlanPermissionRequest("Review the repository");
     });
 
-    it("should handle multiple plan rejections correctly", () => {
-      const { result } = renderHook(() => usePlanRejectionWorkflow());
-
-      // First rejection
-      act(() => {
-        result.current.handlePlanRejection("plan-1", "session-1");
-      });
-
-      // Second rejection
-      act(() => {
-        result.current.handlePlanRejection("plan-2", "session-1");
-      });
-
-      // Should have been called twice
-      expect(result.current.sendToolResult).toHaveBeenCalledTimes(2);
-      expect(result.current.updatePermissionMode).toHaveBeenCalledTimes(2);
-      expect(result.current.closePlanModeRequest).toHaveBeenCalledTimes(2);
-
-      // Verify second call was with correct parameters
-      expect(result.current.sendToolResult).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          type: "user",
-          message: {
-            role: "user",
-            content: [
-              {
-                type: "tool_result",
-                tool_use_id: "plan-2",
-                content: "Exit plan mode?",
-                is_error: true,
-              },
-            ],
-          },
-          session_id: "session-1",
-        }),
-      );
-    });
-  });
-
-  describe("Integration with Streaming System", () => {
-    it("should generate tool_result message that can be processed by stream parser", async () => {
-      const toolUseId = "stream-plan-123";
-      const sessionId = "stream-session-456";
-
-      const toolResult = createExitPlanModeToolResult(sessionId, toolUseId);
-
-      // Simulate stream processing
-      const mockStreamData = {
-        type: "claude_json" as const,
-        data: toolResult,
-      };
-
-      // Verify stream data structure
-      expect(mockStreamData.type).toBe("claude_json");
-      expect(mockStreamData.data.type).toBe("user");
-      const content = mockStreamData.data.message.content;
-      if (Array.isArray(content)) {
-        expect(content[0].type).toBe("tool_result");
-        expect((content[0] as { is_error?: boolean }).is_error).toBe(true);
-      }
+    act(() => {
+      result.current.closePlanModeRequest();
     });
 
-    it("should handle tool_result message processing for plan rejection", () => {
-      // Test that tool_result data structure is compatible with message processing
-      const toolResultData = {
-        type: "tool_result" as const,
-        tool_use_id: "plan-rejection-456",
-        content: "Plan rejected by user",
-        is_error: true,
-      };
-
-      // Verify the structure matches what the system expects
-      expect(toolResultData.type).toBe("tool_result");
-      expect(toolResultData.tool_use_id).toBe("plan-rejection-456");
-      expect(toolResultData.is_error).toBe(true);
-      expect(toolResultData.content).toBe("Plan rejected by user");
-    });
-
-    it("should maintain session continuity during plan rejection", () => {
-      const originalSessionId = "continuous-session-123";
-      const toolUseId = "continuous-plan-456";
-
-      const toolResult = createExitPlanModeToolResult(
-        originalSessionId,
-        toolUseId,
-      );
-
-      // Session ID should be preserved in the tool result
-      expect(toolResult.session_id).toBe(originalSessionId);
-
-      // This ensures that the plan rejection doesn't break conversation continuity
-      expect(toolResult.type).toBe("user");
-      expect(toolResult.parent_tool_use_id).toBeNull();
-    });
-  });
-
-  describe("Error Handling in Plan Rejection", () => {
-    it("should handle plan rejection when sendToolResult fails", () => {
-      const { result } = renderHook(() => usePlanRejectionWorkflow());
-
-      // Make sendToolResult throw an error
-      result.current.sendToolResult.mockImplementation(() => {
-        throw new Error("Network error");
-      });
-
-      const toolUseId = "error-plan-123";
-      const sessionId = "error-session-456";
-
-      // Should handle error gracefully
-      expect(() => {
-        act(() => {
-          result.current.handlePlanRejection(toolUseId, sessionId);
-        });
-      }).toThrow("Network error");
-
-      // State management should still be attempted
-      expect(result.current.sendToolResult).toHaveBeenCalledTimes(1);
-    });
-
-    it("should handle plan rejection with malformed data", () => {
-      const toolUseId = null as unknown as string;
-      const sessionId = undefined as unknown as string;
-
-      // Should not throw error with null/undefined values
-      expect(() => {
-        createExitPlanModeToolResult(sessionId, toolUseId);
-      }).not.toThrow();
-
-      const result = createExitPlanModeToolResult(sessionId, toolUseId);
-      expect(result.session_id).toBeUndefined();
-      const content = result.message.content;
-      if (Array.isArray(content)) {
-        expect((content[0] as { tool_use_id?: string }).tool_use_id).toBeNull();
-      }
-    });
-  });
-
-  describe("Plan Rejection vs Approval Workflow", () => {
-    it("should have different behavior for rejection vs acceptance", () => {
-      // Test that plan rejection creates error tool_result while acceptance doesn't
-      const rejectionResult = createExitPlanModeToolResult(
-        "session",
-        "tool-123",
-      );
-
-      // Rejection should have is_error: true
-      const content = rejectionResult.message.content;
-      if (Array.isArray(content)) {
-        expect((content[0] as { is_error?: boolean }).is_error).toBe(true);
-        expect((content[0] as { content?: string }).content).toBe(
-          "Exit plan mode?",
-        );
-      }
-
-      // Acceptance would not create a tool_result message at all
-      // (This is the current behavior - acceptance just proceeds with the plan)
-    });
-
-    it("should maintain correct tool_use_id relationship", () => {
-      const originalToolUseId = "original-exitplanmode-123";
-      const sessionId = "relationship-session";
-
-      const rejectionResult = createExitPlanModeToolResult(
-        sessionId,
-        originalToolUseId,
-      );
-
-      // The tool_result should reference the original tool_use
-      const content = rejectionResult.message.content;
-      if (Array.isArray(content)) {
-        expect((content[0] as { tool_use_id?: string }).tool_use_id).toBe(
-          originalToolUseId,
-        );
-      }
-      expect(rejectionResult.type).toBe("user");
-    });
-  });
-
-  describe("Plan Rejection UI State Management", () => {
-    it("should reset UI state correctly after plan rejection", () => {
-      const { result } = renderHook(() => usePlanRejectionWorkflow());
-
-      act(() => {
-        result.current.handlePlanRejection("ui-plan-123", "ui-session-456");
-      });
-
-      // Should switch back to plan mode (allowing for more planning)
-      expect(result.current.updatePermissionMode).toHaveBeenCalledWith("plan");
-
-      // Should close the current plan request dialog
-      expect(result.current.closePlanModeRequest).toHaveBeenCalledTimes(1);
-
-      // Should send rejection signal to Qwen
-      expect(result.current.sendToolResult).toHaveBeenCalledTimes(1);
-    });
-
-    it("should allow for immediate re-planning after rejection", () => {
-      const { result } = renderHook(() => usePlanRejectionWorkflow());
-
-      // Reject first plan
-      act(() => {
-        result.current.handlePlanRejection("plan-v1", "session-replan");
-      });
-
-      // Should be in plan mode for immediate re-planning
-      expect(result.current.updatePermissionMode).toHaveBeenLastCalledWith(
-        "plan",
-      );
-
-      // Can immediately handle another plan
-      act(() => {
-        result.current.handlePlanRejection("plan-v2", "session-replan");
-      });
-
-      expect(result.current.updatePermissionMode).toHaveBeenCalledTimes(2);
-      expect(result.current.sendToolResult).toHaveBeenCalledTimes(2);
-    });
+    expect(result.current.planModeRequest).toBeNull();
+    expect(result.current.isPermissionMode).toBe(false);
   });
 });

--- a/frontend/src/hooks/streaming/useMessageProcessor.ts
+++ b/frontend/src/hooks/streaming/useMessageProcessor.ts
@@ -29,12 +29,6 @@ export interface StreamingContext {
   onInitMessageShown?: () => void;
   hasReceivedInit?: boolean;
   setHasReceivedInit?: (received: boolean) => void;
-  onPermissionError?: (
-    toolName: string,
-    patterns: string[],
-    toolUseId: string,
-    requestId?: string,
-  ) => void;
   onAbortRequest?: () => void;
   // Auto-rejection loop detection (SDK-level rejections, e.g. stdin closed)
   onAutoRejection?: (

--- a/frontend/src/hooks/streaming/useStreamParser.test.ts
+++ b/frontend/src/hooks/streaming/useStreamParser.test.ts
@@ -304,6 +304,72 @@ describe("useStreamParser", () => {
     });
   });
 
+  describe("Permission Request Handling", () => {
+    it("should forward proactive permission requests to onPermissionRequest", () => {
+      const onPermissionRequest = vi.fn();
+      mockContext.onPermissionRequest = onPermissionRequest;
+
+      const { result } = renderHook(() => useStreamParser());
+
+      result.current.processStreamLine(
+        JSON.stringify({
+          type: "permission_request",
+          permissionId: "perm-123",
+          toolName: TOOL_NAMES.BASH,
+          toolInput: { command: "ls -la" },
+          suggestions: [
+            {
+              type: "allow",
+              label: "Allow ls",
+              description: "Allow this command",
+            },
+          ],
+          autoApproveMs: 25000,
+        }),
+        mockContext,
+      );
+
+      expect(onPermissionRequest).toHaveBeenCalledWith({
+        permissionId: "perm-123",
+        toolName: TOOL_NAMES.BASH,
+        toolInput: { command: "ls -la" },
+        suggestions: [
+          {
+            type: "allow",
+            label: "Allow ls",
+            description: "Allow this command",
+          },
+        ],
+        autoApproveMs: 25000,
+        confirmationType: undefined,
+        questions: undefined,
+      });
+    });
+
+    it("should ignore invalid proactive permission requests", () => {
+      const onPermissionRequest = vi.fn();
+      mockContext.onPermissionRequest = onPermissionRequest;
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      const { result } = renderHook(() => useStreamParser());
+
+      result.current.processStreamLine(
+        JSON.stringify({
+          type: "permission_request",
+          toolInput: { command: "ls -la" },
+        }),
+        mockContext,
+      );
+
+      expect(onPermissionRequest).not.toHaveBeenCalled();
+      expect(warnSpy).toHaveBeenCalledWith(
+        "Invalid permission_request: missing permissionId or toolName",
+      );
+
+      warnSpy.mockRestore();
+    });
+  });
+
   describe("Stream Line Processing and Error Handling", () => {
     it("should handle malformed JSON gracefully", () => {
       const { result } = renderHook(() => useStreamParser());

--- a/frontend/src/hooks/useDemoAutomation.ts
+++ b/frontend/src/hooks/useDemoAutomation.ts
@@ -102,9 +102,6 @@ export function useDemoAutomation(
   const typingTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const typingIntervalRef = useRef<NodeJS.Timeout | null>(null);
 
-  // Cache tool names from assistant messages for permission error handling
-  const toolNameCacheRef = useRef<Map<string, string>>(new Map());
-
   // Chat state (fallback if not provided externally)
   const chatState = useChatState();
   const {
@@ -182,16 +179,16 @@ export function useDemoAutomation(
   // Process stream data
   const processStreamData = useCallback(
     (step: MockScenarioStep) => {
-      if (step.type === "permission_error") {
-        const errorData = step.data as {
+      if (step.type === "permission_request") {
+        const requestData = step.data as {
           toolName: string;
           pattern: string;
           toolUseId: string;
         };
         finalShowPermissionRequest(
-          errorData.toolName,
-          [errorData.pattern],
-          errorData.toolUseId,
+          requestData.toolName,
+          [requestData.pattern],
+          requestData.toolUseId,
         );
         return;
       }
@@ -262,11 +259,6 @@ export function useDemoAutomation(
                 input: Record<string, unknown>;
               };
 
-              // Cache tool name for permission error lookup
-              if (toolUse.id && toolUse.name) {
-                toolNameCacheRef.current.set(toolUse.id, toolUse.name);
-              }
-
               // Special handling for ExitPlanMode - create plan message instead of tool message
               if (toolUse.name === TOOL_NAMES.EXIT_PLAN_MODE) {
                 const planContent = (toolUse.input?.plan as string) || "";
@@ -294,7 +286,6 @@ export function useDemoAutomation(
         }
 
         case "user": {
-          // Handle user messages containing tool results (like ExitPlanMode)
           const userMsg = sdkMessage as Extract<SDKMessage, { type: "user" }>;
           const messageContent = userMsg.message.content;
 
@@ -308,39 +299,11 @@ export function useDemoAutomation(
                   is_error?: boolean;
                 };
 
-                // Check for permission errors (similar to useToolHandling.ts)
-                if (
-                  toolResult.is_error &&
-                  !toolResult.content.includes("tool_use_error")
-                ) {
-                  // For demo, we need to trigger permission dialog
-                  // Since this is ExitPlanMode, show plan permission request
-                  if (toolResult.content === "Exit plan mode?") {
-                    // This indicates an ExitPlanMode permission error
-                    // Check if showPlanModeRequest is available (it should be from usePermissions)
-                    // For now, trigger regular permission request with ExitPlanMode pattern
-                    // The ChatPage.tsx logic will convert this to plan mode request
-                    finalShowPermissionRequest(
-                      TOOL_NAMES.EXIT_PLAN_MODE,
-                      [TOOL_NAMES.EXIT_PLAN_MODE],
-                      toolResult.tool_use_id,
-                    );
-                  } else {
-                    // For other tool permission errors, look up cached tool name
-                    const cachedToolName = toolNameCacheRef.current.get(toolResult.tool_use_id) || "Unknown";
-                    finalShowPermissionRequest(
-                      cachedToolName,
-                      [cachedToolName],
-                      toolResult.tool_use_id,
-                    );
-                  }
-                } else {
-                  const toolResultMessage = createToolResultMessage(
-                    "Tool result",
-                    toolResult.content,
-                  );
-                  finalAddMessage(toolResultMessage);
-                }
+                const toolResultMessage = createToolResultMessage(
+                  "Tool result",
+                  toolResult.content,
+                );
+                finalAddMessage(toolResultMessage);
               }
             }
           }

--- a/frontend/src/utils/mockResponseGenerator.ts
+++ b/frontend/src/utils/mockResponseGenerator.ts
@@ -3,11 +3,22 @@ import { generateToolPattern } from "./toolUtils";
 import { generateId } from "./id";
 import { TOOL_NAMES } from "./toolNames";
 
-export interface MockStreamResponse {
-  type: "claude_json" | "done" | "error";
-  data?: SDKMessage;
-  error?: string;
-}
+export type MockStreamResponse =
+  | {
+      type: "claude_json";
+      data: SDKMessage;
+    }
+  | {
+      type: "permission_request";
+      data: { toolName: string; pattern: string; toolUseId: string };
+    }
+  | {
+      type: "done";
+    }
+  | {
+      type: "error";
+      error: string;
+    };
 
 export interface ButtonActionData {
   buttonType:
@@ -26,7 +37,7 @@ export type MockScenarioStep =
       data: SDKMessage;
     }
   | {
-      type: "permission_error";
+      type: "permission_request";
       delay: number;
       data: { toolName: string; pattern: string; toolUseId: string };
     }
@@ -202,30 +213,6 @@ export function createExitPlanModeToolUseWithId(
   };
 }
 
-// Generate ExitPlanMode tool result message
-export function createExitPlanModeToolResult(
-  sessionId: string,
-  toolUseId: string,
-): Extract<SDKMessage, { type: "user" }> {
-  return {
-    type: "user",
-    message: {
-      role: "user",
-      content: [
-        {
-          type: "tool_result",
-          tool_use_id: toolUseId,
-          content: "Exit plan mode?",
-          is_error: true, // Mark as error to trigger permission dialog
-        },
-      ],
-    },
-    parent_tool_use_id: null,
-    session_id: sessionId,
-    uuid: generateId(),
-  };
-}
-
 // Generate realistic tool use assistant messages
 export function createToolUseMessage(
   toolName: string,
@@ -262,16 +249,15 @@ export function* generateMockStream(
   steps: MockScenarioStep[],
 ): Generator<MockStreamResponse, void, unknown> {
   for (const step of steps) {
-    if (step.type === "permission_error") {
-      // This would trigger permission request in real app
-      const errorData = step.data as {
+    if (step.type === "permission_request") {
+      const requestData = step.data as {
         toolName: string;
         pattern: string;
         toolUseId: string;
       };
       yield {
-        type: "error",
-        error: `Permission required for tool: ${errorData.toolName}`,
+        type: "permission_request",
+        data: requestData,
       };
       continue;
     }
@@ -344,7 +330,7 @@ export const DEMO_SCENARIOS = {
         ),
       },
       {
-        type: "permission_error" as const,
+        type: "permission_request" as const,
         delay: 1000,
         data: {
           toolName: TOOL_NAMES.READ,
@@ -404,7 +390,7 @@ export const DEMO_SCENARIOS = {
         ),
       },
       {
-        type: "permission_error" as const,
+        type: "permission_request" as const,
         delay: 900,
         data: {
           toolName: TOOL_NAMES.BASH,
@@ -500,7 +486,7 @@ if __name__ == "__main__":
         ),
       },
       {
-        type: "permission_error" as const,
+        type: "permission_request" as const,
         delay: 1000,
         data: {
           toolName: TOOL_NAMES.WRITE,
@@ -551,7 +537,7 @@ if __name__ == "__main__":
         ),
       },
       {
-        type: "permission_error" as const,
+        type: "permission_request" as const,
         delay: 800,
         data: {
           toolName: TOOL_NAMES.BASH,
@@ -631,12 +617,13 @@ I'll create a comprehensive README.md file for the Qwen Code Web UI project with
           ),
         },
         {
-          type: "user" as const,
+          type: "permission_request" as const,
           delay: 1500,
-          data: createExitPlanModeToolResult(
-            "demo-session-plan",
-            planToolUseId,
-          ),
+          data: {
+            toolName: TOOL_NAMES.EXIT_PLAN_MODE,
+            pattern: TOOL_NAMES.EXIT_PLAN_MODE,
+            toolUseId: planToolUseId,
+          },
         },
         {
           type: "button_focus",


### PR DESCRIPTION
## Summary
- remove the unused reactive permission-error path from ChatPage and streaming context
- route remote and demo permission handling through explicit permission_request events
- add stream parser coverage for proactive permission requests

## Testing
- npm run typecheck
- npm run test:run -- src/hooks/streaming/useStreamParser.test.ts

Fixes #158