### PR TITLE
fix(DirectoryBrowser): display API errors and path hints in browse step

### DIFF
--- a/frontend/src/api/openace.ts
+++ b/frontend/src/api/openace.ts
@@ -126,6 +126,17 @@ export interface CheckPathResponse {
   error?: string;
 }
 
+export interface WorkspaceConfigResponse {
+  enabled: boolean;
+  url: string;
+  multi_user_mode: boolean;
+  port_range_start: number;
+  port_range_end: number;
+  max_instances: number;
+  idle_timeout_minutes: number;
+  base_dir: string;
+}
+
 export interface SessionModelsResponse {
   success: boolean;
   models: ModelConfig[];
@@ -244,6 +255,26 @@ export async function checkPath(path: string): Promise<CheckPathResponse> {
     };
   }
   
+  return response.json();
+}
+
+/**
+ * Get workspace configuration from Open-ACE
+ */
+export async function getWorkspaceConfig(): Promise<WorkspaceConfigResponse> {
+  const url = buildOpenAceUrl("/api/workspace/config");
+
+  const response = await fetch(url, {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to get workspace config: ${response.statusText}`);
+  }
+
   return response.json();
 }
 

--- a/frontend/src/components/AddProjectModal.tsx
+++ b/frontend/src/components/AddProjectModal.tsx
@@ -69,6 +69,7 @@ export function AddProjectModal({
 
   const handleSelectDirectory = async (path: string) => {
     setSelectedPath(path);
+    setErrorMessage(""); // Clear previous error
 
     // Extract default name from path
     const segments = path.split(/[/\\]/).filter(Boolean);
@@ -245,6 +246,23 @@ export function AddProjectModal({
                         </button>
                       </div>
                     </div>
+
+                    {/* Error message in browse step */}
+                    {errorMessage && (
+                      <div className="mb-4 p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg">
+                        <div className="flex items-start gap-2">
+                          <ExclamationCircleIcon className="h-5 w-5 text-red-500 flex-shrink-0" />
+                          <div>
+                            <p className="text-sm font-medium text-red-700 dark:text-red-300">
+                              {t("project.invalidPath")}
+                            </p>
+                            <p className="text-sm text-red-600 dark:text-red-400 mt-1">
+                              {errorMessage}
+                            </p>
+                          </div>
+                        </div>
+                      </div>
+                    )}
 
                     {workspaceType === "local" ? (
                       <>

--- a/frontend/src/components/DirectoryBrowser.tsx
+++ b/frontend/src/components/DirectoryBrowser.tsx
@@ -9,6 +9,7 @@ import {
 import { useTranslation } from "react-i18next";
 import {
   browseDirectory,
+  getWorkspaceConfig,
   type DirectoryInfo,
   type BrowseResponse,
 } from "../api/openace";
@@ -33,6 +34,16 @@ export function DirectoryBrowser({
   const [error, setError] = useState<string | null>(null);
   const [newDirName, setNewDirName] = useState("");
   const [showNewDirInput, setShowNewDirInput] = useState(false);
+  const [baseDir, setBaseDir] = useState<string | null>(null);
+
+  // Fetch workspace config to get base_dir for path validation hint
+  useEffect(() => {
+    getWorkspaceConfig()
+      .then((config) => setBaseDir(config.base_dir))
+      .catch(() => {
+        // Ignore error - base_dir hint is optional
+      });
+  }, []);
 
   const loadDirectory = useCallback(async (path?: string) => {
     setLoading(true);
@@ -95,9 +106,15 @@ export function DirectoryBrowser({
   const handleCreateNewDir = () => {
     if (!newDirName.trim()) return;
 
-    const newPath = currentPath
-      ? `${currentPath}/${newDirName.trim()}`.replace(/\/+/g, "/")
-      : newDirName.trim();
+    const inputPath = newDirName.trim();
+
+    // If input is an absolute path (starts with /), use it directly
+    // Otherwise, combine with currentPath as a relative path
+    const newPath = inputPath.startsWith("/")
+      ? inputPath
+      : currentPath
+        ? `${currentPath}/${inputPath}`.replace(/\/+/g, "/")
+        : inputPath;
 
     onSelectDirectory(newPath);
   };
@@ -171,6 +188,15 @@ export function DirectoryBrowser({
       {error && (
         <div className="px-3 py-2 bg-yellow-50 dark:bg-yellow-900/20 border-b border-yellow-200 dark:border-yellow-800">
           <p className="text-sm text-yellow-700 dark:text-yellow-400">{error}</p>
+        </div>
+      )}
+
+      {/* Path hint - show valid base directory */}
+      {baseDir && !error && (
+        <div className="px-3 py-1.5 bg-blue-50 dark:bg-blue-900/20 border-b border-blue-100 dark:border-blue-800">
+          <p className="text-xs text-blue-600 dark:text-blue-400">
+            {t("directoryBrowser.pathHint", { baseDir })}
+          </p>
         </div>
       )}
 

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -42,7 +42,8 @@
     "newFolder": "New Folder",
     "newDirectoryName": "New directory name",
     "selectThisFolder": "Select This Folder",
-    "failedToBrowse": "Failed to browse directory"
+    "failedToBrowse": "Failed to browse directory",
+    "pathHint": "Paths must be under: {{baseDir}}"
   },
   "settings": {
     "title": "Settings",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -42,7 +42,8 @@
     "newFolder": "新建文件夹",
     "newDirectoryName": "新目录名称",
     "selectThisFolder": "选择此目录",
-    "failedToBrowse": "浏览目录失败"
+    "failedToBrowse": "浏览目录失败",
+    "pathHint": "路径必须在 {{baseDir}} 目录下"
   },
   "settings": {
     "title": "设置",


### PR DESCRIPTION
## Summary

Fixes #174

在 DirectoryBrowser 的 browse 步骤中显示 API 错误信息和有效路径范围提示。

## Changes

1. **AddProjectModal.tsx**: 添加错误状态显示和有效路径范围提示
2. **DirectoryBrowser.tsx**: 在 browse 步骤显示 API 错误和路径提示
3. **openace.ts**: 扩展 API 类型定义，支持 baseDir 字段
4. **i18n**: 添加错误提示的国际化文本

## Testing

手动测试：
1. 在 /work 页面创建项目时输入无效路径
2. 验证错误信息正确显示
3. 验证路径提示正确显示