### PR TITLE
chore: publish 0.2.36

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qwen-code-webui",
-  "version": "0.2.35",
+  "version": "0.2.36",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qwen-code-webui",
-      "version": "0.2.35",
+      "version": "0.2.36",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.11",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qwen-code-webui",
-  "version": "0.2.35",
+  "version": "0.2.36",
   "type": "module",
   "description": "Web-based interface for the Qwen Code CLI with streaming chat interface",
   "keywords": [

--- a/frontend/src/components/ChatPage.postMessage.test.tsx
+++ b/frontend/src/components/ChatPage.postMessage.test.tsx
@@ -1,4 +1,3 @@
-import { render, fireEvent, act, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 /**
@@ -89,7 +88,6 @@ describe("ChatPage postMessage listener", () => {
 
     it("ignores messages from non-parent sources", () => {
       // Simulate iframe scenario
-      const iframeWindow = {} as Window;
       const maliciousWindow = {} as Window;
 
       const event = new MessageEvent("message", {
@@ -109,7 +107,7 @@ describe("ChatPage postMessage listener", () => {
       const removeEventListenerSpy = vi.spyOn(window, "removeEventListener");
 
       // Simulate useEffect mounting
-      const handler = (event: MessageEvent) => {};
+      const handler = () => {};
       window.addEventListener("message", handler);
 
       expect(addEventListenerSpy).toHaveBeenCalledWith("message", handler);

--- a/frontend/src/components/chat/ChatMessages.test.tsx
+++ b/frontend/src/components/chat/ChatMessages.test.tsx
@@ -99,7 +99,7 @@ describe("ChatMessages", () => {
           tool_name: "test_tool",
           input: {},
           timestamp: 3000,
-        },
+        } as unknown as AllMessage,
       ];
 
       render(<ChatMessages messages={messagesWithTool} isLoading={false} />);
@@ -119,12 +119,12 @@ describe("ChatMessages", () => {
           subtype: "init",
           session_id: "session-1",
           timestamp: 3000,
-        },
+        } as AllMessage,
         {
           type: "result",
           subtype: "success",
           timestamp: 4000,
-        },
+        } as AllMessage,
       ];
 
       render(<ChatMessages messages={messagesWithSystem} isLoading={false} />);

--- a/frontend/src/components/chat/WebUIChatMessages.test.tsx
+++ b/frontend/src/components/chat/WebUIChatMessages.test.tsx
@@ -105,12 +105,12 @@ describe("WebUIChatMessages", () => {
           subtype: "init",
           session_id: "session-1",
           timestamp: 3000,
-        },
+        } as AllMessage,
         {
           type: "result",
           subtype: "success",
           timestamp: 4000,
-        },
+        } as AllMessage,
       ];
 
       render(<WebUIChatMessages messages={messagesWithSystem} />);

--- a/frontend/src/hooks/streaming/useStreamParser.test.ts
+++ b/frontend/src/hooks/streaming/useStreamParser.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from "vitest";
 import { renderHook } from "@testing-library/react";
 import { useStreamParser } from "./useStreamParser";
-import type { StreamingContext } from "./useMessageProcessor";
+import type { StreamingContext, ThinkingTimeoutInfo } from "./useMessageProcessor";
 import { generateId } from "../../utils/id";
 import { TOOL_NAMES } from "../../utils/toolNames";
 
@@ -718,11 +718,13 @@ describe("useStreamParser", () => {
 
 
   describe("Thinking Timeout", () => {
-    let onThinkingTimeout: ReturnType<typeof vi.fn>;
+    // Typed mock: vitest 4's `vi.fn()` returns the broad `Mock<Procedure | Constructable>`,
+    // which is no longer assignable to the specific onThinkingTimeout signature.
+    let onThinkingTimeout: Mock<ThinkingTimeoutInfo["onThinkingTimeout"]>;
 
     beforeEach(() => {
       vi.useFakeTimers();
-      onThinkingTimeout = vi.fn();
+      onThinkingTimeout = vi.fn<ThinkingTimeoutInfo["onThinkingTimeout"]>();
       mockContext.currentThinkingMessage = null;
       mockContext.setCurrentThinkingMessage = vi.fn((msg) => {
         mockContext.currentThinkingMessage = msg;


### PR DESCRIPTION
Published `qwen-code-webui@0.2.36` to npm. This PR lands the version bump plus the frontend test-type fixes that were required to unblock `npm run build` (which the publish flow runs).

## What's included

- **`fix(frontend): repair test types so \`npm run build\` passes`** — The frontend `typecheck` script is a no-op (root tsconfig has `files: []` + project refs, no `--build`), so CI never caught these; only `tsc -b` in `npm run build` surfaces them.
  - `useStreamParser.test.ts`: type the `onThinkingTimeout` mock for vitest 4 (`Mock<...>` / `vi.fn<...>()`, same pattern as the backend fix in #193).
  - `ChatMessages` / `WebUIChatMessages` fixtures: cast incomplete SDK message objects `as AllMessage` (filtering tests; fields irrelevant).
  - `ChatPage.postMessage.test.tsx`: drop an unused testing-library import and two unused locals.
- **`chore: bump version to 0.2.36`** — `package.json` + `package-lock.json`.

## Verification
- Frontend `npm run build`: ✅ (was failing on 12 TS errors)
- Frontend tests: ✅ 218/218
- Backend `npm run typecheck` + tests: ✅ 84/84 (vitest 4)
- `npm publish`: ✅ `qwen-code-webui@0.2.36`

Note: main is protected (GH013 — changes via PR), so the `/npm-publish` skill's direct `git push` was redirected here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)