### PR TITLE
chore: ignore root-only package-lock.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ screenshots/
 # deno.lock
 # package-lock.json
 # pnpm-lock.yaml
+
+# Root lock file (keep frontend/package-lock.json tracked)
+/package-lock.json


### PR DESCRIPTION
## Summary
Add a root-anchored `/package-lock.json` to `.gitignore`. An empty root-level `package-lock.json` (`packages: {}`) keeps appearing when `npm install` is run at the repo root by accident.

- `/package-lock.json` (anchored) ignores only the root lock file.
- `frontend/package-lock.json` remains tracked (verified with `git check-ignore`).

The pre-existing commented `# package-lock.json` line is left as-is — uncommenting it would wrongly ignore the tracked frontend lockfile too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)