### PR TITLE
fix: 修复深色模式下聊天输入框文字颜色问题 (#184)

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,6 +1,7 @@
 @import "tailwindcss";
 
-@variant dark (.dark &);
+/* Dark mode variant: matches when ancestor has .dark class */
+@variant dark (&:where(.dark, .dark *));
 
 /* Custom scrollbar styles */
 .scrollbar-thin {


### PR DESCRIPTION
## 问题描述

在全局深色主题下，无论是本地工作区还是远程工作区创建的会话，给 AI 发消息的聊天输入窗口里用户输入的文字是黑色的，在深色背景中看不清楚。

## 根因分析

在 `frontend/src/index.css` 中，Tailwind CSS v4 的 dark variant 语法配置有误：

**当前配置：**
```css
@variant dark (.dark &);
```

这个语法中的 `&` 代表**当前元素本身**，会生成 `.dark.text-slate-100` 这样的选择器，要求元素**本身**有 `dark` 类才能匹配。

**问题：**
- `SettingsContext.tsx` 将 `dark` 类添加到 `<html>` 元素（祖先元素）
- textarea 使用了 `dark:text-slate-100` 类期望文字变为浅色
- 但 `.dark.text-slate-100` 选择器要求 textarea 本身有 `dark` 类，而非祖先
- 导致深色模式下文字颜色样式不生效，显示为默认黑色

## 修复内容

将 dark variant 语法改为：
```css
/* Dark mode variant: matches when ancestor has .dark class */
@variant dark (&:where(.dark, .dark *));
```

这会生成 `.dark .text-slate-100` 选择器，匹配祖先元素有 `dark` 类的情况。

## 修改文件

- `frontend/src/index.css` - 修复 Tailwind CSS v4 dark variant 配置

## 关联 Issue

Closes #184