### PR TITLE
chore: ignore .qwen/ local tooling artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ backend/dist/
 # Claude Code
 .claude/
 .agents/
+.qwen/
 
 # OS files
 .DS_Store


### PR DESCRIPTION
## Summary
Add `.qwen/` to `.gitignore` (alongside existing `.claude/` and `.agents/` entries) to stop local `qwen-code` tooling artifacts (`review-cache/`, `reviews/`, `tmp/`) from showing up as untracked files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)