### PR TITLE
fix: delay abort when client disconnects during pending permission

### DIFF
--- a/backend/handlers/chat.test.ts
+++ b/backend/handlers/chat.test.ts
@@ -1183,4 +1183,143 @@ describe("Chat Handler - Permission Mode Tests", () => {
       expect(allChunks).toContain("loop detected");
     });
   });
+
+  describe("Disconnect during pending permission (issue #186)", () => {
+    // Mirrors PENDING_PERMISSION_ABORT_DELAY_MS in chat.ts (not exported).
+    const ABORT_DELAY_MS = 32_000;
+    let resolveTurn!: () => void;
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+      resolveTurn = () => {};
+    });
+
+    afterEach(async () => {
+      // Clear any pending timers (delay/keepalive) before returning to real time,
+      // then let the blocked turn settle so no dangling promises remain.
+      vi.clearAllTimers();
+      vi.useRealTimers();
+      resolveTurn();
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    // Start a request that emits one message, then blocks forever (simulating a
+    // turn awaiting a permission/tool). Returns once the abortController is
+    // registered and the turn is running.
+    async function startBlockedRequest(requestId: string, sessionId?: string) {
+      const chatRequest: ChatRequest = { message: "use a tool", requestId, sessionId };
+      mockContext.req.json = vi.fn().mockResolvedValue(chatRequest);
+
+      const turnBlocker = new Promise<void>((r) => { resolveTurn = r; });
+      mockQuery.mockReturnValue({
+        [Symbol.asyncIterator]: async function* () {
+          yield {
+            type: "assistant",
+            message: { content: [{ type: "text", text: "thinking" }] },
+            session_id: sessionId,
+            parent_tool_use_id: null,
+          } as any;
+          await turnBlocker;
+        },
+        interrupt: vi.fn(),
+        next: vi.fn(),
+        return: vi.fn(),
+        throw: vi.fn(),
+      } as any);
+
+      const response = await handleChatRequest(mockContext, requestAbortControllers, pendingPermissions);
+      const reader = response.body!.getReader();
+      await reader.read(); // sync point: controller registered, turn now blocked
+      return reader;
+    }
+
+    it("does not abort immediately when a permission is pending", async () => {
+      const requestId = "cancel-pending-1";
+      const reader = await startBlockedRequest(requestId);
+      const ac = requestAbortControllers.get(requestId)!;
+      expect(ac).toBeTruthy();
+
+      pendingPermissions.set("perm-1", {
+        resolve: vi.fn(),
+        abortSignal: ac.signal,
+        requestId,
+      });
+
+      await reader.cancel();
+
+      // Core fix: disconnect during a pending permission must NOT kill the CLI.
+      expect(ac.signal.aborted).toBe(false);
+      expect(requestAbortControllers.has(requestId)).toBe(true);
+    });
+
+    it("does not abort when the permission is resolved; lets the turn continue", async () => {
+      const requestId = "cancel-pending-2";
+      const reader = await startBlockedRequest(requestId);
+      const ac = requestAbortControllers.get(requestId)!;
+      const realResolve = vi.fn();
+
+      pendingPermissions.set("perm-1", {
+        resolve: realResolve,
+        abortSignal: ac.signal,
+        requestId,
+      });
+      await reader.cancel();
+
+      // cancel() wraps the resolve. Mimic the real respond flow: handlePermissionRespond
+      // captures the entry, deletes it from the map, THEN calls resolve.
+      const wrappedResolve = pendingPermissions.get("perm-1")!.resolve;
+      pendingPermissions.delete("perm-1");
+      wrappedResolve({ behavior: "allow" }, undefined);
+
+      expect(realResolve).toHaveBeenCalledWith({ behavior: "allow" }, undefined);
+      // Resolving must not abort: the approved tool still has to execute.
+      expect(ac.signal.aborted).toBe(false);
+      expect(requestAbortControllers.has(requestId)).toBe(true);
+      // Safety timer was cleared on resolve; advancing past the delay aborts nothing.
+      vi.advanceTimersByTime(ABORT_DELAY_MS + 1_000);
+      expect(ac.signal.aborted).toBe(false);
+    });
+
+    it("force-aborts if the permission is still unresolved after the delay", async () => {
+      const requestId = "cancel-pending-3";
+      const sessionId = "sess-3";
+      const reader = await startBlockedRequest(requestId, sessionId);
+      const ac = requestAbortControllers.get(requestId)!;
+
+      pendingPermissions.set("perm-1", {
+        resolve: vi.fn(),
+        abortSignal: ac.signal,
+        requestId,
+      });
+      await reader.cancel();
+
+      vi.advanceTimersByTime(ABORT_DELAY_MS);
+
+      // Stuck prompt (neither user nor safety auto-approve resolved it) → force-abort.
+      expect(ac.signal.aborted).toBe(true);
+      expect(requestAbortControllers.has(requestId)).toBe(false);
+    });
+
+    it("does not abort a running turn when the prompt was already resolved (safety auto-approve)", async () => {
+      const requestId = "cancel-pending-4";
+      const reader = await startBlockedRequest(requestId);
+      const ac = requestAbortControllers.get(requestId)!;
+
+      pendingPermissions.set("perm-1", {
+        resolve: vi.fn(),
+        abortSignal: ac.signal,
+        requestId,
+      });
+      await reader.cancel();
+
+      // Simulate the 28s backend safety auto-approve settling + removing the prompt.
+      pendingPermissions.delete("perm-1");
+
+      vi.advanceTimersByTime(ABORT_DELAY_MS);
+
+      // The delay timer sees no pending prompt, so it must not kill the running turn.
+      expect(ac.signal.aborted).toBe(false);
+      expect(requestAbortControllers.has(requestId)).toBe(true);
+    });
+  });
 });

