### PR TITLE
fix(DirectoryBrowser): display API errors and path hints in browse step

### DIFF
--- a/backend/app.ts
+++ b/backend/app.ts
@@ -30,6 +30,7 @@ import {
 } from "./handlers/quota.ts";
 import { logger } from "./utils/logger.ts";
 import { readBinaryFile } from "./utils/fs.ts";
+import { abortAllTrackedCliRequests } from "./utils/cliProcessRegistry.ts";
 import { handleDeleteProjectRequest } from "./handlers/projects.ts";
 import {
   handleGitStatusRequest,
@@ -80,6 +81,7 @@ export function createApp(
     for (const [, ac] of requestAbortControllers) {
       ac.abort();
     }
+    abortAllTrackedCliRequests();
     requestAbortControllers.clear();
     for (const [, pending] of pendingPermissions) {
       pending.resolve({ behavior: "deny", message: "Server shutting down" });

--- a/backend/handlers/abort.test.ts
+++ b/backend/handlers/abort.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { handleAbortRequest } from "./abort.ts";
+import { signalTrackedCliAbort } from "../utils/cliProcessRegistry.ts";
+
+vi.mock("../utils/logger.ts", () => ({
+  logger: {
+    api: {
+      debug: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("../utils/cliProcessRegistry.ts", () => ({
+  signalTrackedCliAbort: vi.fn(),
+}));
+
+function createMockContext(requestId: string | undefined) {
+  return {
+    req: {
+      param: vi.fn().mockReturnValue(requestId),
+    },
+    json: vi.fn().mockImplementation((data, status?: number) => ({ data, status })),
+  } as unknown as Parameters<typeof handleAbortRequest>[0];
+}
+
+describe("handleAbortRequest", () => {
+  let requestAbortControllers: Map<string, AbortController>;
+
+  beforeEach(() => {
+    requestAbortControllers = new Map();
+    vi.clearAllMocks();
+  });
+
+  it("aborts the request without eagerly deleting controller state", () => {
+    const ctx = createMockContext("req-1");
+    const abortController = new AbortController();
+    requestAbortControllers.set("req-1", abortController);
+    const spy = vi.spyOn(abortController, "abort");
+
+    handleAbortRequest(ctx, requestAbortControllers);
+
+    expect(signalTrackedCliAbort).toHaveBeenCalledWith("req-1", "user");
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(signalTrackedCliAbort).mock.invocationCallOrder[0])
+      .toBeLessThan(spy.mock.invocationCallOrder[0]);
+    expect(abortController.signal.aborted).toBe(true);
+    expect(requestAbortControllers.has("req-1")).toBe(true);
+    expect(ctx.json).toHaveBeenCalledWith({ success: true, message: "Request aborted" });
+  });
+
+  it("returns 404 for unknown requests", () => {
+    const ctx = createMockContext("missing");
+
+    handleAbortRequest(ctx, requestAbortControllers);
+
+    expect(ctx.json).toHaveBeenCalledWith(
+      { error: "Request not found or already completed" },
+      404,
+    );
+  });
+});

--- a/backend/handlers/abort.ts
+++ b/backend/handlers/abort.ts
@@ -1,5 +1,6 @@
 import { Context } from "hono";
 import { logger } from "../utils/logger.ts";
+import { signalTrackedCliAbort } from "../utils/cliProcessRegistry.ts";
 
 /**
  * Handles POST /api/abort/:requestId requests
@@ -25,8 +26,8 @@ export function handleAbortRequest(
 
   const abortController = requestAbortControllers.get(requestId);
   if (abortController) {
+    signalTrackedCliAbort(requestId, "user");
     abortController.abort();
-    requestAbortControllers.delete(requestId);
 
     logger.api.debug(`Aborted request: ${requestId}`);
 

--- a/backend/handlers/chat.test.ts
+++ b/backend/handlers/chat.test.ts
@@ -2,19 +2,11 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { Context } from "hono";
 import { handleChatRequest } from "./chat";
 import type { ChatRequest } from "../../shared/types";
-import { query } from "@qwen-code/sdk";
+const mockQuery = vi.fn();
 
-// Define minimal mock types for Qwen Code SDK to maintain type safety in tests
-type MockQwenCode = {
-  query: typeof vi.fn;
-};
-
-vi.mock(
-  "@qwen-code/sdk",
-  (): MockQwenCode => ({
-    query: vi.fn(),
-  }),
-);
+vi.mock("../utils/qwenSdk.ts", () => ({
+  loadQwenQuery: vi.fn(async () => mockQuery),
+}));
 
 // Mock logger
 vi.mock("../utils/logger", () => ({
@@ -34,8 +26,6 @@ vi.mock("../utils/sessionBridge.ts", () => ({
     Promise.resolve(sessionId),
   ),
 }));
-
-const mockQuery = vi.mocked(query);
 
 describe("Chat Handler - Permission Mode Tests", () => {
   let mockContext: Context;
@@ -500,10 +490,7 @@ describe("Chat Handler - Permission Mode Tests", () => {
       expect(doneResponse).toEqual({ type: "done" });
     });
 
-    // TODO: Re-enable when AbortError is properly exported from Claude SDK
-    it.skip("should handle abort errors when using permissionMode", async () => {
-      // Test currently skipped because AbortError is not exported from Claude SDK
-      // When AbortError becomes available, update this test accordingly
+    it("should emit aborted messages when the SDK aborts", async () => {
       const chatRequest: ChatRequest = {
         message: "Abort test",
         requestId: "test-abort",
@@ -538,13 +525,12 @@ describe("Chat Handler - Permission Mode Tests", () => {
       }
 
       const lines = allChunks.trim().split("\n");
-      expect(lines).toHaveLength(1);
+      expect(lines).toHaveLength(2);
 
-      const errorResponse = JSON.parse(lines[0]);
-      expect(errorResponse).toEqual({
-        type: "error",
-        error: "Operation aborted",
-      });
+      const abortedResponse = JSON.parse(lines[0]);
+      const doneResponse = JSON.parse(lines[1]);
+      expect(abortedResponse).toEqual({ type: "aborted" });
+      expect(doneResponse).toEqual({ type: "done" });
     });
   });
 

--- a/backend/handlers/chat.ts
+++ b/backend/handlers/chat.ts
@@ -1,9 +1,17 @@
 import { Context } from "hono";
-import { query, type PermissionMode, type AuthType, type PermissionResult } from "@qwen-code/sdk";
+import type { PermissionMode, AuthType, PermissionResult } from "@qwen-code/sdk";
 import type { ChatRequest, StreamResponse } from "../../shared/types.ts";
 import { logger } from "../utils/logger.ts";
 import { checkLoop, type LoopState } from "../utils/loopDetector.ts";
 import { bridgeSession } from "../utils/sessionBridge.ts";
+import {
+  finalizeTrackedCliRequest,
+  registerTrackedCliRequest,
+  runWithTrackedCliRequest,
+  signalTrackedCliAbort,
+  updateTrackedCliSessionId,
+} from "../utils/cliProcessRegistry.ts";
+import { loadQwenQuery } from "../utils/qwenSdk.ts";
 import type { PendingPermission } from "./permission.ts";
 import type { ServerResponse } from "node:http";
 
@@ -47,6 +55,16 @@ const CLI_CONTROL_REQUEST_TIMEOUT_MS = 30_000;
 const AUTO_APPROVE_MS = CLI_CONTROL_REQUEST_TIMEOUT_MS - 5_000; // 25 s
 /** Backend fallback — fires a few seconds after frontend should have acted. */
 const SAFETY_AUTO_APPROVE_MS = CLI_CONTROL_REQUEST_TIMEOUT_MS - 2_000; // 28 s
+
+function isAbortLikeError(error: unknown): boolean {
+  if (error instanceof DOMException && error.name === "AbortError") {
+    return true;
+  }
+  if (!(error instanceof Error)) {
+    return false;
+  }
+  return error.name === "AbortError" || error.message === "Operation aborted";
+}
 
 /**
  * Maps UI permission mode to Qwen SDK permission mode
@@ -102,7 +120,8 @@ async function executeQwenCommand(
   model?: string,
   authType?: AuthType,
 ): Promise<void> {
-  let abortController: AbortController;
+  let abortController: AbortController | undefined;
+  let onAbort: (() => void) | undefined;
   const localPendingIds = new Set<string>();
   // Read-only tools approved by the user during this request — auto-approved on
   // subsequent calls within the same streaming session. Scope is limited to a
@@ -128,6 +147,13 @@ async function executeQwenCommand(
     // Create and store AbortController for this request
     abortController = new AbortController();
     requestAbortControllers.set(requestId, abortController);
+    registerTrackedCliRequest(requestId, { sessionId, cliPath });
+    const query = await loadQwenQuery();
+
+    onAbort = () => {
+      signalTrackedCliAbort(requestId, "internal_abort");
+    };
+    abortController.signal.addEventListener("abort", onAbort, { once: true });
 
     // Log permission mode for debugging
     const mappedPermissionMode = permissionMode ? mapPermissionMode(permissionMode) : undefined;
@@ -162,7 +188,7 @@ async function executeQwenCommand(
       _options: { signal: AbortSignal; suggestions?: unknown[] | null },
     ): Promise<PermissionResult> => {
       // Defense 1: check main query abort (not SDK's per-request signal)
-      if (abortController.signal.aborted) {
+      if (abortController!.signal.aborted) {
         return { behavior: "deny", message: "Request aborted" };
       }
 
@@ -262,10 +288,10 @@ async function executeQwenCommand(
             Array.isArray(q.options) &&
             q.options.length >= 2 &&
             q.options.length <= 4 &&
-            q.options.every((o) =>
+            q.options.every((o: unknown) =>
               typeof o === "object" &&
               o !== null &&
-              typeof o.label === "string"
+              typeof (o as { label?: unknown }).label === "string"
             ) &&
             typeof q.multiSelect === "boolean"
           )
@@ -273,7 +299,7 @@ async function executeQwenCommand(
           questions = rawQuestions.map((q) => ({
             question: String(q.question),
             header: String(q.header).substring(0, 12), // Limit header to 12 chars
-            options: q.options.map((o) => ({
+            options: q.options.map((o: { label: string; description?: string }) => ({
               label: String(o.label),
               description: o.description ? String(o.description) : undefined,
             })),
@@ -335,12 +361,12 @@ async function executeQwenCommand(
           localPendingIds.delete(permissionId);
           safeResolve({ behavior: "deny", message: "Request aborted" });
         };
-        abortController.signal.addEventListener("abort", onAbort, { once: true });
+        abortController!.signal.addEventListener("abort", onAbort, { once: true });
 
         pendingPermissions.set(permissionId, {
           resolve: (result, scope) => {
             clearTimeout(safetyTimer);
-            abortController.signal.removeEventListener("abort", onAbort);
+            abortController!.signal.removeEventListener("abort", onAbort);
             localPendingIds.delete(permissionId);
             if (result.behavior === "allow") {
               if (scope === "specific" && toolName === "run_shell_command" && input?.command && typeof input.command === "string") {
@@ -352,73 +378,79 @@ async function executeQwenCommand(
             }
             safeResolve(result);
           },
-          abortSignal: abortController.signal,
+          abortSignal: abortController!.signal,
         });
       });
     };
 
-    for await (const sdkMessage of query({
-      prompt: processedMessage,
-      options: {
-        abortController,
-        pathToQwenExecutable: cliPath,
-        ...(sessionId ? { resume: sessionId } : {}),
-        ...(allowedTools ? { allowedTools } : {}),
-        ...(workingDirectory ? { cwd: workingDirectory } : {}),
-        ...(mappedPermissionMode ? { permissionMode: mappedPermissionMode } : {}),
-        ...(model ? { model } : {}),
-        ...(authType ? { authType } : {}),
-        stderr: (message: string) => {
-          logger.chat.info("CLI stderr: {message}", { message });
+    await runWithTrackedCliRequest(requestId, async () => {
+      for await (const sdkMessage of query({
+        prompt: processedMessage,
+        options: {
+          abortController: abortController!,
+          pathToQwenExecutable: cliPath,
+          ...(sessionId ? { resume: sessionId } : {}),
+          ...(allowedTools ? { allowedTools } : {}),
+          ...(workingDirectory ? { cwd: workingDirectory } : {}),
+          ...(mappedPermissionMode ? { permissionMode: mappedPermissionMode } : {}),
+          ...(model ? { model } : {}),
+          ...(authType ? { authType } : {}),
+          stderr: (message: string) => {
+            logger.chat.info("CLI stderr: {message}", { message });
+          },
+          canUseTool,
+          timeout: { canUseTool: SESSION_TIMEOUT_MS, controlRequest: SESSION_TIMEOUT_MS },
         },
-        canUseTool,
-        timeout: { canUseTool: SESSION_TIMEOUT_MS, controlRequest: SESSION_TIMEOUT_MS },
-      },
-    })) {
-      messageCount++;
-      if (firstMessageLatencyMs === null) {
-        firstMessageLatencyMs = Date.now() - startTime;
-        logger.chat.info(
-          "[DIAG] First SDK message received requestId={requestId} latencyMs={latencyMs}",
-          { requestId, latencyMs: firstMessageLatencyMs },
-        );
-      }
+      })) {
+        messageCount++;
+        if (firstMessageLatencyMs === null) {
+          firstMessageLatencyMs = Date.now() - startTime;
+          logger.chat.info(
+            "[DIAG] First SDK message received requestId={requestId} latencyMs={latencyMs}",
+            { requestId, latencyMs: firstMessageLatencyMs },
+          );
+        }
+        const sdkSessionId = (sdkMessage as Record<string, unknown>).session_id;
+        if (typeof sdkSessionId === "string") {
+          updateTrackedCliSessionId(requestId, sdkSessionId);
+        }
 
-      // Backend loop detection — failsafe if frontend detection fails.
-      // Each agent (main session or fork) maintains its own LoopState
-      // so parallel fork agents don't accumulate toward the same counter (#140).
-      const rawForkId = (sdkMessage as Record<string, unknown>).parent_tool_use_id;
-      const forkId = typeof rawForkId === "string" ? rawForkId : undefined;
-      const ls = forkId
-        ? (agentLoopStates.get(forkId) ?? { errorCount: 0, lastFingerprint: "", firstErrorTime: 0 })
-        : loopState;
-      if (forkId && !agentLoopStates.has(forkId)) {
-        agentLoopStates.set(forkId, ls);
-      }
-      const loopResult = checkLoop(sdkMessage, ls);
-      if (loopResult) {
-        logger.chat.error(
-          "Loop detected: fingerprint={fingerprint}, count={count}, aborting CLI",
-          { fingerprint: loopResult.fingerprint, count: loopResult.count },
-        );
-        abortController.abort();
-        const errorMessage = loopResult.fingerprint === "input_closed"
-          ? "CLI session ended unexpectedly. Please send a new message."
-          : `Auto-aborted: loop detected (${loopResult.fingerprint}, ${loopResult.count}x)`;
+        // Backend loop detection — failsafe if frontend detection fails.
+        // Each agent (main session or fork) maintains its own LoopState
+        // so parallel fork agents don't accumulate toward the same counter (#140).
+        const rawForkId = (sdkMessage as Record<string, unknown>).parent_tool_use_id;
+        const forkId = typeof rawForkId === "string" ? rawForkId : undefined;
+        const ls = forkId
+          ? (agentLoopStates.get(forkId) ?? { errorCount: 0, lastFingerprint: "", firstErrorTime: 0 })
+          : loopState;
+        if (forkId && !agentLoopStates.has(forkId)) {
+          agentLoopStates.set(forkId, ls);
+        }
+        const loopResult = checkLoop(sdkMessage, ls);
+        if (loopResult) {
+          logger.chat.error(
+            "Loop detected: fingerprint={fingerprint}, count={count}, aborting CLI",
+            { fingerprint: loopResult.fingerprint, count: loopResult.count },
+          );
+          abortController!.abort();
+          const errorMessage = loopResult.fingerprint === "input_closed"
+            ? "CLI session ended unexpectedly. Please send a new message."
+            : `Auto-aborted: loop detected (${loopResult.fingerprint}, ${loopResult.count}x)`;
+          if (!enqueue({
+            type: "error",
+            error: errorMessage,
+          })) break;
+          break;
+        }
+
+        logger.chat.debug("Qwen SDK Message: {sdkMessage}", { sdkMessage });
+
         if (!enqueue({
-          type: "error",
-          error: errorMessage,
+          type: "claude_json",
+          data: sdkMessage,
         })) break;
-        break;
       }
-
-      logger.chat.debug("Qwen SDK Message: {sdkMessage}", { sdkMessage });
-
-      if (!enqueue({
-        type: "claude_json",
-        data: sdkMessage,
-      })) break;
-    }
+    });
 
     if (!enqueue({ type: "done" })) return;
 
@@ -433,6 +465,11 @@ async function executeQwenCommand(
       },
     );
   } catch (error) {
+    if (abortController?.signal.aborted || isAbortLikeError(error)) {
+      enqueue({ type: "aborted" });
+      enqueue({ type: "done" });
+      return;
+    }
     logger.chat.error(
       "[DIAG] Chat request ERROR requestId={requestId} durationMs={durationMs} "
       + "messageCount={messageCount} error={error}",
@@ -450,12 +487,16 @@ async function executeQwenCommand(
     enqueue({ type: "done" });
   } finally {
     _activeChatCount--;
+    if (abortController && onAbort) {
+      abortController.signal.removeEventListener("abort", onAbort);
+    }
     // Ensure CLI subprocess is killed on any exit path (issue #84)
     const ac = requestAbortControllers.get(requestId);
     if (ac) {
       ac.abort();
       requestAbortControllers.delete(requestId);
     }
+    finalizeTrackedCliRequest(requestId);
     // Clean up session mapping so a new request can start for this session
     if (sessionId && activeSessions.get(sessionId) === requestId) {
       activeSessions.delete(sessionId);

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qwen-code-webui",
-  "version": "0.2.34",
+  "version": "0.2.35",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qwen-code-webui",
-      "version": "0.2.34",
+      "version": "0.2.35",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.11",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qwen-code-webui",
-  "version": "0.2.34",
+  "version": "0.2.35",
   "type": "module",
   "description": "Web-based interface for the Qwen Code CLI with streaming chat interface",
   "keywords": [
@@ -45,6 +45,7 @@
     "build:static": "node scripts/copy-frontend.js",
     "start": "node dist/cli/node.js",
     "test": "vitest --run --reporter=verbose",
+    "test:integration:stop-abort": "node scripts/verify-stop-abort.js",
     "lint": "eslint \"**/*.ts\" --ignore-pattern dist/",
     "format": "prettier --write \"**/*.ts\"",
     "format:check": "prettier --check \"**/*.ts\"",

--- a/backend/scripts/verify-stop-abort.js
+++ b/backend/scripts/verify-stop-abort.js
@@ -1,0 +1,232 @@
+#!/usr/bin/env node
+
+import { spawn, execFileSync } from "node:child_process";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const backendRoot = resolve(__dirname, "..");
+const fakeCliPath = resolve(backendRoot, "test-fixtures/fake-qwen-cli.mjs");
+
+function sleep(ms) {
+  return new Promise((resolvePromise) => setTimeout(resolvePromise, ms));
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function countTraceLines(traceFile) {
+  if (!existsSync(traceFile)) return 0;
+  const content = readFileSync(traceFile, "utf8").trim();
+  if (!content) return 0;
+  return content.split("\n").length;
+}
+
+function findFakeCliProcesses(sessionId) {
+  const output = execFileSync("ps", ["-Ao", "pid=,command="], {
+    encoding: "utf8",
+  });
+
+  return output
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const match = line.match(/^(\d+)\s+(.*)$/);
+      if (!match) return null;
+      return { pid: Number(match[1]), command: match[2] };
+    })
+    .filter((entry) => entry !== null)
+    .filter((entry) =>
+      entry.command.includes(fakeCliPath)
+      && entry.command.includes(`--session-id ${sessionId}`)
+    );
+}
+
+async function waitForServer(port, backendProcess) {
+  const deadline = Date.now() + 20_000;
+  while (Date.now() < deadline) {
+    if (backendProcess.exitCode !== null) {
+      throw new Error(`Backend exited early with code ${backendProcess.exitCode}`);
+    }
+
+    try {
+      const response = await fetch(`http://127.0.0.1:${port}/api/version`);
+      if (response.ok) return;
+    } catch {
+      // Keep polling until the server is reachable.
+    }
+
+    await sleep(250);
+  }
+
+  throw new Error("Timed out waiting for backend server to start");
+}
+
+async function terminateBackend(processHandle) {
+  if (processHandle.exitCode !== null) return;
+
+  processHandle.kill("SIGINT");
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    if (processHandle.exitCode !== null) return;
+    await sleep(100);
+  }
+
+  processHandle.kill("SIGKILL");
+}
+
+async function main() {
+  const tempDir = mkdtempSync(join(tmpdir(), "qwen-stop-abort-"));
+  const traceFile = join(tempDir, "trace.log");
+  writeFileSync(traceFile, "");
+
+  const port = 3200 + Math.floor(Math.random() * 500);
+  const requestId = `verify-stop-${Date.now()}`;
+  let backendProcess = null;
+
+  try {
+    backendProcess = spawn(
+      "./node_modules/.bin/tsx",
+      [
+        "cli/node.ts",
+        "--debug",
+        "--port",
+        String(port),
+        "--host",
+        "127.0.0.1",
+        "--qwen-path",
+        fakeCliPath,
+      ],
+      {
+        cwd: backendRoot,
+        env: {
+          ...process.env,
+          FAKE_QWEN_TRACE_FILE: traceFile,
+        },
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+
+    let backendStdout = "";
+    let backendStderr = "";
+    backendProcess.stdout.on("data", (chunk) => {
+      backendStdout += chunk.toString();
+    });
+    backendProcess.stderr.on("data", (chunk) => {
+      backendStderr += chunk.toString();
+    });
+
+    await waitForServer(port, backendProcess);
+
+    const response = await fetch(`http://127.0.0.1:${port}/api/chat`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        message: "verify stop behavior",
+        requestId,
+        permissionMode: "default",
+      }),
+    });
+
+    assert(response.ok, `Chat request failed with ${response.status}`);
+    assert(response.body, "Chat response did not include a body");
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let lineBuffer = "";
+    let abortSent = false;
+    let sawAborted = false;
+    let sawDone = false;
+    let sessionId = null;
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      lineBuffer += decoder.decode(value, { stream: true });
+      const lines = lineBuffer.split("\n");
+      lineBuffer = lines.pop() || "";
+
+      for (const line of lines) {
+        if (!line.trim()) continue;
+        const message = JSON.parse(line);
+
+        if (message.type === "claude_json" && message.data?.session_id) {
+          sessionId = message.data.session_id;
+          if (!abortSent) {
+            await sleep(1_000);
+            const linesBeforeAbort = countTraceLines(traceFile);
+            assert(linesBeforeAbort > 0, "Fake CLI never started writing to the trace file");
+
+            const cliProcesses = findFakeCliProcesses(sessionId);
+            assert(cliProcesses.length > 0, "Fake CLI process was not running before abort");
+
+            const abortResponse = await fetch(
+              `http://127.0.0.1:${port}/api/abort/${requestId}`,
+              {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+              },
+            );
+            assert(abortResponse.ok, `Abort request failed with ${abortResponse.status}`);
+            abortSent = true;
+          }
+        } else if (message.type === "aborted") {
+          sawAborted = true;
+        } else if (message.type === "done") {
+          sawDone = true;
+        }
+      }
+    }
+
+    assert(abortSent, "Abort endpoint was never triggered during the integration run");
+    assert(sessionId, "Did not observe a CLI session id in the stream");
+    assert(sawAborted, "Stream did not emit an aborted terminal message");
+    assert(sawDone, "Stream did not emit a done terminal message");
+
+    await sleep(6_500);
+    const traceAfterAbort = countTraceLines(traceFile);
+    await sleep(2_000);
+    const traceStableCheck = countTraceLines(traceFile);
+
+    assert(
+      traceAfterAbort === traceStableCheck,
+      `Trace file kept growing after abort (${traceAfterAbort} -> ${traceStableCheck})`,
+    );
+    assert(
+      findFakeCliProcesses(sessionId).length === 0,
+      "Fake CLI process still exists after watchdog escalation window",
+    );
+
+    console.log("Stop abort integration verification passed.");
+  } catch (error) {
+    console.error("Stop abort integration verification failed.");
+    if (backendProcess) {
+      console.error("Backend exit code:", backendProcess.exitCode);
+    }
+    throw error;
+  } finally {
+    if (backendProcess) {
+      await terminateBackend(backendProcess);
+    }
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/backend/test-fixtures/fake-qwen-cli.mjs
+++ b/backend/test-fixtures/fake-qwen-cli.mjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+
+const args = process.argv.slice(2);
+
+if (args.includes("--version")) {
+  console.log("fake-qwen-cli 0.0.1");
+  process.exit(0);
+}
+
+process.on("SIGTERM", () => {
+  // Intentionally ignore SIGTERM so the WebUI watchdog must escalate to SIGKILL.
+  fs.appendFileSync(process.env.FAKE_QWEN_TRACE_FILE, `sigterm:${Date.now()}\n`);
+});
+
+const traceFile = process.env.FAKE_QWEN_TRACE_FILE;
+let sessionId = "fake-session";
+let writer = null;
+
+function send(message) {
+  process.stdout.write(`${JSON.stringify(message)}\n`);
+}
+
+function startWriter() {
+  if (writer) return;
+  writer = setInterval(() => {
+    fs.appendFileSync(traceFile, `tick:${Date.now()}\n`);
+  }, 250);
+}
+
+const chunks = [];
+
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => {
+  chunks.push(chunk);
+  const content = chunks.join("");
+  const lines = content.split("\n");
+  chunks.length = 0;
+  chunks.push(lines.pop() || "");
+
+  for (const line of lines) {
+    if (!line.trim()) continue;
+    const message = JSON.parse(line);
+
+    if (message.type === "control_request") {
+      send({
+        type: "control_response",
+        response: {
+          subtype: "success",
+          request_id: message.request_id,
+          response: {},
+        },
+      });
+      continue;
+    }
+
+    if (message.type === "user") {
+      sessionId = message.session_id || sessionId;
+      send({
+        type: "assistant",
+        uuid: "fake-assistant-1",
+        session_id: sessionId,
+        parent_tool_use_id: null,
+        message: {
+          content: [
+            {
+              type: "text",
+              text: "fake cli working",
+            },
+          ],
+        },
+      });
+      startWriter();
+    }
+  }
+});
+
+process.stdin.on("end", () => {
+  // Keep running even after stdin closes so abort verification can confirm
+  // that the WebUI forcibly reaps the CLI process.
+});

--- a/backend/utils/cliProcessRegistry.test.ts
+++ b/backend/utils/cliProcessRegistry.test.ts
@@ -1,0 +1,98 @@
+import { EventEmitter } from "node:events";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  __cliProcessRegistryTestUtils,
+  finalizeTrackedCliRequest,
+  registerTrackedCliRequest,
+  signalTrackedCliAbort,
+} from "./cliProcessRegistry.ts";
+
+vi.mock("./logger.ts", () => ({
+  logger: {
+    chat: {
+      debug: vi.fn(),
+      error: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+    },
+  },
+}));
+
+class FakeChildProcess extends EventEmitter {
+  pid: number;
+  exitCode: number | null = null;
+  signalCode: NodeJS.Signals | null = null;
+
+  constructor(pid: number) {
+    super();
+    this.pid = pid;
+  }
+}
+
+describe("cliProcessRegistry", () => {
+  let alivePids: Set<number>;
+  let killSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    alivePids = new Set<number>();
+    __cliProcessRegistryTestUtils.reset();
+
+    killSpy = vi.spyOn(process, "kill").mockImplementation(((pid: number, signal?: number | NodeJS.Signals) => {
+      if (signal === 0 || signal === undefined) {
+        if (!alivePids.has(pid)) {
+          throw new Error(`process ${pid} missing`);
+        }
+        return true;
+      }
+
+      if (!alivePids.has(pid)) {
+        throw new Error(`process ${pid} missing`);
+      }
+
+      if (signal === "SIGKILL") {
+        alivePids.delete(pid);
+      }
+      return true;
+    }) as typeof process.kill);
+  });
+
+  afterEach(() => {
+    killSpy.mockRestore();
+    vi.useRealTimers();
+    __cliProcessRegistryTestUtils.reset();
+  });
+
+  it("escalates to SIGKILL when a tracked CLI survives SIGTERM", () => {
+    registerTrackedCliRequest("req-1", { sessionId: "session-1" });
+
+    const child = new FakeChildProcess(4242);
+    alivePids.add(child.pid);
+    __cliProcessRegistryTestUtils.attachChildToRequest("req-1", child as unknown as import("node:child_process").ChildProcess);
+
+    signalTrackedCliAbort("req-1", "user");
+
+    expect(killSpy).toHaveBeenCalledWith(4242, "SIGTERM");
+
+    vi.advanceTimersByTime(5_000);
+
+    expect(killSpy).toHaveBeenCalledWith(4242, "SIGKILL");
+  });
+
+  it("clears abort timers when the tracked CLI exits before escalation", () => {
+    registerTrackedCliRequest("req-2");
+
+    const child = new FakeChildProcess(5252);
+    alivePids.add(child.pid);
+    __cliProcessRegistryTestUtils.attachChildToRequest("req-2", child as unknown as import("node:child_process").ChildProcess);
+
+    signalTrackedCliAbort("req-2", "user");
+    alivePids.delete(child.pid);
+    child.emit("close");
+
+    vi.advanceTimersByTime(5_000);
+
+    expect(killSpy).toHaveBeenCalledTimes(1);
+    finalizeTrackedCliRequest("req-2");
+  });
+});

--- a/backend/utils/cliProcessRegistry.ts
+++ b/backend/utils/cliProcessRegistry.ts
@@ -1,0 +1,307 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import type { ChildProcess } from "node:child_process";
+import { logger } from "./logger.ts";
+
+const childProcess = require("node:child_process") as typeof import("node:child_process");
+
+type AbortSource =
+  | "user"
+  | "stream_disconnect"
+  | "request_superseded"
+  | "server_shutdown"
+  | "internal_abort";
+
+interface TrackedRequest {
+  requestId: string;
+  sessionId?: string;
+  cliPath?: string;
+  children: Map<number, ChildProcess>;
+  abortSource?: AbortSource;
+  forceKillTimer?: ReturnType<typeof setTimeout>;
+  requestEnded?: boolean;
+}
+
+const FORCE_KILL_AFTER_MS = 5_000;
+const trackedRequests = new Map<string, TrackedRequest>();
+const requestContext = new AsyncLocalStorage<{ requestId: string }>();
+
+let patchInstalled = false;
+let originalSpawn = childProcess.spawn;
+let originalFork = childProcess.fork;
+
+function isSdkCliSpawn(command: string, args: readonly string[]): boolean {
+  return (
+    args.includes("--channel=SDK")
+    && args.includes("--input-format")
+    && args.includes("stream-json")
+    && args.includes("--output-format")
+  );
+}
+
+function isSdkCliFork(modulePath: string, args: readonly string[]): boolean {
+  return modulePath.includes("cli.js") && args.includes("--channel=SDK");
+}
+
+function isPidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function findSessionCliPids(sessionId: string, cliPath?: string): number[] {
+  try {
+    const output = childProcess.execFileSync(
+      "ps",
+      ["-Ao", "pid=,command="],
+      { encoding: "utf8" },
+    );
+    const matches = output
+      .split("\n")
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map((line) => {
+        const match = line.match(/^(\d+)\s+(.*)$/);
+        if (!match) return null;
+        return { pid: Number(match[1]), command: match[2] };
+      })
+      .filter((entry): entry is { pid: number; command: string } => !!entry)
+      .filter(({ command }) =>
+        (!cliPath || command.includes(cliPath))
+        && (
+          command.includes(`--session-id ${sessionId}`)
+          || command.includes(`--resume ${sessionId}`)
+        )
+      )
+      .map(({ pid }) => pid);
+
+    return matches;
+  } catch (error) {
+    logger.chat.warn(
+      "[DIAG] Failed to scan process list for sessionId={sessionId}: {error}",
+      { sessionId, error },
+    );
+    return [];
+  }
+}
+
+function sendSignal(child: ChildProcess, signal: NodeJS.Signals, requestId: string): void {
+  const pid = child.pid;
+  if (!pid) return;
+
+  try {
+    process.kill(pid, signal);
+    logger.chat.warn(
+      "[DIAG] Sent signal={signal} to CLI pid={pid} requestId={requestId}",
+      { signal, pid, requestId },
+    );
+  } catch (error) {
+    logger.chat.warn(
+      "[DIAG] Failed to send signal={signal} to CLI pid={pid} requestId={requestId}: {error}",
+      { signal, pid, requestId, error },
+    );
+  }
+}
+
+function maybeClearForceKillTimer(state: TrackedRequest): void {
+  if (state.children.size > 0 || !state.forceKillTimer) return;
+  clearTimeout(state.forceKillTimer);
+  state.forceKillTimer = undefined;
+  if (state.requestEnded) {
+    trackedRequests.delete(state.requestId);
+  }
+}
+
+function attachChildToRequest(requestId: string, child: ChildProcess): void {
+  const pid = child.pid;
+  if (!pid) return;
+
+  const state = trackedRequests.get(requestId);
+  if (!state) return;
+
+  if (state.children.has(pid)) return;
+  state.children.set(pid, child);
+
+  logger.chat.info(
+    "[DIAG] Tracking CLI pid={pid} requestId={requestId} sessionId={sessionId}",
+    { pid, requestId, sessionId: state.sessionId },
+  );
+
+  const cleanup = () => {
+    const current = trackedRequests.get(requestId);
+    if (!current) return;
+    current.children.delete(pid);
+    maybeClearForceKillTimer(current);
+  };
+
+  child.once("close", cleanup);
+  child.once("exit", cleanup);
+
+  if (state.abortSource) {
+    sendSignal(child, "SIGTERM", requestId);
+  }
+}
+
+function installChildProcessPatch(): void {
+  if (patchInstalled) return;
+  patchInstalled = true;
+
+  originalSpawn = childProcess.spawn;
+  originalFork = childProcess.fork;
+  const originalSpawnAny = originalSpawn as (...args: any[]) => ChildProcess;
+  const originalForkAny = originalFork as (...args: any[]) => ChildProcess;
+
+  childProcess.spawn = ((...args: any[]) => {
+    const [command, spawnArgs] = args;
+    const child = originalSpawnAny(...args);
+    const requestId = requestContext.getStore()?.requestId;
+    if (requestId && Array.isArray(spawnArgs) && isSdkCliSpawn(String(command), spawnArgs)) {
+      attachChildToRequest(requestId, child);
+    }
+    return child;
+  }) as unknown as typeof childProcess.spawn;
+
+  childProcess.fork = ((...args: any[]) => {
+    const [modulePath, forkArgs] = args;
+    const child = originalForkAny(...args);
+    const requestId = requestContext.getStore()?.requestId;
+    if (requestId && Array.isArray(forkArgs) && isSdkCliFork(String(modulePath), forkArgs)) {
+      attachChildToRequest(requestId, child);
+    }
+    return child;
+  }) as unknown as typeof childProcess.fork;
+}
+
+export function registerTrackedCliRequest(
+  requestId: string,
+  options: { sessionId?: string; cliPath?: string } = {},
+): void {
+  installChildProcessPatch();
+  trackedRequests.set(requestId, {
+    requestId,
+    sessionId: options.sessionId,
+    cliPath: options.cliPath,
+    children: new Map(),
+  });
+}
+
+export function updateTrackedCliSessionId(requestId: string, sessionId: string): void {
+  const state = trackedRequests.get(requestId);
+  if (!state) return;
+  state.sessionId = sessionId;
+}
+
+export function runWithTrackedCliRequest<T>(requestId: string, fn: () => T): T {
+  return requestContext.run({ requestId }, fn);
+}
+
+export function signalTrackedCliAbort(
+  requestId: string,
+  source: AbortSource,
+): void {
+  const state = trackedRequests.get(requestId);
+  if (!state) return;
+
+  if (!state.abortSource) {
+    state.abortSource = source;
+    logger.chat.warn(
+      "[DIAG] CLI abort requested requestId={requestId} source={source} trackedChildren={trackedChildren}",
+      { requestId, source, trackedChildren: state.children.size },
+    );
+  }
+
+  for (const child of state.children.values()) {
+    sendSignal(child, "SIGTERM", requestId);
+  }
+
+  if (state.sessionId) {
+    for (const pid of findSessionCliPids(state.sessionId, state.cliPath)) {
+      try {
+        process.kill(pid, "SIGTERM");
+        logger.chat.warn(
+          "[DIAG] Sent fallback signal=SIGTERM to CLI pid={pid} requestId={requestId}",
+          { pid, requestId },
+        );
+      } catch (error) {
+        logger.chat.warn(
+          "[DIAG] Failed fallback SIGTERM pid={pid} requestId={requestId}: {error}",
+          { pid, requestId, error },
+        );
+      }
+    }
+  }
+
+  if (state.forceKillTimer) return;
+
+  state.forceKillTimer = setTimeout(() => {
+    const current = trackedRequests.get(requestId);
+    if (!current) return;
+
+    current.forceKillTimer = undefined;
+    for (const [pid, child] of current.children) {
+      if (!isPidAlive(pid)) continue;
+      sendSignal(child, "SIGKILL", requestId);
+    }
+    if (current.sessionId) {
+      for (const pid of findSessionCliPids(current.sessionId, current.cliPath)) {
+        if (!isPidAlive(pid)) continue;
+        try {
+          process.kill(pid, "SIGKILL");
+          logger.chat.warn(
+            "[DIAG] Sent fallback signal=SIGKILL to CLI pid={pid} requestId={requestId}",
+            { pid, requestId },
+          );
+        } catch (error) {
+          logger.chat.warn(
+            "[DIAG] Failed fallback SIGKILL pid={pid} requestId={requestId}: {error}",
+            { pid, requestId, error },
+          );
+        }
+      }
+    }
+    if (current.requestEnded) {
+      trackedRequests.delete(requestId);
+    }
+  }, FORCE_KILL_AFTER_MS);
+
+  if (state.forceKillTimer.unref) {
+    state.forceKillTimer.unref();
+  }
+}
+
+export function finalizeTrackedCliRequest(requestId: string): void {
+  const state = trackedRequests.get(requestId);
+  if (!state) return;
+
+  if (state.forceKillTimer) {
+    state.requestEnded = true;
+    return;
+  }
+
+  trackedRequests.delete(requestId);
+}
+
+export function abortAllTrackedCliRequests(): void {
+  for (const requestId of trackedRequests.keys()) {
+    signalTrackedCliAbort(requestId, "server_shutdown");
+  }
+}
+
+export const __cliProcessRegistryTestUtils = {
+  attachChildToRequest,
+  isSdkCliSpawn,
+  isSdkCliFork,
+  reset(): void {
+    for (const state of trackedRequests.values()) {
+      if (state.forceKillTimer) {
+        clearTimeout(state.forceKillTimer);
+      }
+    }
+    trackedRequests.clear();
+  },
+  getTrackedRequest(requestId: string): TrackedRequest | undefined {
+    return trackedRequests.get(requestId);
+  },
+};

--- a/backend/utils/qwenSdk.ts
+++ b/backend/utils/qwenSdk.ts
@@ -1,0 +1,4 @@
+export async function loadQwenQuery(): Promise<typeof import("@qwen-code/sdk").query> {
+  const sdk = await import("@qwen-code/sdk");
+  return sdk.query;
+}

--- a/frontend/src/api/openace.ts
+++ b/frontend/src/api/openace.ts
@@ -528,7 +528,8 @@ export async function getRemoteSessionStatus(
  * Abort the current in-progress request without stopping the session
  */
 export async function abortRemoteRequest(
-  sessionId: string
+  sessionId: string,
+  reason = "user"
 ): Promise<{ success: boolean }> {
   const url = buildOpenAceUrl(`/api/remote/sessions/${sessionId}/abort`);
 
@@ -537,6 +538,7 @@ export async function abortRemoteRequest(
     headers: {
       "Content-Type": "application/json",
     },
+    body: JSON.stringify({ reason }),
   });
 
   if (!response.ok) {

--- a/frontend/src/api/openace.ts
+++ b/frontend/src/api/openace.ts
@@ -126,6 +126,17 @@ export interface CheckPathResponse {
   error?: string;
 }
 
+export interface WorkspaceConfigResponse {
+  enabled: boolean;
+  url: string;
+  multi_user_mode: boolean;
+  port_range_start: number;
+  port_range_end: number;
+  max_instances: number;
+  idle_timeout_minutes: number;
+  base_dir: string;
+}
+
 export interface SessionModelsResponse {
   success: boolean;
   models: ModelConfig[];
@@ -244,6 +255,26 @@ export async function checkPath(path: string): Promise<CheckPathResponse> {
     };
   }
   
+  return response.json();
+}
+
+/**
+ * Get workspace configuration from Open-ACE
+ */
+export async function getWorkspaceConfig(): Promise<WorkspaceConfigResponse> {
+  const url = buildOpenAceUrl("/api/workspace/config");
+
+  const response = await fetch(url, {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to get workspace config: ${response.statusText}`);
+  }
+
   return response.json();
 }
 

--- a/frontend/src/components/AddProjectModal.tsx
+++ b/frontend/src/components/AddProjectModal.tsx
@@ -69,6 +69,7 @@ export function AddProjectModal({
 
   const handleSelectDirectory = async (path: string) => {
     setSelectedPath(path);
+    setErrorMessage(""); // Clear previous error
 
     // Extract default name from path
     const segments = path.split(/[/\\]/).filter(Boolean);
@@ -245,6 +246,23 @@ export function AddProjectModal({
                         </button>
                       </div>
                     </div>
+
+                    {/* Error message in browse step */}
+                    {errorMessage && (
+                      <div className="mb-4 p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg">
+                        <div className="flex items-start gap-2">
+                          <ExclamationCircleIcon className="h-5 w-5 text-red-500 flex-shrink-0" />
+                          <div>
+                            <p className="text-sm font-medium text-red-700 dark:text-red-300">
+                              {t("project.invalidPath")}
+                            </p>
+                            <p className="text-sm text-red-600 dark:text-red-400 mt-1">
+                              {errorMessage}
+                            </p>
+                          </div>
+                        </div>
+                      </div>
+                    )}
 
                     {workspaceType === "local" ? (
                       <>

--- a/frontend/src/components/ChatPage.tsx
+++ b/frontend/src/components/ChatPage.tsx
@@ -334,7 +334,7 @@ export function ChatPage() {
               notificationTriggeredRef.current = true;
               commandLoopShowRef.current?.(request);
               // Auto-abort the remote request
-              remoteChat.abortCurrentRequest();
+              remoteChat.abortCurrentRequest("system");
               // Clear sessionId on fatal session errors
               if (request.errorOutput?.toLowerCase().includes("input closed")) {
                 setCurrentSessionId(null);
@@ -356,11 +356,33 @@ export function ChatPage() {
             },
           },
           onPermissionRequest: (event) => {
-            // Forward remote CLI permission request to the existing permission panel
             const req = event.request;
             if (req?.tool_name) {
-              const patterns = req.permission_suggestions?.map(s => s.rule) || [];
-              permissionErrorRef.current?.(req.tool_name, patterns, req.tool_use_id || "", event.request_id);
+              const toolInput = req.input || {};
+              const { toolName: extractedName, commands } = extractToolInfo(
+                req.tool_name,
+                toolInput,
+              );
+              const patterns =
+                req.permission_suggestions?.map((suggestion) => suggestion.rule) ||
+                generateToolPatterns(extractedName, commands);
+
+              notificationTriggeredRef.current = true;
+              if (patterns.includes(TOOL_NAMES.EXIT_PLAN_MODE)) {
+                showPlanModeRequest("");
+                showPlanNotification();
+                return;
+              }
+
+              showPermissionRequest(
+                extractedName,
+                patterns,
+                req.tool_use_id || "",
+                event.request_id,
+                undefined,
+                toolInput,
+              );
+              showPermissionNotification();
             }
           },
           onQuotaExceeded: (quotaStatus) => {
@@ -526,13 +548,7 @@ export function ChatPage() {
   // during the current streaming session (used to decide if input notification should fire)
   const notificationTriggeredRef = useRef(false);
 
-  // Ref for permission error handler — used by remote streamingContext to
-  // avoid declaration-order issues (handlePermissionError is defined below).
-  const permissionErrorRef = useRef<
-    ((toolName: string, patterns: string[], toolUseId: string, requestId?: string) => void) | null
-  >(null);
-
-  // Ref for thinking timeout handler — same pattern as permissionErrorRef
+  // Ref for thinking timeout handler
   const thinkingTimeoutRef = useRef<
     ((accumulatedContent: string, info: ThinkingTimeoutContext) => void) | null
   >(null);
@@ -542,6 +558,38 @@ export function ChatPage() {
 
   // Ref to suppress error message when abort is triggered by /clear
   const clearAbortRef = useRef(false);
+  const activeFetchAbortControllerRef = useRef<AbortController | null>(null);
+  const activeLocalAbortReasonRef = useRef<"user" | "stall" | "system" | null>(null);
+
+  const abortLocalFetch = useCallback((reason: "user" | "stall" | "system") => {
+    activeLocalAbortReasonRef.current = reason;
+    const controller = activeFetchAbortControllerRef.current;
+    if (controller && !controller.signal.aborted) {
+      controller.abort();
+    }
+  }, []);
+
+  const abortLocalRequest = useCallback(
+    async (
+      requestId: string | null,
+      options: { resetState?: boolean; reason: "user" | "system" } = { reason: "user" },
+    ) => {
+      if (!requestId || !isLoading) return;
+
+      abortLocalFetch(options.reason);
+
+      try {
+        await abortRequest(requestId, true);
+      } catch (error) {
+        console.error("Failed to abort request:", error);
+      } finally {
+        if (options.resetState) {
+          resetRequestState();
+        }
+      }
+    },
+    [abortLocalFetch, abortRequest, isLoading, resetRequestState],
+  );
 
   // Show input notification when AI finishes responding (isLoading changes from true to false)
   useEffect(() => {
@@ -564,25 +612,6 @@ export function ChatPage() {
       notificationTriggeredRef.current = false;
     }
   }, [effectiveIsLoading, showInputNotification]);
-
-  const handlePermissionError = useCallback(
-    (toolName: string, patterns: string[], toolUseId: string, requestId?: string) => {
-      notificationTriggeredRef.current = true;
-      // Check if this is an ExitPlanMode permission error
-      if (patterns.includes(TOOL_NAMES.EXIT_PLAN_MODE)) {
-        // For ExitPlanMode, show plan permission interface instead of regular permission
-        showPlanModeRequest(""); // Empty plan content since it was already displayed
-        // Show tab notification for plan approval
-        showPlanNotification();
-      } else {
-        showPermissionRequest(toolName, patterns, toolUseId, requestId);
-        // Show tab notification for permission request
-        showPermissionNotification();
-      }
-    },
-    [showPermissionRequest, showPlanModeRequest, showPermissionNotification, showPlanNotification],
-  );
-  permissionErrorRef.current = handlePermissionError;
 
   const sendMessage = useCallback(
     async (
@@ -652,7 +681,13 @@ export function ChatPage() {
       // Stream stall detection: abort fetch if no data received for 120s.
       // Backend sends heartbeat every 15s, so 120s = 8 missed heartbeats.
       const fetchAbortController = new AbortController();
-      const stallDetector = createStallDetector(fetchAbortController);
+      activeFetchAbortControllerRef.current = fetchAbortController;
+      activeLocalAbortReasonRef.current = null;
+      const stallDetector = createStallDetector(fetchAbortController, undefined, () => {
+        if (activeFetchAbortControllerRef.current === fetchAbortController) {
+          activeLocalAbortReasonRef.current = "stall";
+        }
+      });
 
       try {
         const response = await fetch(getChatUrl(), {
@@ -712,6 +747,7 @@ export function ChatPage() {
           },
           onAbortRequest: async () => {
             shouldAbort = true;
+            abortLocalFetch("system");
             await createAbortHandler(requestId)();
           },
           // Auto-rejection loop detection
@@ -725,6 +761,7 @@ export function ChatPage() {
             shouldAbort = true;
             showCommandLoopRequest(request);
             // Auto-abort the request
+            abortLocalFetch("system");
             createAbortHandler(requestId)();
             // Clear sessionId on fatal session errors
             if (request.errorOutput?.toLowerCase().includes("input closed")) {
@@ -809,13 +846,15 @@ export function ChatPage() {
           error instanceof DOMException && error.name === "AbortError"
           && fetchAbortController.signal.aborted
         ) {
-          addMessage({
-            type: "chat",
-            role: "assistant",
-            content: t("chat.errorStreamStall"),
-            timestamp: Date.now(),
-          });
-          setCurrentSessionId(null);
+          if (activeLocalAbortReasonRef.current === "stall") {
+            addMessage({
+              type: "chat",
+              role: "assistant",
+              content: t("chat.errorStreamStall"),
+              timestamp: Date.now(),
+            });
+            setCurrentSessionId(null);
+          }
         } else if (!clearAbortRef.current) {
           console.error("Failed to send message:", error);
           const errorText = error instanceof Error
@@ -833,6 +872,10 @@ export function ChatPage() {
         }
       } finally {
         stallDetector.dispose();
+        if (activeFetchAbortControllerRef.current === fetchAbortController) {
+          activeFetchAbortControllerRef.current = null;
+          activeLocalAbortReasonRef.current = null;
+        }
 
         // Release the reader to free the HTTP connection.
         // Without this, the browser keeps connections open and eventually
@@ -887,7 +930,7 @@ export function ChatPage() {
       setCurrentAssistantMessage,
       resetRequestState,
       processStreamLine,
-      handlePermissionError,
+      abortLocalFetch,
       createAbortHandler,
       showInputNotification,
       isRemoteWorkspace,
@@ -897,12 +940,11 @@ export function ChatPage() {
 
   const handleAbort = useCallback(() => {
     if (isRemoteWorkspace && remoteChat.session) {
-      remoteChat.abortCurrentRequest();
-      resetRequestState();
+      void remoteChat.abortCurrentRequest("user");
       return;
     }
-    abortRequest(currentRequestId, isLoading, resetRequestState);
-  }, [abortRequest, currentRequestId, isLoading, resetRequestState, isRemoteWorkspace, remoteChat.abortCurrentRequest, remoteChat.session]);
+    void abortLocalRequest(currentRequestId, { reason: "user" });
+  }, [abortLocalRequest, currentRequestId, isRemoteWorkspace, remoteChat.abortCurrentRequest, remoteChat.session]);
 
   // Slash command execution handler
   const handleExecuteSlashCommand = useCallback(
@@ -921,9 +963,9 @@ export function ChatPage() {
     // Abort any in-flight request to prevent stale messages
     clearAbortRef.current = true;
     if (isRemoteWorkspace && remoteChat.session) {
-      remoteChat.abortCurrentRequest();
+      void remoteChat.abortCurrentRequest("system");
     } else {
-      abortRequest(currentRequestId, isLoading, resetRequestState);
+      void abortLocalRequest(currentRequestId, { reason: "system", resetState: true });
     }
     resetRequestState();
     setMessages([]);
@@ -938,14 +980,14 @@ export function ChatPage() {
       content: t("slashCommands.contextCleared"),
       timestamp: Date.now(),
     });
-  }, [setMessages, setCurrentSessionId, setHasShownInitMessage, setHasReceivedInit, addMessage, t, navigate, abortRequest, currentRequestId, isLoading, resetRequestState, isRemoteWorkspace, remoteChat.abortCurrentRequest, remoteChat.session]);
+  }, [setMessages, setCurrentSessionId, setHasShownInitMessage, setHasReceivedInit, addMessage, t, navigate, abortLocalRequest, currentRequestId, resetRequestState, isRemoteWorkspace, remoteChat.abortCurrentRequest, remoteChat.session]);
 
   // Permission request handlers
   // Abort backend request when permission response HTTP POST fails,
   // preventing stuck canUseTool promises that block the stream forever.
   const handlePermissionAbort = useCallback(async () => {
-    await abortRequest(currentRequestId, isLoading, resetRequestState);
-  }, [abortRequest, currentRequestId, isLoading, resetRequestState]);
+    await abortLocalRequest(currentRequestId, { reason: "system" });
+  }, [abortLocalRequest, currentRequestId]);
 
   const handlePermissionAllow = useCallback(async () => {
     if (!permissionRequest) return;
@@ -995,23 +1037,11 @@ export function ChatPage() {
       return;
     }
 
-    // Legacy reactive flow — abort + new request with expanded allowedTools
-    let updatedAllowedTools = allowedTools;
-    permissionRequest.patterns.forEach((pattern) => {
-      updatedAllowedTools = allowToolTemporary(pattern, updatedAllowedTools);
-    });
-
     closePermissionRequest();
-
-    if (currentSessionId) {
-      sendMessage("continue", updatedAllowedTools, true);
-    }
   }, [
     permissionRequest,
-    currentSessionId,
-    sendMessage,
     allowedTools,
-    allowToolTemporary,
+    allowToolPermanent,
     closePermissionRequest,
     resetDenialCounter,
     clearNotification,
@@ -1065,22 +1095,9 @@ export function ChatPage() {
       return;
     }
 
-    // Legacy reactive flow
-    // Accumulate all patterns into a single update to avoid React batching race
-    let updatedAllowedTools = allowedTools;
-    permissionRequest.patterns.forEach((pattern) => {
-      updatedAllowedTools = allowToolPermanent(pattern, updatedAllowedTools);
-    });
-
     closePermissionRequest();
-
-    if (currentSessionId) {
-      sendMessage("continue", updatedAllowedTools, true);
-    }
   }, [
     permissionRequest,
-    currentSessionId,
-    sendMessage,
     allowedTools,
     allowToolPermanent,
     closePermissionRequest,
@@ -1098,36 +1115,30 @@ export function ChatPage() {
     resetDenialCounter();
     clearNotification();
 
-    if (permissionRequest.permissionId) {
-      // Persist bare tool name so ALL run_shell_command calls are auto-approved
-      allowToolPermanent(permissionRequest.toolName, allowedTools);
-      try {
-        const resp = await sendPermissionResponse(permissionRequest.permissionId, "allow", {
-          updatedInput: permissionRequest.toolInput || {},
-          scope: "all",
-        });
-        if (!resp.ok) {
-          console.warn("Permission response failed:", resp.status);
-          await handlePermissionAbort();
-        }
-      } catch (error) {
-        console.error("Failed to send permission response:", error);
-        await handlePermissionAbort();
-      }
+    // Defensive guard: the UI only renders "allow all" for proactive requests.
+    if (!permissionRequest.permissionId) {
       closePermissionRequest();
       return;
     }
 
-    // Legacy reactive flow
-    const updatedAllowedTools = allowToolPermanent(permissionRequest.toolName, allowedTools);
-    closePermissionRequest();
-    if (currentSessionId) {
-      sendMessage("continue", updatedAllowedTools, true);
+    // Persist bare tool name so ALL run_shell_command calls are auto-approved
+    allowToolPermanent(permissionRequest.toolName, allowedTools);
+    try {
+      const resp = await sendPermissionResponse(permissionRequest.permissionId, "allow", {
+        updatedInput: permissionRequest.toolInput || {},
+        scope: "all",
+      });
+      if (!resp.ok) {
+        console.warn("Permission response failed:", resp.status);
+        await handlePermissionAbort();
+      }
+    } catch (error) {
+      console.error("Failed to send permission response:", error);
+      await handlePermissionAbort();
     }
+    closePermissionRequest();
   }, [
     permissionRequest,
-    currentSessionId,
-    sendMessage,
     allowedTools,
     allowToolPermanent,
     closePermissionRequest,
@@ -1180,25 +1191,9 @@ export function ChatPage() {
       return;
     }
 
-    // Legacy reactive flow
     closePermissionRequest();
-
-    if (currentSessionId) {
-      if (loopMessage) {
-        sendMessage(loopMessage, allowedTools, true);
-      } else {
-        sendMessage(
-          `The user denied the permission request for ${toolName}. Please stop retrying and ask the user what they would like to do instead.`,
-          allowedTools,
-          true
-        );
-      }
-    }
   }, [
     permissionRequest,
-    currentSessionId,
-    sendMessage,
-    allowedTools,
     closePermissionRequest,
     recordDenial,
     clearNotification,
@@ -1293,14 +1288,13 @@ export function ChatPage() {
     closeCommandLoopRequest();
     // Abort current request if loading
     if (isLoading && currentRequestId) {
-      abortRequest(currentRequestId, isLoading, resetRequestState);
+      void abortLocalRequest(currentRequestId, { reason: "system" });
     }
   }, [
+    abortLocalRequest,
     closeCommandLoopRequest,
     isLoading,
     currentRequestId,
-    abortRequest,
-    resetRequestState,
   ]);
 
   // Thinking timeout handler — abort and show notification
@@ -1320,11 +1314,10 @@ export function ChatPage() {
 
       // Abort the request
       if (isLoading && currentRequestId) {
-        abortRequest(currentRequestId, isLoading, resetRequestState);
+        void abortLocalRequest(currentRequestId, { reason: "system" });
         aborted = true;
       } else if (isRemoteWorkspace && remoteChat.session) {
-        remoteChat.abortCurrentRequest();
-        resetRequestState();
+        remoteChat.abortCurrentRequest("timeout");
         aborted = true;
       }
 
@@ -1336,7 +1329,7 @@ export function ChatPage() {
         aborted,
       });
     },
-    [isLoading, currentRequestId, abortRequest, resetRequestState, isRemoteWorkspace, remoteChat],
+    [abortLocalRequest, isLoading, currentRequestId, isRemoteWorkspace, remoteChat],
   );
   thinkingTimeoutRef.current = handleThinkingTimeout;
 
@@ -1348,7 +1341,9 @@ export function ChatPage() {
         toolInput: permissionRequest.toolInput,
         onAllow: handlePermissionAllow,
         onAllowPermanent: handlePermissionAllowPermanent,
-        onAllowAll: handlePermissionAllowAll,
+        onAllowAll: permissionRequest.permissionId
+          ? handlePermissionAllowAll
+          : undefined,
         onDeny: handlePermissionDeny,
         autoApproveMs: permissionRequest.autoApproveMs,
       }
@@ -1847,6 +1842,7 @@ export function ChatPage() {
               <ChatInput
                 input={input}
                 isLoading={effectiveIsLoading}
+                isStopping={isRemoteWorkspace && remoteChat.isStopping}
                 currentRequestId={currentRequestId}
                 onInputChange={setInput}
                 onSubmit={() => sendMessage()}

--- a/frontend/src/components/DemoPage.tsx
+++ b/frontend/src/components/DemoPage.tsx
@@ -135,12 +135,11 @@ export function DemoPage() {
     closePlanModeRequest,
   } = usePermissions();
 
-  const handlePermissionError = useCallback(
+  const handlePermissionRequest = useCallback(
     (toolName: string, patterns: string[], toolUseId: string) => {
-      // Check if this is an ExitPlanMode permission error
+      // Route ExitPlanMode requests to the plan approval UI
       if (patterns.includes(TOOL_NAMES.EXIT_PLAN_MODE)) {
-        // For ExitPlanMode, show plan permission interface instead of regular permission
-        showPlanModeRequest(""); // Empty plan content since it was already displayed
+        showPlanModeRequest("");
       } else {
         showPermissionRequest(toolName, patterns, toolUseId);
       }
@@ -319,7 +318,7 @@ export function DemoPage() {
     startRequest,
     resetRequestState,
     generateRequestId,
-    showPermissionRequest: handlePermissionError,
+    showPermissionRequest: handlePermissionRequest,
     onButtonFocus: handleButtonFocus,
     onButtonClick: handleButtonClick,
   });

--- a/frontend/src/components/DirectoryBrowser.tsx
+++ b/frontend/src/components/DirectoryBrowser.tsx
@@ -9,6 +9,7 @@ import {
 import { useTranslation } from "react-i18next";
 import {
   browseDirectory,
+  getWorkspaceConfig,
   type DirectoryInfo,
   type BrowseResponse,
 } from "../api/openace";
@@ -33,6 +34,16 @@ export function DirectoryBrowser({
   const [error, setError] = useState<string | null>(null);
   const [newDirName, setNewDirName] = useState("");
   const [showNewDirInput, setShowNewDirInput] = useState(false);
+  const [baseDir, setBaseDir] = useState<string | null>(null);
+
+  // Fetch workspace config to get base_dir for path validation hint
+  useEffect(() => {
+    getWorkspaceConfig()
+      .then((config) => setBaseDir(config.base_dir))
+      .catch(() => {
+        // Ignore error - base_dir hint is optional
+      });
+  }, []);
 
   const loadDirectory = useCallback(async (path?: string) => {
     setLoading(true);
@@ -95,9 +106,15 @@ export function DirectoryBrowser({
   const handleCreateNewDir = () => {
     if (!newDirName.trim()) return;
 
-    const newPath = currentPath
-      ? `${currentPath}/${newDirName.trim()}`.replace(/\/+/g, "/")
-      : newDirName.trim();
+    const inputPath = newDirName.trim();
+
+    // If input is an absolute path (starts with /), use it directly
+    // Otherwise, combine with currentPath as a relative path
+    const newPath = inputPath.startsWith("/")
+      ? inputPath
+      : currentPath
+        ? `${currentPath}/${inputPath}`.replace(/\/+/g, "/")
+        : inputPath;
 
     onSelectDirectory(newPath);
   };
@@ -171,6 +188,15 @@ export function DirectoryBrowser({
       {error && (
         <div className="px-3 py-2 bg-yellow-50 dark:bg-yellow-900/20 border-b border-yellow-200 dark:border-yellow-800">
           <p className="text-sm text-yellow-700 dark:text-yellow-400">{error}</p>
+        </div>
+      )}
+
+      {/* Path hint - show valid base directory */}
+      {baseDir && !error && (
+        <div className="px-3 py-1.5 bg-blue-50 dark:bg-blue-900/20 border-b border-blue-100 dark:border-blue-800">
+          <p className="text-xs text-blue-600 dark:text-blue-400">
+            {t("directoryBrowser.pathHint", { baseDir })}
+          </p>
         </div>
       )}
 

--- a/frontend/src/components/chat/ChatInput.tsx
+++ b/frontend/src/components/chat/ChatInput.tsx
@@ -1,5 +1,5 @@
 import React, { useRef, useEffect, useState, useCallback } from "react";
-import { StopIcon } from "@heroicons/react/24/solid";
+import { ArrowPathIcon, StopIcon } from "@heroicons/react/24/solid";
 import { useTranslation } from "react-i18next";
 import { UI_CONSTANTS, KEYBOARD_SHORTCUTS } from "../../utils/constants";
 import { useEnterBehavior } from "../../hooks/useSettings";
@@ -52,6 +52,7 @@ interface PlanPermissionData {
 interface ChatInputProps {
   input: string;
   isLoading: boolean;
+  isStopping?: boolean;
   currentRequestId: string | null;
   onInputChange: (value: string) => void;
   onSubmit: () => void;
@@ -74,6 +75,7 @@ interface ChatInputProps {
 export function ChatInput({
   input,
   isLoading,
+  isStopping = false,
   currentRequestId,
   onInputChange,
   onSubmit,
@@ -420,9 +422,14 @@ export function ChatInput({
                 type="button"
                 onClick={onAbort}
                 className="p-2 bg-red-100 hover:bg-red-200 dark:bg-red-900/20 dark:hover:bg-red-900/30 text-red-600 dark:text-red-400 rounded-lg transition-all duration-200 shadow-sm hover:shadow-md"
-                title={t("chat.stop")}
+                title={isStopping ? t("chat.stopping") : t("chat.stop")}
+                aria-label={isStopping ? t("chat.stopping") : t("chat.stop")}
               >
-                <StopIcon className="w-4 h-4" />
+                {isStopping ? (
+                  <ArrowPathIcon className="w-4 h-4 animate-spin" />
+                ) : (
+                  <StopIcon className="w-4 h-4" />
+                )}
               </button>
             )}
             <button

--- a/frontend/src/components/settings/GeneralSettings.tsx
+++ b/frontend/src/components/settings/GeneralSettings.tsx
@@ -6,6 +6,7 @@ import {
   ChevronDownIcon,
   ChevronUpIcon,
   ArrowPathIcon,
+  InformationCircleIcon,
 } from "@heroicons/react/24/outline";
 import { useTranslation } from "react-i18next";
 import { useSettings } from "../../hooks/useSettings";
@@ -28,6 +29,7 @@ export function GeneralSettings({ allowedTools = [], onResetPermissions }: Gener
     enterBehavior,
     experimental,
     expandThinking,
+    isEmbeddedMode,
     toggleTheme,
     toggleEnterBehavior,
     toggleExpandThinking,
@@ -70,29 +72,51 @@ export function GeneralSettings({ allowedTools = [], onResetPermissions }: Gener
             <label className="text-sm font-medium text-slate-700 dark:text-slate-300 mb-2 block">
               {t("settings.theme")}
             </label>
-            <div className="flex items-center gap-2">
-              <button
-                onClick={toggleTheme}
-                className="flex items-center gap-3 px-4 py-3 bg-slate-50 dark:bg-slate-700/50 border border-slate-200 dark:border-slate-600 rounded-lg hover:bg-slate-100 dark:hover:bg-slate-700 transition-all duration-200 text-left flex-1"
-                role="switch"
-                aria-checked={theme === "dark"}
-                aria-label={`Theme toggle. Currently set to ${theme} mode. Click to switch to ${theme === "light" ? "dark" : "light"} mode.`}
-              >
+            {isEmbeddedMode ? (
+              // In embedded mode, show current theme with info message
+              <div className="flex items-center gap-3 px-4 py-3 bg-slate-50 dark:bg-slate-700/50 border border-slate-200 dark:border-slate-600 rounded-lg">
                 {theme === "light" ? (
                   <SunIcon className="w-5 h-5 text-yellow-500" />
                 ) : (
                   <MoonIcon className="w-5 h-5 text-blue-400" />
                 )}
-                <div>
+                <div className="flex-1">
                   <div className="text-sm font-medium text-slate-800 dark:text-slate-100">
                     {theme === "light" ? t("settings.lightMode") : t("settings.darkMode")}
                   </div>
-                  <div className="text-xs text-slate-500 dark:text-slate-400">
-                    {theme === "light" ? t("settings.darkMode") : t("settings.lightMode")}
+                  <div className="text-xs text-slate-500 dark:text-slate-400 flex items-center gap-1">
+                    <InformationCircleIcon className="w-3 h-3" />
+                    Theme follows parent window settings
                   </div>
                 </div>
-              </button>
-            </div>
+              </div>
+            ) : (
+              // Normal mode: show toggle button
+              <div className="flex items-center gap-2">
+                <button
+                  onClick={toggleTheme}
+                  className="flex items-center gap-3 px-4 py-3 bg-slate-50 dark:bg-slate-700/50 border border-slate-200 dark:border-slate-600 rounded-lg hover:bg-slate-100 dark:hover:bg-slate-700 transition-all duration-200 text-left flex-1"
+                  role="switch"
+                  aria-checked={theme === "dark"}
+                  aria-label={`Theme toggle. Currently set to ${theme} mode. Click to switch to ${theme === "light" ? "dark" : "light"} mode.`}
+                >
+                  {theme === "light" ? (
+                    <SunIcon className="w-5 h-5 text-yellow-500" />
+                  ) : (
+                    <MoonIcon className="w-5 h-5 text-blue-400" />
+                  )}
+                  <div>
+                    <div className="text-sm font-medium text-slate-800 dark:text-slate-100">
+                      {theme === "light" ? "Light Mode" : "Dark Mode"}
+                    </div>
+                    <div className="text-xs text-slate-500 dark:text-slate-400">
+                      Click to switch to {theme === "light" ? "dark" : "light"}{" "}
+                      mode
+                    </div>
+                  </div>
+                </button>
+              </div>
+            )}
           </div>
 
           {/* Language Setting */}
@@ -120,8 +144,8 @@ export function GeneralSettings({ allowedTools = [], onResetPermissions }: Gener
               </select>
             </div>
             <div className="mt-2 text-xs text-slate-500 dark:text-slate-400">
-              {i18n.language === "zh-CN" 
-                ? "选择界面显示语言" 
+              {i18n.language === "zh-CN"
+                ? "选择界面显示语言"
                 : "Select the interface display language"}
             </div>
           </div>
@@ -181,7 +205,7 @@ export function GeneralSettings({ allowedTools = [], onResetPermissions }: Gener
                 )}
                 <div>
                   <div className="text-sm font-medium text-slate-800 dark:text-slate-100">
-                    {expandThinking 
+                    {expandThinking
                       ? (i18n.language === "zh-CN" ? "已展开" : "Thinking Expanded")
                       : (i18n.language === "zh-CN" ? "已折叠" : "Thinking Collapsed")}
                   </div>
@@ -231,7 +255,7 @@ export function GeneralSettings({ allowedTools = [], onResetPermissions }: Gener
                 </div>
                 <div>
                   <div className="text-sm font-medium text-slate-800 dark:text-slate-100">
-                    {experimental.useWebUIComponents 
+                    {experimental.useWebUIComponents
                       ? (i18n.language === "zh-CN" ? "已启用" : "Enabled")
                       : (i18n.language === "zh-CN" ? "已禁用" : "Disabled")}
                   </div>

--- a/frontend/src/contexts/SettingsContext.tsx
+++ b/frontend/src/contexts/SettingsContext.tsx
@@ -3,6 +3,7 @@ import type {
   AppSettings,
   SettingsContextType,
   ExperimentalFeatures,
+  Theme,
 } from "../types/settings";
 import { getSettings, setSettings } from "../utils/storage";
 import { SettingsContext } from "./SettingsContextTypes";
@@ -14,12 +15,58 @@ export function SettingsProvider({ children }: { children: React.ReactNode }) {
   );
   const [isInitialized, setIsInitialized] = useState(false);
 
+  // Detect if running in iframe (embedded mode)
+  const isEmbeddedMode = useMemo(
+    () => typeof window !== "undefined" && window.parent !== window,
+    [],
+  );
+
   // Initialize settings on client side (handles migration automatically)
+  // Also check for URL parameter theme override (Issue #104 - iframe theme sync)
   useEffect(() => {
     const initialSettings = getSettings();
+
+    // Check URL parameter for theme override
+    const urlParams = new URLSearchParams(window.location.search);
+    const themeParam = urlParams.get("theme");
+    if (themeParam === "dark" || themeParam === "light") {
+      initialSettings.theme = themeParam as Theme;
+    }
+
     setSettingsState(initialSettings);
     setIsInitialized(true);
   }, []);
+
+  // Listen for postMessage theme updates from parent window (Issue #104 - realtime sync)
+  useEffect(() => {
+    if (!isEmbeddedMode) return;
+
+    // Get trusted origin from URL parameter (handles cross-origin iframe scenario)
+    const urlParams = new URLSearchParams(window.location.search);
+    const openaceUrl = urlParams.get("openace_url");
+    const trustedOrigin = openaceUrl ? new URL(openaceUrl).origin : null;
+
+    const handleMessage = (event: MessageEvent) => {
+      // Validate message type
+      if (event.data?.type !== "openace-theme-change") return;
+
+      // Validate origin for security (use openace_url parameter for cross-origin scenario)
+      // When iframe is cross-origin, we cannot access window.parent.location.origin
+      // Instead, we use the openace_url parameter passed from parent
+      if (trustedOrigin && event.origin !== trustedOrigin) {
+        console.warn("Received theme change from untrusted origin:", event.origin);
+        return;
+      }
+
+      const newTheme = event.data.theme;
+      if (newTheme === "dark" || newTheme === "light") {
+        setSettingsState((prev) => ({ ...prev, theme: newTheme as Theme }));
+      }
+    };
+
+    window.addEventListener("message", handleMessage);
+    return () => window.removeEventListener("message", handleMessage);
+  }, [isEmbeddedMode]);
 
   // Apply theme changes to document when settings change
   useEffect(() => {
@@ -75,12 +122,13 @@ export function SettingsProvider({ children }: { children: React.ReactNode }) {
       enterBehavior: settings.enterBehavior,
       experimental,
       expandThinking: settings.expandThinking ?? true, // Default to expanded
+      isEmbeddedMode,
       toggleTheme,
       toggleEnterBehavior,
       toggleExpandThinking,
       updateSettings,
     }),
-    [settings, experimental, toggleTheme, toggleEnterBehavior, toggleExpandThinking, updateSettings],
+    [settings, experimental, isEmbeddedMode, toggleTheme, toggleEnterBehavior, toggleExpandThinking, updateSettings],
   );
 
   return (

--- a/frontend/src/hooks/chat/useAbortController.ts
+++ b/frontend/src/hooks/chat/useAbortController.ts
@@ -4,28 +4,30 @@ import { getAbortUrl, getPermissionRespondUrl } from "../../config/api";
 export function useAbortController() {
   // Helper function to perform abort request
   const performAbortRequest = useCallback(async (requestId: string) => {
-    await fetch(getAbortUrl(requestId), {
+    const response = await fetch(getAbortUrl(requestId), {
       method: "POST",
       headers: { "Content-Type": "application/json" },
     });
+
+    if (response.status === 404) {
+      return response;
+    }
+
+    if (!response.ok) {
+      throw new Error(`Failed to abort request: ${response.status} ${response.statusText}`);
+    }
+
+    return response;
   }, []);
 
   const abortRequest = useCallback(
     async (
       requestId: string | null,
       isLoading: boolean,
-      onAbortComplete: () => void,
     ) => {
       if (!requestId || !isLoading) return;
 
-      try {
-        await performAbortRequest(requestId);
-      } catch (error) {
-        console.error("Failed to abort request:", error);
-      } finally {
-        // Clean up state after successful abort or error
-        onAbortComplete();
-      }
+      return performAbortRequest(requestId);
     },
     [performAbortRequest],
   );

--- a/frontend/src/hooks/chat/usePermissions.ts
+++ b/frontend/src/hooks/chat/usePermissions.ts
@@ -131,9 +131,9 @@ export function usePermissions(options: UsePermissionsOptions = {}) {
   const loopDetectionConfigRef = useRef(DEFAULT_LOOP_DETECTION_CONFIG);
 
   // Auto-rejection loop detection state (SDK-level rejections, e.g. stdin closed)
-  // Map-based per-agent counter: key = agentId:toolName (or just toolName for main session)
+  // Track the most recent rejected tool per agent so switching tools resets the loop counter.
   const autoRejectionStatesRef = useRef<
-    Map<string, { count: number; lastTime: number }>
+    Map<string, { toolName: string; count: number; lastTime: number }>
   >(new Map());
 
   // Command result loop detection state
@@ -442,7 +442,7 @@ export function usePermissions(options: UsePermissionsOptions = {}) {
       const now = Date.now();
 
       // Build a scoped key for agent isolation
-      const scopeKey = agentId ? `${agentId}:${toolName}` : toolName;
+      const scopeKey = agentId || "__main__";
 
       // "Input closed" is a session-level fatal error — always detect immediately
       // Match the full SDK error format to avoid false positives from benign "Operation Cancelled"
@@ -454,7 +454,7 @@ export function usePermissions(options: UsePermissionsOptions = {}) {
       // When this occurs the CLI process is dead, so the entire session tree
       // (including all fork agents) is unusable regardless of which agent reported it.
       if (isInputClosed) {
-        autoRejectionStatesRef.current.delete(scopeKey);
+        autoRejectionStatesRef.current.clear();
         return {
           isOpen: true,
           toolName,
@@ -471,10 +471,13 @@ export function usePermissions(options: UsePermissionsOptions = {}) {
       // Get or create per-key state
       const states = autoRejectionStatesRef.current;
       const existing = states.get(scopeKey);
-      const state = existing && now - existing.lastTime <= config.resetWindowMs
-        ? existing
-        : { count: 0, lastTime: now };
+      const isWithinWindow = existing && now - existing.lastTime <= config.resetWindowMs;
+      const state =
+        isWithinWindow && existing.toolName === toolName
+          ? existing
+          : { toolName, count: 0, lastTime: now };
 
+      state.toolName = toolName;
       state.count++;
       state.lastTime = now;
       states.set(scopeKey, state);

--- a/frontend/src/hooks/chat/usePlanApproval.test.ts
+++ b/frontend/src/hooks/chat/usePlanApproval.test.ts
@@ -1,372 +1,114 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import { renderHook, act } from "@testing-library/react";
-import { createExitPlanModeToolResult } from "../../utils/mockResponseGenerator";
+import { usePermissions } from "./usePermissions";
+import { createExitPlanModeToolUseWithId } from "../../utils/mockResponseGenerator";
 import { TOOL_NAMES } from "../../utils/toolNames";
 
-// Mock the message converter
-vi.mock("../useMessageConverter", () => ({
-  useMessageConverter: () => ({
-    createToolResultMessage: vi.fn((data) => ({
-      type: "tool_result",
-      toolName: TOOL_NAMES.EXIT_PLAN_MODE,
-      content: data.content || "Plan rejected",
-      summary: "Plan rejection",
-      toolUseId: data.tool_use_id,
-      timestamp: Date.now(),
-    })),
-  }),
-}));
+function usePlanApprovalWorkflow() {
+  const permissions = usePermissions();
 
-// Create a simple hook for testing plan rejection workflow
-function usePlanRejectionWorkflow() {
-  const sendToolResult = vi.fn();
-  const updatePermissionMode = vi.fn();
-  const closePlanModeRequest = vi.fn();
-
-  const handlePlanRejection = (toolUseId: string, sessionId: string) => {
-    // Create tool result message for plan rejection
-    const toolResultMessage = createExitPlanModeToolResult(
-      sessionId,
+  const handlePlanPermissionRequest = (planContent: string, toolUseId = "plan-123") => {
+    const assistantMessage = createExitPlanModeToolUseWithId(
+      "session-123",
       toolUseId,
+      planContent,
     );
-    sendToolResult(toolResultMessage);
+    const toolUse = assistantMessage.message.content.find(
+      (item) => item.type === "tool_use",
+    );
 
-    // Update UI state
-    updatePermissionMode("plan");
-    closePlanModeRequest();
+    if (toolUse?.type !== "tool_use" || toolUse.name !== TOOL_NAMES.EXIT_PLAN_MODE) {
+      throw new Error("Expected ExitPlanMode tool_use");
+    }
 
-    return {
-      success: true,
-      toolResultGenerated: true,
-      stateUpdated: true,
-    };
+    permissions.showPlanModeRequest(
+      typeof toolUse.input.plan === "string" ? toolUse.input.plan : "",
+    );
+
+    return toolUse;
   };
 
   return {
-    handlePlanRejection,
-    sendToolResult,
-    updatePermissionMode,
-    closePlanModeRequest,
+    ...permissions,
+    handlePlanPermissionRequest,
   };
 }
 
-describe("Plan Rejection Workflow Tests", () => {
-  describe("Tool Result Generation", () => {
-    it("should create correct tool_result message for plan rejection", () => {
-      const toolUseId = "exit-plan-123";
-      const sessionId = "session-456";
+describe("Plan Approval Workflow", () => {
+  it("creates an ExitPlanMode tool_use with the expected plan content", () => {
+    const assistantMessage = createExitPlanModeToolUseWithId(
+      "session-123",
+      "plan-456",
+      "1. Inspect files\n2. Update tests",
+    );
 
-      const toolResult = createExitPlanModeToolResult(sessionId, toolUseId);
-
-      expect(toolResult).toEqual({
-        type: "user",
-        message: {
-          role: "user",
-          content: [
-            {
-              type: "tool_result",
-              tool_use_id: toolUseId,
-              content: "Exit plan mode?",
-              is_error: true,
-            },
-          ],
+    expect(assistantMessage.type).toBe("assistant");
+    expect(assistantMessage.session_id).toBe("session-123");
+    expect(assistantMessage.message.content).toEqual([
+      {
+        type: "tool_use",
+        id: "plan-456",
+        name: TOOL_NAMES.EXIT_PLAN_MODE,
+        input: {
+          plan: "1. Inspect files\n2. Update tests",
         },
-        parent_tool_use_id: null,
-        session_id: sessionId,
-        uuid: expect.any(String),
-      });
+      },
+    ]);
+  });
+
+  it("opens plan approval directly from the proactive ExitPlanMode request", () => {
+    const { result } = renderHook(() => usePlanApprovalWorkflow());
+
+    let toolUse;
+    act(() => {
+      toolUse = result.current.handlePlanPermissionRequest(
+        "1. Inspect files\n2. Update tests",
+        "plan-789",
+      );
     });
 
-    it("should handle plan rejection with missing toolUseId gracefully", () => {
-      const toolUseId = "";
-      const sessionId = "session-456";
+    expect(toolUse).toEqual({
+      type: "tool_use",
+      id: "plan-789",
+      name: TOOL_NAMES.EXIT_PLAN_MODE,
+      input: {
+        plan: "1. Inspect files\n2. Update tests",
+      },
+    });
+    expect(result.current.permissionRequest).toBeNull();
+    expect(result.current.planModeRequest).toEqual({
+      isOpen: true,
+      planContent: "1. Inspect files\n2. Update tests",
+    });
+    expect(result.current.isPermissionMode).toBe(true);
+  });
 
-      const toolResult = createExitPlanModeToolResult(sessionId, toolUseId);
+  it("supports empty plan content without falling back to reactive tool_result handling", () => {
+    const { result } = renderHook(() => usePlanApprovalWorkflow());
 
-      expect(toolResult.message.content[0]).toEqual({
-        type: "tool_result",
-        tool_use_id: "",
-        content: "Exit plan mode?",
-        is_error: true,
-      });
+    act(() => {
+      result.current.handlePlanPermissionRequest("", "plan-empty");
     });
 
-    it("should handle plan rejection with missing sessionId", () => {
-      const toolUseId = "exit-plan-123";
-      const sessionId = "";
-
-      const toolResult = createExitPlanModeToolResult(sessionId, toolUseId);
-
-      expect(toolResult.session_id).toBe("");
-      expect(toolResult.type).toBe("user");
+    expect(result.current.permissionRequest).toBeNull();
+    expect(result.current.planModeRequest).toEqual({
+      isOpen: true,
+      planContent: "",
     });
   });
 
-  describe("State Management During Plan Rejection", () => {
-    it("should properly manage state when rejecting plan", () => {
-      const { result } = renderHook(() => usePlanRejectionWorkflow());
+  it("closes the plan approval dialog and exits permission mode", () => {
+    const { result } = renderHook(() => usePlanApprovalWorkflow());
 
-      const toolUseId = "plan-rejection-123";
-      const sessionId = "session-789";
-
-      let rejectionResult;
-      act(() => {
-        rejectionResult = result.current.handlePlanRejection(
-          toolUseId,
-          sessionId,
-        );
-      });
-
-      // Should have sent tool result
-      expect(result.current.sendToolResult).toHaveBeenCalledTimes(1);
-      expect(result.current.sendToolResult).toHaveBeenCalledWith({
-        type: "user",
-        message: {
-          role: "user",
-          content: [
-            {
-              type: "tool_result",
-              tool_use_id: toolUseId,
-              content: "Exit plan mode?",
-              is_error: true,
-            },
-          ],
-        },
-        parent_tool_use_id: null,
-        session_id: sessionId,
-        uuid: expect.any(String),
-      });
-
-      // Should have updated permission mode back to plan
-      expect(result.current.updatePermissionMode).toHaveBeenCalledWith("plan");
-
-      // Should have closed the plan mode request
-      expect(result.current.closePlanModeRequest).toHaveBeenCalledTimes(1);
-
-      // Should return successful result
-      expect(rejectionResult).toEqual({
-        success: true,
-        toolResultGenerated: true,
-        stateUpdated: true,
-      });
+    act(() => {
+      result.current.handlePlanPermissionRequest("Review the repository");
     });
 
-    it("should handle multiple plan rejections correctly", () => {
-      const { result } = renderHook(() => usePlanRejectionWorkflow());
-
-      // First rejection
-      act(() => {
-        result.current.handlePlanRejection("plan-1", "session-1");
-      });
-
-      // Second rejection
-      act(() => {
-        result.current.handlePlanRejection("plan-2", "session-1");
-      });
-
-      // Should have been called twice
-      expect(result.current.sendToolResult).toHaveBeenCalledTimes(2);
-      expect(result.current.updatePermissionMode).toHaveBeenCalledTimes(2);
-      expect(result.current.closePlanModeRequest).toHaveBeenCalledTimes(2);
-
-      // Verify second call was with correct parameters
-      expect(result.current.sendToolResult).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          type: "user",
-          message: {
-            role: "user",
-            content: [
-              {
-                type: "tool_result",
-                tool_use_id: "plan-2",
-                content: "Exit plan mode?",
-                is_error: true,
-              },
-            ],
-          },
-          session_id: "session-1",
-        }),
-      );
-    });
-  });
-
-  describe("Integration with Streaming System", () => {
-    it("should generate tool_result message that can be processed by stream parser", async () => {
-      const toolUseId = "stream-plan-123";
-      const sessionId = "stream-session-456";
-
-      const toolResult = createExitPlanModeToolResult(sessionId, toolUseId);
-
-      // Simulate stream processing
-      const mockStreamData = {
-        type: "claude_json" as const,
-        data: toolResult,
-      };
-
-      // Verify stream data structure
-      expect(mockStreamData.type).toBe("claude_json");
-      expect(mockStreamData.data.type).toBe("user");
-      const content = mockStreamData.data.message.content;
-      if (Array.isArray(content)) {
-        expect(content[0].type).toBe("tool_result");
-        expect((content[0] as { is_error?: boolean }).is_error).toBe(true);
-      }
+    act(() => {
+      result.current.closePlanModeRequest();
     });
 
-    it("should handle tool_result message processing for plan rejection", () => {
-      // Test that tool_result data structure is compatible with message processing
-      const toolResultData = {
-        type: "tool_result" as const,
-        tool_use_id: "plan-rejection-456",
-        content: "Plan rejected by user",
-        is_error: true,
-      };
-
-      // Verify the structure matches what the system expects
-      expect(toolResultData.type).toBe("tool_result");
-      expect(toolResultData.tool_use_id).toBe("plan-rejection-456");
-      expect(toolResultData.is_error).toBe(true);
-      expect(toolResultData.content).toBe("Plan rejected by user");
-    });
-
-    it("should maintain session continuity during plan rejection", () => {
-      const originalSessionId = "continuous-session-123";
-      const toolUseId = "continuous-plan-456";
-
-      const toolResult = createExitPlanModeToolResult(
-        originalSessionId,
-        toolUseId,
-      );
-
-      // Session ID should be preserved in the tool result
-      expect(toolResult.session_id).toBe(originalSessionId);
-
-      // This ensures that the plan rejection doesn't break conversation continuity
-      expect(toolResult.type).toBe("user");
-      expect(toolResult.parent_tool_use_id).toBeNull();
-    });
-  });
-
-  describe("Error Handling in Plan Rejection", () => {
-    it("should handle plan rejection when sendToolResult fails", () => {
-      const { result } = renderHook(() => usePlanRejectionWorkflow());
-
-      // Make sendToolResult throw an error
-      result.current.sendToolResult.mockImplementation(() => {
-        throw new Error("Network error");
-      });
-
-      const toolUseId = "error-plan-123";
-      const sessionId = "error-session-456";
-
-      // Should handle error gracefully
-      expect(() => {
-        act(() => {
-          result.current.handlePlanRejection(toolUseId, sessionId);
-        });
-      }).toThrow("Network error");
-
-      // State management should still be attempted
-      expect(result.current.sendToolResult).toHaveBeenCalledTimes(1);
-    });
-
-    it("should handle plan rejection with malformed data", () => {
-      const toolUseId = null as unknown as string;
-      const sessionId = undefined as unknown as string;
-
-      // Should not throw error with null/undefined values
-      expect(() => {
-        createExitPlanModeToolResult(sessionId, toolUseId);
-      }).not.toThrow();
-
-      const result = createExitPlanModeToolResult(sessionId, toolUseId);
-      expect(result.session_id).toBeUndefined();
-      const content = result.message.content;
-      if (Array.isArray(content)) {
-        expect((content[0] as { tool_use_id?: string }).tool_use_id).toBeNull();
-      }
-    });
-  });
-
-  describe("Plan Rejection vs Approval Workflow", () => {
-    it("should have different behavior for rejection vs acceptance", () => {
-      // Test that plan rejection creates error tool_result while acceptance doesn't
-      const rejectionResult = createExitPlanModeToolResult(
-        "session",
-        "tool-123",
-      );
-
-      // Rejection should have is_error: true
-      const content = rejectionResult.message.content;
-      if (Array.isArray(content)) {
-        expect((content[0] as { is_error?: boolean }).is_error).toBe(true);
-        expect((content[0] as { content?: string }).content).toBe(
-          "Exit plan mode?",
-        );
-      }
-
-      // Acceptance would not create a tool_result message at all
-      // (This is the current behavior - acceptance just proceeds with the plan)
-    });
-
-    it("should maintain correct tool_use_id relationship", () => {
-      const originalToolUseId = "original-exitplanmode-123";
-      const sessionId = "relationship-session";
-
-      const rejectionResult = createExitPlanModeToolResult(
-        sessionId,
-        originalToolUseId,
-      );
-
-      // The tool_result should reference the original tool_use
-      const content = rejectionResult.message.content;
-      if (Array.isArray(content)) {
-        expect((content[0] as { tool_use_id?: string }).tool_use_id).toBe(
-          originalToolUseId,
-        );
-      }
-      expect(rejectionResult.type).toBe("user");
-    });
-  });
-
-  describe("Plan Rejection UI State Management", () => {
-    it("should reset UI state correctly after plan rejection", () => {
-      const { result } = renderHook(() => usePlanRejectionWorkflow());
-
-      act(() => {
-        result.current.handlePlanRejection("ui-plan-123", "ui-session-456");
-      });
-
-      // Should switch back to plan mode (allowing for more planning)
-      expect(result.current.updatePermissionMode).toHaveBeenCalledWith("plan");
-
-      // Should close the current plan request dialog
-      expect(result.current.closePlanModeRequest).toHaveBeenCalledTimes(1);
-
-      // Should send rejection signal to Qwen
-      expect(result.current.sendToolResult).toHaveBeenCalledTimes(1);
-    });
-
-    it("should allow for immediate re-planning after rejection", () => {
-      const { result } = renderHook(() => usePlanRejectionWorkflow());
-
-      // Reject first plan
-      act(() => {
-        result.current.handlePlanRejection("plan-v1", "session-replan");
-      });
-
-      // Should be in plan mode for immediate re-planning
-      expect(result.current.updatePermissionMode).toHaveBeenLastCalledWith(
-        "plan",
-      );
-
-      // Can immediately handle another plan
-      act(() => {
-        result.current.handlePlanRejection("plan-v2", "session-replan");
-      });
-
-      expect(result.current.updatePermissionMode).toHaveBeenCalledTimes(2);
-      expect(result.current.sendToolResult).toHaveBeenCalledTimes(2);
-    });
+    expect(result.current.planModeRequest).toBeNull();
+    expect(result.current.isPermissionMode).toBe(false);
   });
 });

--- a/frontend/src/hooks/streaming/useMessageProcessor.ts
+++ b/frontend/src/hooks/streaming/useMessageProcessor.ts
@@ -29,12 +29,6 @@ export interface StreamingContext {
   onInitMessageShown?: () => void;
   hasReceivedInit?: boolean;
   setHasReceivedInit?: (received: boolean) => void;
-  onPermissionError?: (
-    toolName: string,
-    patterns: string[],
-    toolUseId: string,
-    requestId?: string,
-  ) => void;
   onAbortRequest?: () => void;
   // Auto-rejection loop detection (SDK-level rejections, e.g. stdin closed)
   onAutoRejection?: (

--- a/frontend/src/hooks/streaming/useStreamParser.test.ts
+++ b/frontend/src/hooks/streaming/useStreamParser.test.ts
@@ -304,6 +304,72 @@ describe("useStreamParser", () => {
     });
   });
 
+  describe("Permission Request Handling", () => {
+    it("should forward proactive permission requests to onPermissionRequest", () => {
+      const onPermissionRequest = vi.fn();
+      mockContext.onPermissionRequest = onPermissionRequest;
+
+      const { result } = renderHook(() => useStreamParser());
+
+      result.current.processStreamLine(
+        JSON.stringify({
+          type: "permission_request",
+          permissionId: "perm-123",
+          toolName: TOOL_NAMES.BASH,
+          toolInput: { command: "ls -la" },
+          suggestions: [
+            {
+              type: "allow",
+              label: "Allow ls",
+              description: "Allow this command",
+            },
+          ],
+          autoApproveMs: 25000,
+        }),
+        mockContext,
+      );
+
+      expect(onPermissionRequest).toHaveBeenCalledWith({
+        permissionId: "perm-123",
+        toolName: TOOL_NAMES.BASH,
+        toolInput: { command: "ls -la" },
+        suggestions: [
+          {
+            type: "allow",
+            label: "Allow ls",
+            description: "Allow this command",
+          },
+        ],
+        autoApproveMs: 25000,
+        confirmationType: undefined,
+        questions: undefined,
+      });
+    });
+
+    it("should ignore invalid proactive permission requests", () => {
+      const onPermissionRequest = vi.fn();
+      mockContext.onPermissionRequest = onPermissionRequest;
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      const { result } = renderHook(() => useStreamParser());
+
+      result.current.processStreamLine(
+        JSON.stringify({
+          type: "permission_request",
+          toolInput: { command: "ls -la" },
+        }),
+        mockContext,
+      );
+
+      expect(onPermissionRequest).not.toHaveBeenCalled();
+      expect(warnSpy).toHaveBeenCalledWith(
+        "Invalid permission_request: missing permissionId or toolName",
+      );
+
+      warnSpy.mockRestore();
+    });
+  });
+
   describe("Stream Line Processing and Error Handling", () => {
     it("should handle malformed JSON gracefully", () => {
       const { result } = renderHook(() => useStreamParser());

--- a/frontend/src/hooks/useDemoAutomation.ts
+++ b/frontend/src/hooks/useDemoAutomation.ts
@@ -102,9 +102,6 @@ export function useDemoAutomation(
   const typingTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const typingIntervalRef = useRef<NodeJS.Timeout | null>(null);
 
-  // Cache tool names from assistant messages for permission error handling
-  const toolNameCacheRef = useRef<Map<string, string>>(new Map());
-
   // Chat state (fallback if not provided externally)
   const chatState = useChatState();
   const {
@@ -182,16 +179,16 @@ export function useDemoAutomation(
   // Process stream data
   const processStreamData = useCallback(
     (step: MockScenarioStep) => {
-      if (step.type === "permission_error") {
-        const errorData = step.data as {
+      if (step.type === "permission_request") {
+        const requestData = step.data as {
           toolName: string;
           pattern: string;
           toolUseId: string;
         };
         finalShowPermissionRequest(
-          errorData.toolName,
-          [errorData.pattern],
-          errorData.toolUseId,
+          requestData.toolName,
+          [requestData.pattern],
+          requestData.toolUseId,
         );
         return;
       }
@@ -262,11 +259,6 @@ export function useDemoAutomation(
                 input: Record<string, unknown>;
               };
 
-              // Cache tool name for permission error lookup
-              if (toolUse.id && toolUse.name) {
-                toolNameCacheRef.current.set(toolUse.id, toolUse.name);
-              }
-
               // Special handling for ExitPlanMode - create plan message instead of tool message
               if (toolUse.name === TOOL_NAMES.EXIT_PLAN_MODE) {
                 const planContent = (toolUse.input?.plan as string) || "";
@@ -294,7 +286,6 @@ export function useDemoAutomation(
         }
 
         case "user": {
-          // Handle user messages containing tool results (like ExitPlanMode)
           const userMsg = sdkMessage as Extract<SDKMessage, { type: "user" }>;
           const messageContent = userMsg.message.content;
 
@@ -308,39 +299,11 @@ export function useDemoAutomation(
                   is_error?: boolean;
                 };
 
-                // Check for permission errors (similar to useToolHandling.ts)
-                if (
-                  toolResult.is_error &&
-                  !toolResult.content.includes("tool_use_error")
-                ) {
-                  // For demo, we need to trigger permission dialog
-                  // Since this is ExitPlanMode, show plan permission request
-                  if (toolResult.content === "Exit plan mode?") {
-                    // This indicates an ExitPlanMode permission error
-                    // Check if showPlanModeRequest is available (it should be from usePermissions)
-                    // For now, trigger regular permission request with ExitPlanMode pattern
-                    // The ChatPage.tsx logic will convert this to plan mode request
-                    finalShowPermissionRequest(
-                      TOOL_NAMES.EXIT_PLAN_MODE,
-                      [TOOL_NAMES.EXIT_PLAN_MODE],
-                      toolResult.tool_use_id,
-                    );
-                  } else {
-                    // For other tool permission errors, look up cached tool name
-                    const cachedToolName = toolNameCacheRef.current.get(toolResult.tool_use_id) || "Unknown";
-                    finalShowPermissionRequest(
-                      cachedToolName,
-                      [cachedToolName],
-                      toolResult.tool_use_id,
-                    );
-                  }
-                } else {
-                  const toolResultMessage = createToolResultMessage(
-                    "Tool result",
-                    toolResult.content,
-                  );
-                  finalAddMessage(toolResultMessage);
-                }
+                const toolResultMessage = createToolResultMessage(
+                  "Tool result",
+                  toolResult.content,
+                );
+                finalAddMessage(toolResultMessage);
               }
             }
           }

--- a/frontend/src/hooks/useRemoteChat.test.ts
+++ b/frontend/src/hooks/useRemoteChat.test.ts
@@ -1,0 +1,203 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  abortRemoteRequest,
+  createRemoteSession,
+  createRemoteSessionStream,
+  getRemoteSessionStatus,
+  pauseRemoteSession,
+  resumeRemoteSession,
+  sendPermissionResponse,
+  sendRemoteMessage,
+  stopRemoteSession,
+  switchRemoteModel,
+} from "../api/openace";
+import { useRemoteChat } from "./useRemoteChat";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback?: string) => fallback ?? _key,
+  }),
+}));
+
+vi.mock("../api/openace", () => ({
+  createRemoteSession: vi.fn(),
+  sendRemoteMessage: vi.fn(),
+  stopRemoteSession: vi.fn(),
+  abortRemoteRequest: vi.fn(),
+  getRemoteSessionStatus: vi.fn(),
+  createRemoteSessionStream: vi.fn(),
+  sendPermissionResponse: vi.fn(),
+  switchRemoteModel: vi.fn(),
+  pauseRemoteSession: vi.fn(),
+  resumeRemoteSession: vi.fn(),
+}));
+
+describe("useRemoteChat", () => {
+  const streamCallbacks: {
+    onLine?: (line: string) => void;
+    onError?: (err: Event) => void;
+    onDone?: () => void;
+  } = {};
+
+  const streamingContext = {
+    setCurrentThinkingMessage: vi.fn(),
+    setCurrentAssistantMessage: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+    streamCallbacks.onLine = undefined;
+    streamCallbacks.onError = undefined;
+    streamCallbacks.onDone = undefined;
+
+    vi.mocked(createRemoteSession).mockResolvedValue({
+      session: {
+        session_id: "remote-session-1",
+        status: "active",
+        model: "test-model",
+      },
+    } as never);
+    vi.mocked(sendRemoteMessage).mockResolvedValue({ success: true } as never);
+    vi.mocked(abortRemoteRequest).mockResolvedValue({ success: true } as never);
+    vi.mocked(stopRemoteSession).mockResolvedValue({ success: true } as never);
+    vi.mocked(getRemoteSessionStatus).mockResolvedValue({
+      success: true,
+      session: {
+        session_id: "remote-session-1",
+        status: "active",
+        model: "test-model",
+      },
+    } as never);
+    vi.mocked(sendPermissionResponse).mockResolvedValue({ success: true } as never);
+    vi.mocked(switchRemoteModel).mockResolvedValue({ success: true } as never);
+    vi.mocked(pauseRemoteSession).mockResolvedValue({ success: true } as never);
+    vi.mocked(resumeRemoteSession).mockResolvedValue({ success: true } as never);
+    vi.mocked(createRemoteSessionStream).mockImplementation(
+      ((_sessionId, onLine, onError, onDone) => {
+        streamCallbacks.onLine = onLine;
+        streamCallbacks.onError = onError;
+        streamCallbacks.onDone = onDone;
+        return { close: vi.fn() } as unknown as EventSource;
+      }) as typeof createRemoteSessionStream
+    );
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("keeps remote Stop in stopping state until an aborted event arrives", async () => {
+    const { result } = renderHook(() =>
+      useRemoteChat({
+        onStreamLine: vi.fn(),
+        streamingContext: streamingContext as never,
+      })
+    );
+
+    await act(async () => {
+      await result.current.startSession("machine-1", "/workspace", "test-model");
+    });
+
+    await act(async () => {
+      await result.current.sendMessage("hello");
+    });
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.isStopping).toBe(false);
+
+    await act(async () => {
+      await result.current.abortCurrentRequest("user");
+    });
+
+    expect(abortRemoteRequest).toHaveBeenCalledWith("remote-session-1", "user");
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.isStopping).toBe(true);
+
+    act(() => {
+      streamCallbacks.onLine?.(
+        JSON.stringify({
+          type: "request_state",
+          data: { type: "aborted", reason: "user" },
+        })
+      );
+    });
+
+    expect(result.current.isStopping).toBe(false);
+    expect(result.current.isLoading).toBe(false);
+    expect(streamingContext.setCurrentThinkingMessage).toHaveBeenCalledWith(null);
+    expect(streamingContext.setCurrentAssistantMessage).toHaveBeenCalledWith(null);
+  });
+
+  it("surfaces abort_failed without pretending the request stopped", async () => {
+    const { result } = renderHook(() =>
+      useRemoteChat({
+        onStreamLine: vi.fn(),
+        streamingContext: streamingContext as never,
+      })
+    );
+
+    await act(async () => {
+      await result.current.startSession("machine-1", "/workspace", "test-model");
+    });
+
+    await act(async () => {
+      await result.current.sendMessage("hello");
+    });
+
+    await act(async () => {
+      await result.current.abortCurrentRequest("timeout");
+    });
+
+    act(() => {
+      streamCallbacks.onLine?.(
+        JSON.stringify({
+          type: "request_state",
+          data: {
+            type: "abort_failed",
+            reason: "timeout",
+            message: "interrupt failed",
+          },
+        })
+      );
+    });
+
+    expect(result.current.isStopping).toBe(false);
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.error).toBe("interrupt failed");
+  });
+
+  it("times out if remote abort is never confirmed", async () => {
+    vi.useFakeTimers();
+
+    const { result } = renderHook(() =>
+      useRemoteChat({
+        onStreamLine: vi.fn(),
+        streamingContext: streamingContext as never,
+      })
+    );
+
+    await act(async () => {
+      await result.current.startSession("machine-1", "/workspace", "test-model");
+    });
+
+    await act(async () => {
+      await result.current.sendMessage("hello");
+    });
+
+    await act(async () => {
+      await result.current.abortCurrentRequest("user");
+    });
+
+    expect(result.current.isStopping).toBe(true);
+
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+
+    expect(result.current.isStopping).toBe(false);
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.error).toBe("Remote stop was not confirmed");
+  });
+});

--- a/frontend/src/hooks/useRemoteChat.ts
+++ b/frontend/src/hooks/useRemoteChat.ts
@@ -37,11 +37,19 @@ export interface RemoteChatOptions {
   onQuotaExceeded?: (quotaStatus: unknown) => void;
 }
 
+type RemoteRequestStateEvent = {
+  type: "aborted" | "abort_failed";
+  reason?: string;
+  message?: string;
+};
+
 export function useRemoteChat(options?: RemoteChatOptions) {
   const [session, setSession] = useState<RemoteSession | null>(null);
   const [isLoading, setIsLoading] = useState(false);
+  const [isStopping, setIsStopping] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const eventSourceRef = useRef<EventSource | null>(null);
+  const abortAckTimerRef = useRef<number | null>(null);
   const sendingRef = useRef(false);
   const { t } = useTranslation();
 
@@ -57,6 +65,13 @@ export function useRemoteChat(options?: RemoteChatOptions) {
     }
     if (opts?.streamingContext?.setCurrentAssistantMessage) {
       opts.streamingContext.setCurrentAssistantMessage(null);
+    }
+  }, []);
+
+  const clearAbortAckTimer = useCallback(() => {
+    if (abortAckTimerRef.current !== null) {
+      window.clearTimeout(abortAckTimerRef.current);
+      abortAckTimerRef.current = null;
     }
   }, []);
 
@@ -77,13 +92,34 @@ export function useRemoteChat(options?: RemoteChatOptions) {
         return; // Don't forward to onStreamLine
       }
 
+      if (parsed.type === "request_state" && parsed.data) {
+        const requestState = parsed.data as RemoteRequestStateEvent;
+        if (requestState.type === "aborted") {
+          clearAbortAckTimer();
+          setIsStopping(false);
+          setIsLoading(false);
+          clearStreamingState();
+          return;
+        }
+        if (requestState.type === "abort_failed") {
+          clearAbortAckTimer();
+          setIsStopping(false);
+          setError(requestState.message || "Failed to stop remote request");
+          return;
+        }
+      }
+
       // Detect result events to clear loading state
       if (parsed.type === "claude_json" && parsed.data?.type === "result") {
+        clearAbortAckTimer();
+        setIsStopping(false);
         setIsLoading(false);
       }
 
       // Handle error events from the remote agent (e.g. CLI crash, send failure)
       if (parsed.type === "error") {
+        clearAbortAckTimer();
+        setIsStopping(false);
         setIsLoading(false);
         setError(parsed.data || "Unknown remote error");
         return; // Don't forward to onStreamLine
@@ -95,7 +131,7 @@ export function useRemoteChat(options?: RemoteChatOptions) {
     if (opts?.onStreamLine && opts.streamingContext) {
       opts.onStreamLine(line, opts.streamingContext);
     }
-  }, []);
+  }, [clearAbortAckTimer, clearStreamingState]);
 
   // Cleanup on unmount
   useEffect(() => {
@@ -104,8 +140,9 @@ export function useRemoteChat(options?: RemoteChatOptions) {
         eventSourceRef.current.close();
         eventSourceRef.current = null;
       }
+      clearAbortAckTimer();
     };
-  }, []);
+  }, [clearAbortAckTimer]);
 
   // ---------------------------------------------------------------------------
   // Actions
@@ -121,6 +158,8 @@ export function useRemoteChat(options?: RemoteChatOptions) {
       haPoolToken?: string
     ) => {
       setIsLoading(true);
+      clearAbortAckTimer();
+      setIsStopping(false);
       setError(null);
       setSession(null);
 
@@ -148,6 +187,8 @@ export function useRemoteChat(options?: RemoteChatOptions) {
             (err) => {
               console.error("[useRemoteChat] SSE error:", err);
               setError(t("chat.remoteDisconnected"));
+              clearAbortAckTimer();
+              setIsStopping(false);
               setIsLoading(false);
               clearStreamingState();
               setSession((prev) =>
@@ -156,6 +197,8 @@ export function useRemoteChat(options?: RemoteChatOptions) {
             },
             () => {
               console.log("[useRemoteChat] SSE done");
+              clearAbortAckTimer();
+              setIsStopping(false);
               setIsLoading(false);
               clearStreamingState();
               // If the session was active and SSE closed, it likely means
@@ -199,6 +242,8 @@ export function useRemoteChat(options?: RemoteChatOptions) {
       if (session) return; // already connected
 
       setIsLoading(true);
+      clearAbortAckTimer();
+      setIsStopping(false);
       setError(null);
 
       try {
@@ -275,6 +320,8 @@ export function useRemoteChat(options?: RemoteChatOptions) {
             (err) => {
               console.error("[useRemoteChat] SSE error:", err);
               setError(t("chat.remoteReconnectFailed"));
+              clearAbortAckTimer();
+              setIsStopping(false);
               setIsLoading(false);
               clearStreamingState();
               setSession((prev) =>
@@ -283,6 +330,8 @@ export function useRemoteChat(options?: RemoteChatOptions) {
             },
             () => {
               console.log("[useRemoteChat] SSE done");
+              clearAbortAckTimer();
+              setIsStopping(false);
               setIsLoading(false);
               clearStreamingState();
             },
@@ -310,6 +359,9 @@ export function useRemoteChat(options?: RemoteChatOptions) {
       // Prevent double-sends
       if (sendingRef.current) return;
       sendingRef.current = true;
+      clearAbortAckTimer();
+      setIsStopping(false);
+      setError(null);
       setIsLoading(true);
 
       try {
@@ -330,19 +382,28 @@ export function useRemoteChat(options?: RemoteChatOptions) {
         sendingRef.current = false;
       }
     },
-    [session]
+    [clearAbortAckTimer, session]
   );
 
-  const abortCurrentRequest = useCallback(async () => {
-    if (!session) return;
+  const abortCurrentRequest = useCallback(async (reason = "user") => {
+    if (!session || isStopping) return;
     try {
-      await abortRemoteRequest(session.session_id);
-      setIsLoading(false);
-      clearStreamingState();
+      setIsStopping(true);
+      setError(null);
+      await abortRemoteRequest(session.session_id, reason);
+      abortAckTimerRef.current = window.setTimeout(() => {
+        setIsStopping(false);
+        setError("Remote stop was not confirmed");
+      }, 5000);
     } catch (err) {
+      clearAbortAckTimer();
+      setIsStopping(false);
       console.error("[useRemoteChat] Failed to abort request:", err);
+      setError(
+        err instanceof Error ? err.message : "Failed to abort remote request"
+      );
     }
-  }, [session, clearStreamingState]);
+  }, [clearAbortAckTimer, isStopping, session]);
 
   const stopSessionHandler = useCallback(async () => {
     if (!session) return;
@@ -355,13 +416,16 @@ export function useRemoteChat(options?: RemoteChatOptions) {
 
     try {
       await stopRemoteSession(session.session_id);
+      clearAbortAckTimer();
+      setIsStopping(false);
+      setIsLoading(false);
       setSession((prev) => (prev ? { ...prev, status: "stopped" } : null));
     } catch (err) {
       setError(
         err instanceof Error ? err.message : "Failed to stop remote session"
       );
     }
-  }, [session]);
+  }, [clearAbortAckTimer, session]);
 
   const resetSession = useCallback(async () => {
     if (session) {
@@ -375,10 +439,12 @@ export function useRemoteChat(options?: RemoteChatOptions) {
         console.error("[useRemoteChat] Failed to stop session during reset:", err);
       }
     }
+    clearAbortAckTimer();
     setSession(null);
     setError(null);
+    setIsStopping(false);
     setIsLoading(false);
-  }, [session]);
+  }, [clearAbortAckTimer, session]);
 
   const reconnect = useCallback(
     async (machineId: string, projectPath: string, model?: string) => {
@@ -452,6 +518,7 @@ export function useRemoteChat(options?: RemoteChatOptions) {
   return {
     session,
     isLoading,
+    isStopping,
     sendMessage,
     startSession,
     connectSession,

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -59,6 +59,7 @@
   },
   "chat": {
     "processing": "Processing...",
+    "stopping": "Stopping...",
     "typeMessage": "Type message...",
     "send": "Send",
     "plan": "Plan",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -42,7 +42,8 @@
     "newFolder": "New Folder",
     "newDirectoryName": "New directory name",
     "selectThisFolder": "Select This Folder",
-    "failedToBrowse": "Failed to browse directory"
+    "failedToBrowse": "Failed to browse directory",
+    "pathHint": "Paths must be under: {{baseDir}}"
   },
   "settings": {
     "title": "Settings",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -59,6 +59,7 @@
   },
   "chat": {
     "processing": "処理中...",
+    "stopping": "停止中...",
     "typeMessage": "メッセージを入力...",
     "send": "送信",
     "plan": "プラン",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -59,6 +59,7 @@
   },
   "chat": {
     "processing": "처리 중...",
+    "stopping": "중지하는 중...",
     "typeMessage": "메시지를 입력하세요...",
     "send": "전송",
     "plan": "계획",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -59,6 +59,7 @@
   },
   "chat": {
     "processing": "处理中...",
+    "stopping": "正在停止...",
     "typeMessage": "输入消息...",
     "send": "发送",
     "plan": "计划",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -42,7 +42,8 @@
     "newFolder": "新建文件夹",
     "newDirectoryName": "新目录名称",
     "selectThisFolder": "选择此目录",
-    "failedToBrowse": "浏览目录失败"
+    "failedToBrowse": "浏览目录失败",
+    "pathHint": "路径必须在 {{baseDir}} 目录下"
   },
   "settings": {
     "title": "设置",

--- a/frontend/src/types/settings.ts
+++ b/frontend/src/types/settings.ts
@@ -31,6 +31,8 @@ export interface SettingsContextType {
   enterBehavior: EnterBehavior;
   experimental: ExperimentalFeatures;
   expandThinking: boolean;
+  /** Whether running in iframe (embedded mode) - theme controlled by parent */
+  isEmbeddedMode: boolean;
   toggleTheme: () => void;
   toggleEnterBehavior: () => void;
   toggleExpandThinking: () => void;

--- a/frontend/src/utils/mockResponseGenerator.ts
+++ b/frontend/src/utils/mockResponseGenerator.ts
@@ -3,11 +3,22 @@ import { generateToolPattern } from "./toolUtils";
 import { generateId } from "./id";
 import { TOOL_NAMES } from "./toolNames";
 
-export interface MockStreamResponse {
-  type: "claude_json" | "done" | "error";
-  data?: SDKMessage;
-  error?: string;
-}
+export type MockStreamResponse =
+  | {
+      type: "claude_json";
+      data: SDKMessage;
+    }
+  | {
+      type: "permission_request";
+      data: { toolName: string; pattern: string; toolUseId: string };
+    }
+  | {
+      type: "done";
+    }
+  | {
+      type: "error";
+      error: string;
+    };
 
 export interface ButtonActionData {
   buttonType:
@@ -26,7 +37,7 @@ export type MockScenarioStep =
       data: SDKMessage;
     }
   | {
-      type: "permission_error";
+      type: "permission_request";
       delay: number;
       data: { toolName: string; pattern: string; toolUseId: string };
     }
@@ -202,30 +213,6 @@ export function createExitPlanModeToolUseWithId(
   };
 }
 
-// Generate ExitPlanMode tool result message
-export function createExitPlanModeToolResult(
-  sessionId: string,
-  toolUseId: string,
-): Extract<SDKMessage, { type: "user" }> {
-  return {
-    type: "user",
-    message: {
-      role: "user",
-      content: [
-        {
-          type: "tool_result",
-          tool_use_id: toolUseId,
-          content: "Exit plan mode?",
-          is_error: true, // Mark as error to trigger permission dialog
-        },
-      ],
-    },
-    parent_tool_use_id: null,
-    session_id: sessionId,
-    uuid: generateId(),
-  };
-}
-
 // Generate realistic tool use assistant messages
 export function createToolUseMessage(
   toolName: string,
@@ -262,16 +249,15 @@ export function* generateMockStream(
   steps: MockScenarioStep[],
 ): Generator<MockStreamResponse, void, unknown> {
   for (const step of steps) {
-    if (step.type === "permission_error") {
-      // This would trigger permission request in real app
-      const errorData = step.data as {
+    if (step.type === "permission_request") {
+      const requestData = step.data as {
         toolName: string;
         pattern: string;
         toolUseId: string;
       };
       yield {
-        type: "error",
-        error: `Permission required for tool: ${errorData.toolName}`,
+        type: "permission_request",
+        data: requestData,
       };
       continue;
     }
@@ -344,7 +330,7 @@ export const DEMO_SCENARIOS = {
         ),
       },
       {
-        type: "permission_error" as const,
+        type: "permission_request" as const,
         delay: 1000,
         data: {
           toolName: TOOL_NAMES.READ,
@@ -404,7 +390,7 @@ export const DEMO_SCENARIOS = {
         ),
       },
       {
-        type: "permission_error" as const,
+        type: "permission_request" as const,
         delay: 900,
         data: {
           toolName: TOOL_NAMES.BASH,
@@ -500,7 +486,7 @@ if __name__ == "__main__":
         ),
       },
       {
-        type: "permission_error" as const,
+        type: "permission_request" as const,
         delay: 1000,
         data: {
           toolName: TOOL_NAMES.WRITE,
@@ -551,7 +537,7 @@ if __name__ == "__main__":
         ),
       },
       {
-        type: "permission_error" as const,
+        type: "permission_request" as const,
         delay: 800,
         data: {
           toolName: TOOL_NAMES.BASH,
@@ -631,12 +617,13 @@ I'll create a comprehensive README.md file for the Qwen Code Web UI project with
           ),
         },
         {
-          type: "user" as const,
+          type: "permission_request" as const,
           delay: 1500,
-          data: createExitPlanModeToolResult(
-            "demo-session-plan",
-            planToolUseId,
-          ),
+          data: {
+            toolName: TOOL_NAMES.EXIT_PLAN_MODE,
+            pattern: TOOL_NAMES.EXIT_PLAN_MODE,
+            toolUseId: planToolUseId,
+          },
         },
         {
           type: "button_focus",

--- a/frontend/src/utils/streamStallDetector.ts
+++ b/frontend/src/utils/streamStallDetector.ts
@@ -14,6 +14,7 @@ export interface StallDetector {
 export function createStallDetector(
   abortController: AbortController,
   timeoutMs: number = 120_000,
+  onAbort?: () => void,
 ): StallDetector {
   let stallTimerId: ReturnType<typeof setTimeout> | null = null;
   let lastDataTime = Date.now();
@@ -37,6 +38,7 @@ export function createStallDetector(
       return;
     }
     console.warn(`[Stream stall] No data for ${timeoutMs / 1000}s, aborting fetch`);
+    onAbort?.();
     abortController.abort();
   };
 


### PR DESCRIPTION
## Related Issue

Related to Issue #174 - WebUI not showing Open ACE API errors

## Problem

When using Open ACE with WORKSPACE_BASE_DIR=/workspace, users entering paths like /tools/open-ace in the Add Project modal would see no response when clicking Create. The Open ACE API returned an error but WebUI didn't display it in the browse step.

Additionally, when users entered absolute paths like /etc in New Folder, the path was incorrectly appended to the current browsing directory.

## Solution

### 1. Workspace Config API Integration
- Added `WorkspaceConfigResponse` interface and `getWorkspaceConfig()` API function
- Fetches `base_dir` from Open ACE backend for frontend hint display

### 2. DirectoryBrowser Enhancements
- Display blue hint showing valid path range: "Paths must be under: /workspace"
- Fix New Folder to handle absolute paths correctly (use directly instead of appending)

### 3. AddProjectModal Error Display
- Display API error messages in browse step as red error box
- Users see errors immediately without proceeding to next step

### 4. i18n Support
- Added `pathHint` translations in English and Chinese

## Files Changed
- frontend/src/api/openace.ts: Workspace config API
- frontend/src/components/DirectoryBrowser.tsx: Path hint + absolute path fix
- frontend/src/components/AddProjectModal.tsx: Error display in browse step
- frontend/src/i18n/locales/en.json: English translation
- frontend/src/i18n/locales/zh-CN.json: Chinese translation

## Testing
Tested with Open ACE Docker deployment:
- Path hint "路径必须在 /workspace 目录下" displayed in DirectoryBrowser
- Entering /etc in New Folder shows error: "Path must be under one of: /workspace"

## Requires
This PR should be merged together with Open ACE PR #715 which adds the backend `base_dir` field to workspace config API.