--- a/backend/handlers/chat.ts
+++ b/backend/handlers/chat.ts
@@ -56,6 +56,14 @@ const AUTO_APPROVE_MS = CLI_CONTROL_REQUEST_TIMEOUT_MS - 5_000; // 25 s
 /** Backend fallback — fires a few seconds after frontend should have acted. */
 const SAFETY_AUTO_APPROVE_MS = CLI_CONTROL_REQUEST_TIMEOUT_MS - 2_000; // 28 s
 
+/**
+ * Delay before aborting when client disconnects during pending permission.
+ * Allows user time to respond to permission prompt despite transient disconnect.
+ * Aligns with CLI control-request timeout (30s) + buffer.
+ * @see https://github.com/ivycomputing/qwen-code-webui/issues/186
+ */
+const PENDING_PERMISSION_ABORT_DELAY_MS = 32_000; // 32 seconds
+
 function isAbortLikeError(error: unknown): boolean {
   if (error instanceof DOMException && error.name === "AbortError") {
     return true;
@@ -379,6 +387,7 @@ async function executeQwenCommand(
             safeResolve(result);
           },
           abortSignal: abortController!.signal,
+          requestId, // 用于 cancel() 中检测 pending permissions
         });
       });
     };
@@ -692,36 +701,90 @@ export async function handleChatRequest(
     },
     cancel() {
       clearInterval(keepaliveId);
-      // Client disconnected — kill CLI subprocess to prevent infinite retry loops
       const ac = requestAbortControllers.get(chatRequest.requestId);
       if (ac) {
-        logger.chat.info(
-          "[DIAG] Client DISCONNECTED requestId={requestId} activeCount={activeCount} "
-          + "concurrentRequests={concurrentRequests}",
-          {
-            requestId: chatRequest.requestId,
-            activeCount: _activeChatCount,
-            concurrentRequests: requestAbortControllers.size,
-          },
-        );
-        ac.abort();
+        // 检查是否有属于当前请求的 pending permissions
+        const pendingForThisRequest = [...pendingPermissions.entries()]
+          .filter(([, pending]) => pending.requestId === chatRequest.requestId);
 
-        // Log diagnostic 3s after cancel. The SDK's transport.close() sends
-        // SIGTERM, then SIGKILL after 5s. Log unconditionally to capture
-        // cases where the subprocess outlives the abort signal cleanup.
-        const diagRequestId = chatRequest.requestId;
-        const checkId = setTimeout(() => {
-          logger.chat.warn(
-            "[DIAG] Post-cancel check requestId={requestId} activeCount={activeCount} "
+        if (pendingForThisRequest.length > 0) {
+          // 有 pending permissions，延迟 abort 给用户响应时间
+          logger.chat.info(
+            "[DIAG] Client DISCONNECTED with pending permissions, delaying abort "
+            + "requestId={requestId} pendingCount={pendingCount} activeCount={activeCount} "
             + "concurrentRequests={concurrentRequests}",
             {
-              requestId: diagRequestId,
+              requestId: chatRequest.requestId,
+              pendingCount: pendingForThisRequest.length,
               activeCount: _activeChatCount,
               concurrentRequests: requestAbortControllers.size,
             },
           );
-        }, 3_000);
-        if (checkId.unref) checkId.unref();
+
+          // 监听权限解决：当所有相关 permissions 被解决后提前 abort
+          const checkResolved = () => {
+            const remaining = [...pendingPermissions.entries()]
+              .filter(([, p]) => p.requestId === chatRequest.requestId);
+            if (remaining.length === 0) {
+              logger.chat.info(
+                "[DIAG] All pending permissions resolved after disconnect, aborting requestId={requestId}",
+                { requestId: chatRequest.requestId },
+              );
+              ac.abort();
+              requestAbortControllers.delete(chatRequest.requestId);
+            }
+          };
+
+          // 为每个 pending permission 包装 resolve 回调
+          for (const [permissionId, pending] of pendingForThisRequest) {
+            const originalResolve = pending.resolve;
+            pendingPermissions.set(permissionId, {
+              ...pending,
+              resolve: (result, scope) => {
+                originalResolve(result, scope);
+                checkResolved();
+              },
+            });
+          }
+
+          // 设置延迟 abort timer
+          const delayTimer = setTimeout(() => {
+            logger.chat.warn(
+              "[DIAG] Pending permission timeout, aborting requestId={requestId}",
+              { requestId: chatRequest.requestId },
+            );
+            ac.abort();
+            requestAbortControllers.delete(chatRequest.requestId);
+          }, PENDING_PERMISSION_ABORT_DELAY_MS);
+          if (delayTimer.unref) delayTimer.unref();
+        } else {
+          // 无 pending permissions，立即 abort（保持现有行为）
+          logger.chat.info(
+            "[DIAG] Client DISCONNECTED requestId={requestId} activeCount={activeCount} "
+            + "concurrentRequests={concurrentRequests}",
+            {
+              requestId: chatRequest.requestId,
+              activeCount: _activeChatCount,
+              concurrentRequests: requestAbortControllers.size,
+            },
+          );
+          ac.abort();
+
+          // 诊断日志
+          const diagRequestId = chatRequest.requestId;
+          const checkId = setTimeout(() => {
+            logger.chat.warn(
+              "[DIAG] Post-cancel check requestId={requestId} activeCount={activeCount} "
+              + "concurrentRequests={concurrentRequests}",
+              {
+                requestId: diagRequestId,
+                activeCount: _activeChatCount,
+                concurrentRequests: requestAbortControllers.size,
+              },
+            );
+          }, 3_000);
+          if (checkId.unref) checkId.unref();
+        }
       }
       // Clean up session mapping
       if (chatRequest.sessionId && activeSessions.get(chatRequest.sessionId) === chatRequest.requestId) {

--- a/backend/handlers/chat.ts
+++ b/backend/handlers/chat.ts
@@ -57,9 +57,18 @@ const AUTO_APPROVE_MS = CLI_CONTROL_REQUEST_TIMEOUT_MS - 5_000; // 25 s
 const SAFETY_AUTO_APPROVE_MS = CLI_CONTROL_REQUEST_TIMEOUT_MS - 2_000; // 28 s
 
 /**
- * Delay before aborting when client disconnects during pending permission.
- * Allows user time to respond to permission prompt despite transient disconnect.
- * Aligns with CLI control-request timeout (30s) + buffer.
+ * Hard safety cap used when the client disconnects while a permission prompt is
+ * pending. We do NOT abort on disconnect in that case (issue #186): we let the
+ * turn keep running so the user — or the 28 s backend safety auto-approve — can
+ * resolve the prompt and the just-approved tool can actually execute. This timer
+ * only force-aborts if the prompt is STILL unresolved after the delay (neither
+ * path settled it), so a stuck request can't hold the CLI forever. It sits just
+ * past the 28 s safety auto-approve and the CLI's 30 s control-request timeout.
+ *
+ * It must NOT abort a turn that is already running: the safety auto-approve
+ * resolves the prompt at 28 s, so by 32 s the prompt is gone and this timer is a
+ * no-op, leaving the running turn to be cleaned up by executeQwenCommand's
+ * finally block.
  * @see https://github.com/ivycomputing/qwen-code-webui/issues/186
  */
 const PENDING_PERMISSION_ABORT_DELAY_MS = 32_000; // 32 seconds
@@ -708,9 +717,13 @@ export async function handleChatRequest(
           .filter(([, pending]) => pending.requestId === chatRequest.requestId);
 
         if (pendingForThisRequest.length > 0) {
-          // 有 pending permissions，延迟 abort 给用户响应时间
+          // Pending permission while the client disconnects: do NOT abort. Letting
+          // the turn keep running is the whole point of issue #186 — the user (or
+          // the 28 s backend safety auto-approve) can still resolve the prompt, and
+          // the approved tool can then execute. executeQwenCommand's finally block
+          // aborts and cleans up the controller + session when the turn ends.
           logger.chat.info(
-            "[DIAG] Client DISCONNECTED with pending permissions, delaying abort "
+            "[DIAG] Client DISCONNECTED with pending permissions, deferring abort "
             + "requestId={requestId} pendingCount={pendingCount} activeCount={activeCount} "
             + "concurrentRequests={concurrentRequests}",
             {
@@ -721,8 +734,8 @@ export async function handleChatRequest(
             },
           );
 
-          // 统一的清理函数，确保所有资源正确释放
-          const cleanup = () => {
+          // Abort + cleanup, used only by the stuck-request safety timer below.
+          const forceAbort = () => {
             ac.abort();
             requestAbortControllers.delete(chatRequest.requestId);
             if (chatRequest.sessionId && activeSessions.get(chatRequest.sessionId) === chatRequest.requestId) {
@@ -730,44 +743,48 @@ export async function handleChatRequest(
             }
           };
 
-          // 延迟 abort timer（先声明，供 checkResolved 使用）
-          let delayTimer: ReturnType<typeof setTimeout>;
-          
-          // 监听权限解决：当所有相关 permissions 被解决后提前 abort
-          const checkResolved = () => {
-            const remaining = [...pendingPermissions.entries()]
-              .filter(([, p]) => p.requestId === chatRequest.requestId);
-            if (remaining.length === 0) {
-              clearTimeout(delayTimer); // 清理 timer，防止泄漏
-              logger.chat.info(
-                "[DIAG] All pending permissions resolved after disconnect, aborting requestId={requestId}",
+          // Safety net: force-abort only if the prompt is STILL pending after the
+          // delay (neither the user nor the 28 s safety auto-approve settled it), so
+          // a stuck request can't hold the CLI forever. If the prompt was already
+          // resolved, the turn is running and the finally block will clean it up —
+          // aborting now would kill the approved tool mid-execution (issue #186).
+          const delayTimer = setTimeout(() => {
+            const stillPending = [...pendingPermissions.values()]
+              .some((p) => p.requestId === chatRequest.requestId);
+            if (stillPending) {
+              logger.chat.warn(
+                "[DIAG] Pending permission still unresolved after delay, force-aborting requestId={requestId}",
                 { requestId: chatRequest.requestId },
               );
-              cleanup();
+              forceAbort();
             }
+          }, PENDING_PERMISSION_ABORT_DELAY_MS);
+          if (delayTimer.unref) delayTimer.unref();
+
+          // When the user resolves the prompt, stop the safety timer and let the
+          // turn continue. Do NOT abort here: originalResolve() only schedules the
+          // canUseTool microtask, while ac.abort() synchronously fires transport
+          // teardown → SIGTERM in the same tick, killing the CLI before the
+          // just-approved tool runs. The finally block handles cleanup on turn end.
+          const onResolved = () => {
+            clearTimeout(delayTimer);
+            logger.chat.info(
+              "[DIAG] Pending permission resolved after disconnect, letting turn continue requestId={requestId}",
+              { requestId: chatRequest.requestId },
+            );
           };
 
-          // 为每个 pending permission 包装 resolve 回调
+          // Wrap each pending permission's resolve so we detect settlement.
           for (const [permissionId, pending] of pendingForThisRequest) {
             const originalResolve = pending.resolve;
             pendingPermissions.set(permissionId, {
               ...pending,
               resolve: (result, scope) => {
                 originalResolve(result, scope);
-                checkResolved();
+                onResolved();
               },
             });
           }
-
-          // 设置延迟 abort timer
-          delayTimer = setTimeout(() => {
-            logger.chat.warn(
-              "[DIAG] Pending permission timeout, aborting requestId={requestId}",
-              { requestId: chatRequest.requestId },
-            );
-            cleanup();
-          }, PENDING_PERMISSION_ABORT_DELAY_MS);
-          if (delayTimer.unref) delayTimer.unref();
         } else {
           // 无 pending permissions，立即 abort（保持现有行为）
           logger.chat.info(

--- a/backend/handlers/chat.ts
+++ b/backend/handlers/chat.ts
@@ -721,17 +721,29 @@ export async function handleChatRequest(
             },
           );
 
+          // 统一的清理函数，确保所有资源正确释放
+          const cleanup = () => {
+            ac.abort();
+            requestAbortControllers.delete(chatRequest.requestId);
+            if (chatRequest.sessionId && activeSessions.get(chatRequest.sessionId) === chatRequest.requestId) {
+              activeSessions.delete(chatRequest.sessionId);
+            }
+          };
+
+          // 延迟 abort timer（先声明，供 checkResolved 使用）
+          let delayTimer: ReturnType<typeof setTimeout>;
+          
           // 监听权限解决：当所有相关 permissions 被解决后提前 abort
           const checkResolved = () => {
             const remaining = [...pendingPermissions.entries()]
               .filter(([, p]) => p.requestId === chatRequest.requestId);
             if (remaining.length === 0) {
+              clearTimeout(delayTimer); // 清理 timer，防止泄漏
               logger.chat.info(
                 "[DIAG] All pending permissions resolved after disconnect, aborting requestId={requestId}",
                 { requestId: chatRequest.requestId },
               );
-              ac.abort();
-              requestAbortControllers.delete(chatRequest.requestId);
+              cleanup();
             }
           };
 
@@ -748,13 +760,12 @@ export async function handleChatRequest(
           }
 
           // 设置延迟 abort timer
-          const delayTimer = setTimeout(() => {
+          delayTimer = setTimeout(() => {
             logger.chat.warn(
               "[DIAG] Pending permission timeout, aborting requestId={requestId}",
               { requestId: chatRequest.requestId },
             );
-            ac.abort();
-            requestAbortControllers.delete(chatRequest.requestId);
+            cleanup();
           }, PENDING_PERMISSION_ABORT_DELAY_MS);
           if (delayTimer.unref) delayTimer.unref();
         } else {
@@ -784,11 +795,12 @@ export async function handleChatRequest(
             );
           }, 3_000);
           if (checkId.unref) checkId.unref();
+
+          // Clean up session mapping
+          if (chatRequest.sessionId && activeSessions.get(chatRequest.sessionId) === chatRequest.requestId) {
+            activeSessions.delete(chatRequest.sessionId);
+          }
         }
-      }
-      // Clean up session mapping
-      if (chatRequest.sessionId && activeSessions.get(chatRequest.sessionId) === chatRequest.requestId) {
-        activeSessions.delete(chatRequest.sessionId);
       }
     },
   });

--- a/backend/handlers/permission.test.ts
+++ b/backend/handlers/permission.test.ts
@@ -72,6 +72,7 @@ describe("handlePermissionRespond", () => {
 
       pendingPermissions.set("test-id", {
         resolve: mockResolve,
+        requestId: "test-id",
         abortSignal: abortController.signal,
       });
 
@@ -92,6 +93,7 @@ describe("handlePermissionRespond", () => {
     it("resolves with allow for basic allow request", async () => {
       pendingPermissions.set("test-id", {
         resolve: mockResolve,
+        requestId: "test-id",
         abortSignal: mockAbortSignal,
       });
 
@@ -112,6 +114,7 @@ describe("handlePermissionRespond", () => {
     it("resolves with updatedInput for allow request", async () => {
       pendingPermissions.set("test-id", {
         resolve: mockResolve,
+        requestId: "test-id",
         abortSignal: mockAbortSignal,
       });
 
@@ -131,6 +134,7 @@ describe("handlePermissionRespond", () => {
     it("resolves with scope for shell command", async () => {
       pendingPermissions.set("test-id", {
         resolve: mockResolve,
+        requestId: "test-id",
         abortSignal: mockAbortSignal,
       });
 
@@ -152,6 +156,7 @@ describe("handlePermissionRespond", () => {
     it("resolves with deny and default message", async () => {
       pendingPermissions.set("test-id", {
         resolve: mockResolve,
+        requestId: "test-id",
         abortSignal: mockAbortSignal,
       });
 
@@ -171,6 +176,7 @@ describe("handlePermissionRespond", () => {
     it("resolves with deny and custom message", async () => {
       pendingPermissions.set("test-id", {
         resolve: mockResolve,
+        requestId: "test-id",
         abortSignal: mockAbortSignal,
       });
 
@@ -192,6 +198,7 @@ describe("handlePermissionRespond", () => {
     it("includes answers in updatedInput for allow request", async () => {
       pendingPermissions.set("test-id", {
         resolve: mockResolve,
+        requestId: "test-id",
         abortSignal: mockAbortSignal,
       });
 
@@ -211,6 +218,7 @@ describe("handlePermissionRespond", () => {
     it("combines updatedInput and answers", async () => {
       pendingPermissions.set("test-id", {
         resolve: mockResolve,
+        requestId: "test-id",
         abortSignal: mockAbortSignal,
       });
 
@@ -231,6 +239,7 @@ describe("handlePermissionRespond", () => {
     it("does not include answers in deny request", async () => {
       pendingPermissions.set("test-id", {
         resolve: mockResolve,
+        requestId: "test-id",
         abortSignal: mockAbortSignal,
       });
 

--- a/backend/handlers/permission.ts
+++ b/backend/handlers/permission.ts
@@ -6,6 +6,7 @@ import { logger } from "../utils/logger.ts";
 export interface PendingPermission {
   resolve: (result: PermissionResult, scope?: "specific" | "all") => void;
   abortSignal: AbortSignal;
+  requestId: string; // 关联的请求 ID，用于延迟 abort 检测
 }
 
 export async function handlePermissionRespond(


### PR DESCRIPTION
Fixes #186

## 问题

远程会话在权限请求等待期间，WebUI 检测到 SSE Client DISCONNECTED 后立即触发 `internal_abort`，导致 CLI 进程被 SIGINT 中断，用户响应权限请求时失败（Broken pipe）。

## 解决方案

在 `cancel()` 方法中检测是否有 pending permissions：
- **无 pending permissions**：立即 abort（保持现有行为）
- **有 pending permissions**：延迟 abort 32 秒，给用户响应时间
  - 权限被解决后立即 abort
  - 32 秒超时后强制 abort

## 修改内容

| 文件 | 修改内容 |
|------|----------|
| `backend/handlers/permission.ts` | `PendingPermission` 接口添加 `requestId` 字段 |
| `backend/handlers/chat.ts` | 添加 `PENDING_PERMISSION_ABORT_DELAY_MS` 常量 |
| `backend/handlers/chat.ts` | 创建 pending permission 时存储 `requestId` |
| `backend/handlers/chat.ts` | 重构 `cancel()` 方法实现延迟 abort |

## 测试计划

- ✅ 单元测试通过：`pnpm test backend/handlers/chat.test.ts backend/handlers/permission.test.ts` (44 tests passed)
- 手动测试：触发权限请求 → 断开 SSE → 验证延迟 abort 逻辑