### PR TITLE
fix(frontend): SSE auto-reconnect for remote session stability

### DIFF
--- a/frontend/src/api/openace.reconnect.test.ts
+++ b/frontend/src/api/openace.reconnect.test.ts
@@ -1,0 +1,226 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Type describing the fake EventSource instances the test controls.
+interface FakeEventSource {
+  onopen: ((ev: Event) => void) | null;
+  onmessage: ((ev: MessageEvent) => void) | null;
+  onerror: ((ev: Event) => void) | null;
+  readyState: number;
+  url: string;
+  close: () => void;
+  addEventListener: () => void;
+  removeEventListener: () => void;
+  dispatchEvent: () => boolean;
+}
+
+// createRemoteSessionStreamWithReconnect is imported after the global
+// EventSource stub is wired up in beforeEach.
+import { createRemoteSessionStreamWithReconnect } from "./openace";
+
+const OPEN = 1; // EventSource.OPEN
+
+describe("createRemoteSessionStreamWithReconnect", () => {
+  let instances: FakeEventSource[];
+
+  // A class so that `new EventSource(url)` works in the code under test.
+  // The constructor records each instance so tests can fire events on it.
+  class FakeEventSourceImpl {
+    // Static constants the code under test reads (EventSource.OPEN etc.).
+    static readonly CONNECTING = 0;
+    static readonly OPEN = 1;
+    static readonly CLOSED = 2;
+    onopen: ((ev: Event) => void) | null = null;
+    onmessage: ((ev: MessageEvent) => void) | null = null;
+    onerror: ((ev: Event) => void) | null = null;
+    readyState: number = OPEN;
+    url: string;
+    constructor(url: string) {
+      this.url = url;
+      instances.push(this as unknown as FakeEventSource);
+    }
+    close = vi.fn(function (this: FakeEventSourceImpl) {
+      this.readyState = FakeEventSourceImpl.CLOSED;
+    });
+    addEventListener = vi.fn();
+    removeEventListener = vi.fn();
+    dispatchEvent = vi.fn(() => true);
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    instances = [];
+    vi.stubGlobal("EventSource", FakeEventSourceImpl);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  /** Open the (latest) EventSource instance and reset its retry counter. */
+  function fireOpen(idx = -1) {
+    const inst = instances.at(idx)!;
+    inst.readyState = OPEN;
+    inst.onopen?.(new Event("open"));
+  }
+
+  /** Trigger an error on the (latest) EventSource instance. */
+  function fireError(idx = -1) {
+    instances.at(idx)!.onerror?.(new Event("error"));
+  }
+
+  it("reconnects with increasing backoff on consecutive errors", () => {
+    const onError = vi.fn();
+    const onStateChange = vi.fn();
+    createRemoteSessionStreamWithReconnect("sid", {
+      onLine: vi.fn(),
+      onError,
+      onDone: vi.fn(),
+      onStateChange,
+      maxRetries: 5,
+      initialRetryDelay: 1000,
+      maxRetryDelay: 30000,
+    });
+    // Initial connect creates the first EventSource.
+    expect(instances).toHaveLength(1);
+
+    // 1st error → schedule reconnect after 1000ms.
+    fireError();
+    expect(onStateChange).toHaveBeenLastCalledWith("reconnecting");
+    // advancing less than the delay must NOT reconnect yet.
+    vi.advanceTimersByTime(999);
+    expect(instances).toHaveLength(1);
+    vi.advanceTimersByTime(1); // reach 1000ms → reconnect
+    expect(instances).toHaveLength(2);
+
+    // 2nd error → backoff doubles to 2000ms.
+    fireError();
+    vi.advanceTimersByTime(1999);
+    expect(instances).toHaveLength(2);
+    vi.advanceTimersByTime(1); // 2000ms
+    expect(instances).toHaveLength(3);
+
+    // 3rd error → backoff 4000ms.
+    fireError();
+    vi.advanceTimersByTime(3999);
+    expect(instances).toHaveLength(3);
+    vi.advanceTimersByTime(1);
+    expect(instances).toHaveLength(4);
+  });
+
+  it("fires onError exactly once when maxRetries is exhausted", () => {
+    const onError = vi.fn();
+    const onStateChange = vi.fn();
+    createRemoteSessionStreamWithReconnect("sid", {
+      onLine: vi.fn(),
+      onError,
+      onDone: vi.fn(),
+      onStateChange,
+      maxRetries: 2,
+      initialRetryDelay: 1000,
+      maxRetryDelay: 30000,
+    });
+
+    // Error 1 → reconnect (retryCount 1). Error 2 → reconnect (retryCount 2).
+    fireError();
+    vi.advanceTimersByTime(1000);
+    fireError();
+    vi.advanceTimersByTime(2000);
+    // retryCount(2) is not < maxRetries(2) → disconnect, single onError.
+    fireError();
+    expect(onStateChange).toHaveBeenLastCalledWith("disconnected");
+    expect(onError).toHaveBeenCalledTimes(1);
+    // Advancing time well past any backoff must not create more connections.
+    vi.advanceTimersByTime(120000);
+    expect(instances).toHaveLength(3);
+  });
+
+  it("resets retryCount and delay on successful reconnect (onopen)", () => {
+    const onError = vi.fn();
+    createRemoteSessionStreamWithReconnect("sid", {
+      onLine: vi.fn(),
+      onError,
+      onDone: vi.fn(),
+      maxRetries: 5,
+      initialRetryDelay: 1000,
+      maxRetryDelay: 30000,
+    });
+
+    // Error → reconnect after 1s.
+    fireError();
+    vi.advanceTimersByTime(1000);
+    expect(instances).toHaveLength(2);
+    // The new connection opens successfully → retryCount resets to 0.
+    fireOpen();
+    // Now an error should reconnect after 1s again (not 2s), proving reset.
+    fireError();
+    vi.advanceTimersByTime(1000);
+    expect(instances).toHaveLength(3);
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("treats stall (no data) as a reconnect trigger", () => {
+    const onLine = vi.fn();
+    createRemoteSessionStreamWithReconnect("sid", {
+      onLine,
+      onError: vi.fn(),
+      onDone: vi.fn(),
+      maxRetries: 5,
+      initialRetryDelay: 1000,
+      maxRetryDelay: 30000,
+      stallTimeout: 35000,
+    });
+    // Connection opens, starting the stall timer.
+    fireOpen();
+
+    // No data for 35s → stall detected → close + reconnect scheduled.
+    vi.advanceTimersByTime(35000);
+    // First instance closed, reconnect scheduled after initialRetryDelay.
+    expect(instances[0].close).toHaveBeenCalled();
+    vi.advanceTimersByTime(1000);
+    expect(instances).toHaveLength(2);
+  });
+
+  it("keepalive messages reset the stall timer and are not forwarded to onLine", () => {
+    const onLine = vi.fn();
+    createRemoteSessionStreamWithReconnect("sid", {
+      onLine,
+      onError: vi.fn(),
+      onDone: vi.fn(),
+      maxRetries: 5,
+      initialRetryDelay: 1000,
+      maxRetryDelay: 30000,
+      stallTimeout: 35000,
+    });
+    fireOpen();
+
+    // Backend sends a keepalive every ~10s. Feed several over 40s total; if the
+    // keepalive resets the stall timer, no reconnect occurs (no 2nd instance).
+    for (let i = 0; i < 4; i++) {
+      vi.advanceTimersByTime(10000);
+      instances.at(-1)!.onmessage?.({ data: '{"type":"keepalive"}' } as MessageEvent);
+    }
+    expect(instances).toHaveLength(1); // no stall reconnect
+    expect(onLine).not.toHaveBeenCalled(); // keepalive never forwarded
+  });
+
+  it("manual close clears timers so no reconnect happens afterwards", () => {
+    const onError = vi.fn();
+    const es = createRemoteSessionStreamWithReconnect("sid", {
+      onLine: vi.fn(),
+      onError,
+      onDone: vi.fn(),
+      maxRetries: 5,
+      initialRetryDelay: 1000,
+      maxRetryDelay: 30000,
+    });
+    fireOpen();
+
+    // Close manually, then advance well past stall + reconnect delays.
+    es.close();
+    vi.advanceTimersByTime(120000);
+    expect(instances).toHaveLength(1); // no reconnect
+    expect(onError).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/api/openace.ts
+++ b/frontend/src/api/openace.ts
@@ -803,7 +803,7 @@ export function createRemoteSessionStreamWithReconnect(
     };
 
     es.onmessage = (event) => {
-      resetStallTimer();  // Reset stall timer on every message
+      resetStallTimer();  // Reset stall timer on every message (incl. keepalive)
       if (event.data === "[DONE]") {
         console.debug("[SSE] Received [DONE]");
         es.close();
@@ -813,6 +813,13 @@ export function createRemoteSessionStreamWithReconnect(
         }
         onDone();
         return;
+      }
+      // Backend keepalive heartbeat — only keeps the stall timer alive above;
+      // it carries no session output, so don't forward it to onLine.
+      try {
+        if (JSON.parse(event.data)?.type === "keepalive") return;
+      } catch {
+        // Not JSON — treat as a regular SSE line.
       }
       onLine(event.data);
     };

--- a/frontend/src/api/openace.ts
+++ b/frontend/src/api/openace.ts
@@ -707,42 +707,124 @@ export async function resumeRemoteSession(
   return response.json();
 }
 
+export type SSEConnectionState = 'connected' | 'reconnecting' | 'disconnected';
+
+export interface SSEOptions {
+  onLine: (line: string) => void;
+  onError: (err: Event) => void;
+  onDone: () => void;
+  onStateChange?: (state: SSEConnectionState) => void;
+  maxRetries?: number;
+  initialRetryDelay?: number;
+  maxRetryDelay?: number;
+}
+
 export function createRemoteSessionStream(
   sessionId: string,
   onLine: (line: string) => void,
   onError: (err: Event) => void,
   onDone: () => void,
 ): EventSource {
-  const url = buildOpenAceUrl(`/api/remote/sessions/${sessionId}/stream`);
-  console.log("[SSE] Connecting to:", url);
-  const es = new EventSource(url);
-  es.onopen = () => {
-    console.log("[SSE] Connection opened");
-  };
-  es.onmessage = (event) => {
-    if (event.data === "[DONE]") {
-      console.log("[SSE] Received [DONE]");
-      es.close();
-      onDone();
-      return;
-    }
-    onLine(event.data);
-  };
-  es.onerror = (e) => {
-    console.error("[SSE] Error, readyState:", es.readyState, e);
-    es.close();
-    onError(e);
-  };
-  return es;
+  // Legacy API - no reconnect, just wrap the new function
+  return createRemoteSessionStreamWithReconnect(sessionId, {
+    onLine,
+    onError,
+    onDone,
+    maxRetries: 0, // No reconnect for legacy API
+  });
 }
 
-// -------------------------------------------------------
-// Remote Git API functions
-// -------------------------------------------------------
+export function createRemoteSessionStreamWithReconnect(
+  sessionId: string,
+  options: SSEOptions,
+): EventSource {
+  const {
+    onLine,
+    onError,
+    onDone,
+    onStateChange,
+    maxRetries = 5,
+    initialRetryDelay = 1000,
+    maxRetryDelay = 30000,
+  } = options;
 
-/**
- * Fetch git status from a remote machine via Open-ACE proxy.
- * Only called in remote workspace mode (workspaceType=remote).
+  const url = buildOpenAceUrl(`/api/remote/sessions/${sessionId}/stream`);
+  let retryCount = 0;
+  let currentDelay = initialRetryDelay;
+  let es: EventSource;
+  let reconnectTimer: number | null = null;
+
+  const connect = () => {
+    console.log("[SSE] Connecting to:", url, `(retry ${retryCount}/${maxRetries})`);
+    onStateChange?.(retryCount > 0 ? 'reconnecting' : 'connected');
+    
+    es = new EventSource(url);
+    
+    es.onopen = () => {
+      console.log("[SSE] Connection opened");
+      retryCount = 0;
+      currentDelay = initialRetryDelay;
+      onStateChange?.('connected');
+    };
+    
+    es.onmessage = (event) => {
+      if (event.data === "[DONE]") {
+        console.log("[SSE] Received [DONE]");
+        es.close();
+        onDone();
+        return;
+      }
+      onLine(event.data);
+    };
+    
+    es.onerror = (e) => {
+      console.error("[SSE] Error, readyState:", es.readyState, e);
+      es.close();
+      
+      if (retryCount < maxRetries && maxRetries > 0) {
+        retryCount++;
+        console.log("[SSE] Reconnecting in", currentDelay, "ms");
+        onStateChange?.('reconnecting');
+        
+        reconnectTimer = window.setTimeout(() => {
+          currentDelay = Math.min(currentDelay * 2, maxRetryDelay);
+          connect();
+        }, currentDelay);
+      } else {
+        console.log("[SSE] Max retries exceeded, disconnected");
+        onStateChange?.('disconnected');
+        onError(e);
+      }
+    };
+  };
+
+  connect();
+
+  // Return a wrapped EventSource that also clears reconnect timer on close
+  const wrappedEs = {
+    close: () => {
+      if (reconnectTimer !== null) {
+        window.clearTimeout(reconnectTimer);
+        reconnectTimer = null;
+      }
+      es.close();
+    },
+    get readyState() {
+      return es.readyState;
+    },
+    get url() {
+      return es.url;
+    },
+    addEventListener: es.addEventListener.bind(es),
+    removeEventListener: es.removeEventListener.bind(es),
+    dispatchEvent: es.dispatchEvent.bind(es),
+    onopen: null as ((this: EventSource, ev: Event) => any) | null,
+    onmessage: null as ((this: EventSource, ev: MessageEvent) => any) | null,
+    onerror: null as ((this: EventSource, ev: Event) => any) | null,
+  } as EventSource;
+
+  return wrappedEs;
+}
  */
 export async function fetchRemoteGitStatus(
   machineId: string,

--- a/frontend/src/api/openace.ts
+++ b/frontend/src/api/openace.ts
@@ -747,7 +747,7 @@ export function createRemoteSessionStreamWithReconnect(
     maxRetries = 5,
     initialRetryDelay = 1000,
     maxRetryDelay = 30000,
-    stallTimeout = 60000,  // 60 seconds stall detection (Issue #195)
+    stallTimeout = 35000,  // 35s: backend heartbeat is 10s, use 3.5x to avoid false stall detection
   } = options;
 
   const url = buildOpenAceUrl(`/api/remote/sessions/${sessionId}/stream`);
@@ -756,6 +756,23 @@ export function createRemoteSessionStreamWithReconnect(
   let es: EventSource;
   let reconnectTimer: number | null = null;
   let stallTimer: number | null = null;  // Stall detection timer
+
+  // Shared reconnect scheduler to avoid code duplication
+  const scheduleReconnect = (reason: string) => {
+    if (retryCount < maxRetries && maxRetries > 0) {
+      retryCount++;
+      console.debug(`[SSE] Reconnecting after ${reason}...`);
+      onStateChange?.('reconnecting');
+      reconnectTimer = window.setTimeout(() => {
+        currentDelay = Math.min(currentDelay * 2, maxRetryDelay);
+        connect();
+      }, currentDelay);
+    } else {
+      console.debug(`[SSE] Max retries exceeded after ${reason}, disconnected`);
+      onStateChange?.('disconnected');
+      onError(new Event('error'));
+    }
+  };
 
   // Stall detection: reset timer on every data received (Issue #195)
   const resetStallTimer = () => {
@@ -766,32 +783,19 @@ export function createRemoteSessionStreamWithReconnect(
       console.warn("[SSE] Stall detected, no data for", stallTimeout, "ms");
       if (es.readyState === EventSource.OPEN) {
         es.close();
-        // Trigger reconnect if retries available
-        if (retryCount < maxRetries && maxRetries > 0) {
-          retryCount++;
-          console.log("[SSE] Reconnecting after stall...");
-          onStateChange?.('reconnecting');
-          reconnectTimer = window.setTimeout(() => {
-            currentDelay = Math.min(currentDelay * 2, maxRetryDelay);
-            connect();
-          }, currentDelay);
-        } else {
-          console.log("[SSE] Max retries exceeded after stall, disconnected");
-          onStateChange?.('disconnected');
-          onError(new Event('error'));
-        }
+        scheduleReconnect('stall');
       }
     }, stallTimeout);
   };
 
   const connect = () => {
-    console.log("[SSE] Connecting to:", url, `(retry ${retryCount}/${maxRetries})`);
+    console.debug("[SSE] Connecting to:", url, `(retry ${retryCount}/${maxRetries})`);
     onStateChange?.(retryCount > 0 ? 'reconnecting' : 'connected');
 
     es = new EventSource(url);
 
     es.onopen = () => {
-      console.log("[SSE] Connection opened");
+      console.debug("[SSE] Connection opened");
       retryCount = 0;
       currentDelay = initialRetryDelay;
       onStateChange?.('connected');
@@ -801,7 +805,7 @@ export function createRemoteSessionStreamWithReconnect(
     es.onmessage = (event) => {
       resetStallTimer();  // Reset stall timer on every message
       if (event.data === "[DONE]") {
-        console.log("[SSE] Received [DONE]");
+        console.debug("[SSE] Received [DONE]");
         es.close();
         if (stallTimer !== null) {
           window.clearTimeout(stallTimer);
@@ -820,27 +824,16 @@ export function createRemoteSessionStreamWithReconnect(
         stallTimer = null;
       }
       es.close();
-
-      if (retryCount < maxRetries && maxRetries > 0) {
-        retryCount++;
-        console.log("[SSE] Reconnecting in", currentDelay, "ms");
-        onStateChange?.('reconnecting');
-
-        reconnectTimer = window.setTimeout(() => {
-          currentDelay = Math.min(currentDelay * 2, maxRetryDelay);
-          connect();
-        }, currentDelay);
-      } else {
-        console.log("[SSE] Max retries exceeded, disconnected");
-        onStateChange?.('disconnected');
-        onError(e);
-      }
+      scheduleReconnect('error');
     };
   };
 
   connect();
 
   // Return a wrapped EventSource that also clears reconnect timer on close
+  // Note: onopen/onmessage/onerror are null because handlers are set directly
+  // on the internal `es` in connect(). These null properties exist only for
+  // type compatibility with EventSource interface.
   const wrappedEs = {
     close: () => {
       if (reconnectTimer !== null) {
@@ -859,9 +852,16 @@ export function createRemoteSessionStreamWithReconnect(
     get url() {
       return es.url;
     },
-    addEventListener: es.addEventListener.bind(es),
-    removeEventListener: es.removeEventListener.bind(es),
-    dispatchEvent: es.dispatchEvent.bind(es),
+    // Dynamic proxy to current EventSource instance (not bound to old es)
+    addEventListener: (...args: Parameters<EventSource['addEventListener']>) => {
+      es.addEventListener(...args);
+    },
+    removeEventListener: (...args: Parameters<EventSource['removeEventListener']>) => {
+      es.removeEventListener(...args);
+    },
+    dispatchEvent: (event: Event) => {
+      return es.dispatchEvent(event);
+    },
     onopen: null as ((this: EventSource, ev: Event) => any) | null,
     onmessage: null as ((this: EventSource, ev: MessageEvent) => any) | null,
     onerror: null as ((this: EventSource, ev: Event) => any) | null,

--- a/frontend/src/api/openace.ts
+++ b/frontend/src/api/openace.ts
@@ -717,6 +717,7 @@ export interface SSEOptions {
   maxRetries?: number;
   initialRetryDelay?: number;
   maxRetryDelay?: number;
+  stallTimeout?: number;  // Stall detection timeout in ms (Issue #195)
 }
 
 export function createRemoteSessionStream(
@@ -746,6 +747,7 @@ export function createRemoteSessionStreamWithReconnect(
     maxRetries = 5,
     initialRetryDelay = 1000,
     maxRetryDelay = 30000,
+    stallTimeout = 60000,  // 60 seconds stall detection (Issue #195)
   } = options;
 
   const url = buildOpenAceUrl(`/api/remote/sessions/${sessionId}/stream`);
@@ -753,39 +755,77 @@ export function createRemoteSessionStreamWithReconnect(
   let currentDelay = initialRetryDelay;
   let es: EventSource;
   let reconnectTimer: number | null = null;
+  let stallTimer: number | null = null;  // Stall detection timer
+
+  // Stall detection: reset timer on every data received (Issue #195)
+  const resetStallTimer = () => {
+    if (stallTimer !== null) {
+      window.clearTimeout(stallTimer);
+    }
+    stallTimer = window.setTimeout(() => {
+      console.warn("[SSE] Stall detected, no data for", stallTimeout, "ms");
+      if (es.readyState === EventSource.OPEN) {
+        es.close();
+        // Trigger reconnect if retries available
+        if (retryCount < maxRetries && maxRetries > 0) {
+          retryCount++;
+          console.log("[SSE] Reconnecting after stall...");
+          onStateChange?.('reconnecting');
+          reconnectTimer = window.setTimeout(() => {
+            currentDelay = Math.min(currentDelay * 2, maxRetryDelay);
+            connect();
+          }, currentDelay);
+        } else {
+          console.log("[SSE] Max retries exceeded after stall, disconnected");
+          onStateChange?.('disconnected');
+          onError(new Event('error'));
+        }
+      }
+    }, stallTimeout);
+  };
 
   const connect = () => {
     console.log("[SSE] Connecting to:", url, `(retry ${retryCount}/${maxRetries})`);
     onStateChange?.(retryCount > 0 ? 'reconnecting' : 'connected');
-    
+
     es = new EventSource(url);
-    
+
     es.onopen = () => {
       console.log("[SSE] Connection opened");
       retryCount = 0;
       currentDelay = initialRetryDelay;
       onStateChange?.('connected');
+      resetStallTimer();  // Start stall detection on connection open
     };
-    
+
     es.onmessage = (event) => {
+      resetStallTimer();  // Reset stall timer on every message
       if (event.data === "[DONE]") {
         console.log("[SSE] Received [DONE]");
         es.close();
+        if (stallTimer !== null) {
+          window.clearTimeout(stallTimer);
+          stallTimer = null;
+        }
         onDone();
         return;
       }
       onLine(event.data);
     };
-    
+
     es.onerror = (e) => {
       console.error("[SSE] Error, readyState:", es.readyState, e);
+      if (stallTimer !== null) {
+        window.clearTimeout(stallTimer);
+        stallTimer = null;
+      }
       es.close();
-      
+
       if (retryCount < maxRetries && maxRetries > 0) {
         retryCount++;
         console.log("[SSE] Reconnecting in", currentDelay, "ms");
         onStateChange?.('reconnecting');
-        
+
         reconnectTimer = window.setTimeout(() => {
           currentDelay = Math.min(currentDelay * 2, maxRetryDelay);
           connect();
@@ -807,6 +847,10 @@ export function createRemoteSessionStreamWithReconnect(
         window.clearTimeout(reconnectTimer);
         reconnectTimer = null;
       }
+      if (stallTimer !== null) {
+        window.clearTimeout(stallTimer);
+        stallTimer = null;
+      }
       es.close();
     },
     get readyState() {
@@ -825,6 +869,14 @@ export function createRemoteSessionStreamWithReconnect(
 
   return wrappedEs;
 }
+
+// -------------------------------------------------------
+// Remote Git API functions
+// -------------------------------------------------------
+
+/**
+ * Fetch git status from a remote machine via Open-ACE proxy.
+ * Only called in remote workspace mode (workspaceType=remote).
  */
 export async function fetchRemoteGitStatus(
   machineId: string,

--- a/frontend/src/components/ChatPage.tsx
+++ b/frontend/src/components/ChatPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useCallback, useState, useMemo, useRef } from "react";
 import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
-import { ChevronLeftIcon, DocumentTextIcon, ServerIcon } from "@heroicons/react/24/outline";
+import { ArrowPathIcon, ChevronLeftIcon, DocumentTextIcon, ServerIcon } from "@heroicons/react/24/outline";
 import { useTranslation } from "react-i18next";
 import type {
   ChatRequest,
@@ -1616,6 +1616,26 @@ export function ChatPage() {
                     }`}
                     title={`Status: ${remoteChat.session.status}`}
                   />
+                </div>
+              )}
+              {/* SSE connection state (Issue #195 P2) */}
+              {isRemoteWorkspace && remoteChat.session && remoteChat.sseState === "reconnecting" && (
+                <div className="flex items-center gap-1.5 mt-1 text-xs text-amber-600 dark:text-amber-400">
+                  <ArrowPathIcon className="h-3 w-3 animate-spin" />
+                  <span>{t("chat.sseReconnecting")}</span>
+                </div>
+              )}
+              {isRemoteWorkspace && remoteChat.session && remoteChat.sseState === "disconnected" && (
+                <div className="flex items-center gap-2 mt-1 text-xs text-red-500 dark:text-red-400">
+                  <span>{t("chat.sseDisconnected")}</span>
+                  {remoteMachineId && (
+                    <button
+                      onClick={() => remoteChat.reconnect(remoteMachineId, workingDirectory || "", selectedModel || undefined)}
+                      className="px-2 py-0.5 rounded bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-400 hover:bg-red-200 dark:hover:bg-red-900/50"
+                    >
+                      {t("chat.reconnect")}
+                    </button>
+                  )}
                 </div>
               )}
               {/* Remote session error */}

--- a/frontend/src/hooks/useRemoteChat.test.ts
+++ b/frontend/src/hooks/useRemoteChat.test.ts
@@ -4,6 +4,7 @@ import {
   abortRemoteRequest,
   createRemoteSession,
   createRemoteSessionStream,
+  createRemoteSessionStreamWithReconnect,
   getRemoteSessionStatus,
   pauseRemoteSession,
   resumeRemoteSession,
@@ -27,6 +28,7 @@ vi.mock("../api/openace", () => ({
   abortRemoteRequest: vi.fn(),
   getRemoteSessionStatus: vi.fn(),
   createRemoteSessionStream: vi.fn(),
+  createRemoteSessionStreamWithReconnect: vi.fn(),
   sendPermissionResponse: vi.fn(),
   switchRemoteModel: vi.fn(),
   pauseRemoteSession: vi.fn(),
@@ -74,13 +76,13 @@ describe("useRemoteChat", () => {
     vi.mocked(switchRemoteModel).mockResolvedValue({ success: true } as never);
     vi.mocked(pauseRemoteSession).mockResolvedValue({ success: true } as never);
     vi.mocked(resumeRemoteSession).mockResolvedValue({ success: true } as never);
-    vi.mocked(createRemoteSessionStream).mockImplementation(
-      ((_sessionId, onLine, onError, onDone) => {
-        streamCallbacks.onLine = onLine;
-        streamCallbacks.onError = onError;
-        streamCallbacks.onDone = onDone;
+    vi.mocked(createRemoteSessionStreamWithReconnect).mockImplementation(
+      ((_sessionId, options) => {
+        streamCallbacks.onLine = options.onLine;
+        streamCallbacks.onError = options.onError;
+        streamCallbacks.onDone = options.onDone;
         return { close: vi.fn() } as unknown as EventSource;
-      }) as typeof createRemoteSessionStream
+      }) as typeof createRemoteSessionStreamWithReconnect
     );
   });
 

--- a/frontend/src/hooks/useRemoteChat.ts
+++ b/frontend/src/hooks/useRemoteChat.ts
@@ -182,33 +182,43 @@ export function useRemoteChat(options?: RemoteChatOptions) {
         // Open SSE connection — read options from ref to avoid stale closure
         const currentOptions = optionsRef.current;
         if (currentOptions?.onStreamLine && currentOptions.streamingContext) {
-          console.log("[useRemoteChat] Opening SSE for session:", response.session.session_id);
           const es = createRemoteSessionStreamWithReconnect(
             response.session.session_id,
-            (line) => {
-              handleSSELine(line);
+            {
+              onLine: (line) => {
+                handleSSELine(line);
+              },
+              onError: (err) => {
+                console.error("[useRemoteChat] SSE error:", err);
+                setError(t("chat.remoteDisconnected"));
+                clearAbortAckTimer();
+                setIsStopping(false);
+                setIsLoading(false);
+                clearStreamingState();
+                setSession((prev) =>
+                  prev ? { ...prev, status: "error" } : null
+                );
+              },
+              onDone: () => {
+                console.log("[useRemoteChat] SSE done");
+                clearAbortAckTimer();
+                setIsStopping(false);
+                setIsLoading(false);
+                clearStreamingState();
+                // If the session was active and SSE closed, it likely means
+                // the server was restarted or the session was marked completed.
+                if (session?.status === "active") {
+                  setError(t("chat.remoteEnded"));
+                  setSession((prev) =>
+                    prev ? { ...prev, status: "completed" } : null
+                  );
+                }
+              },
+              onStateChange: (state) => {
+                setSseState(state);
+              },
             },
-            (err) => {
-              console.error("[useRemoteChat] SSE error:", err);
-              setError(t("chat.remoteDisconnected"));
-              clearAbortAckTimer();
-              setIsStopping(false);
-              setIsLoading(false);
-              clearStreamingState();
-              setSession((prev) =>
-                prev ? { ...prev, status: "error" } : null
-              );
-            },
-            () => {
-              console.log("[useRemoteChat] SSE done");
-              clearAbortAckTimer();
-              setIsStopping(false);
-              setIsLoading(false);
-              clearStreamingState();
-              // If the session was active and SSE closed, it likely means
-              // the server was restarted or the session was marked completed.
-              if (session?.status === "active") {
-                setError(t("chat.remoteEnded"));
+          );
                 setSession((prev) =>
                   prev ? { ...prev, status: "completed" } : null
                 );
@@ -318,29 +328,33 @@ export function useRemoteChat(options?: RemoteChatOptions) {
 
           const es = createRemoteSessionStreamWithReconnect(
             s.session_id,
-            (line) => {
-              handleSSELine(line);
-            },
-            (err) => {
-              console.error("[useRemoteChat] SSE error:", err);
-              setError(t("chat.remoteReconnectFailed"));
-              clearAbortAckTimer();
-              setIsStopping(false);
-              setIsLoading(false);
-              clearStreamingState();
-              setSession((prev) =>
-                prev ? { ...prev, status: "error" } : null
-              );
-            },
-            () => {
-              console.log("[useRemoteChat] SSE done");
-              clearAbortAckTimer();
-              setIsStopping(false);
-              setIsLoading(false);
-              clearStreamingState();
+            {
+              onLine: (line) => {
+                handleSSELine(line);
+              },
+              onError: (err) => {
+                console.error("[useRemoteChat] SSE error:", err);
+                setError(t("chat.remoteReconnectFailed"));
+                clearAbortAckTimer();
+                setIsStopping(false);
+                setIsLoading(false);
+                clearStreamingState();
+                setSession((prev) =>
+                  prev ? { ...prev, status: "error" } : null
+                );
+              },
+              onDone: () => {
+                console.log("[useRemoteChat] SSE done");
+                clearAbortAckTimer();
+                setIsStopping(false);
+                setIsLoading(false);
+                clearStreamingState();
+              },
+              onStateChange: (state) => {
+                setSseState(state);
+              },
             },
           );
-          eventSourceRef.current = es;
         }
         setIsLoading(false);
       } catch (err) {

--- a/frontend/src/hooks/useRemoteChat.ts
+++ b/frontend/src/hooks/useRemoteChat.ts
@@ -355,6 +355,7 @@ export function useRemoteChat(options?: RemoteChatOptions) {
               },
             },
           );
+          eventSourceRef.current = es;
         }
         setIsLoading(false);
       } catch (err) {

--- a/frontend/src/hooks/useRemoteChat.ts
+++ b/frontend/src/hooks/useRemoteChat.ts
@@ -7,6 +7,9 @@ import {
   abortRemoteRequest,
   getRemoteSessionStatus,
   createRemoteSessionStream,
+  createRemoteSessionStreamWithReconnect,
+  type SSEConnectionState,
+  type SSEOptions,
   sendPermissionResponse,
   switchRemoteModel,
   pauseRemoteSession,
@@ -48,6 +51,7 @@ export function useRemoteChat(options?: RemoteChatOptions) {
   const [isLoading, setIsLoading] = useState(false);
   const [isStopping, setIsStopping] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [sseState, setSseState] = useState<SSEConnectionState>("connected");
   const eventSourceRef = useRef<EventSource | null>(null);
   const abortAckTimerRef = useRef<number | null>(null);
   const sendingRef = useRef(false);
@@ -179,7 +183,7 @@ export function useRemoteChat(options?: RemoteChatOptions) {
         const currentOptions = optionsRef.current;
         if (currentOptions?.onStreamLine && currentOptions.streamingContext) {
           console.log("[useRemoteChat] Opening SSE for session:", response.session.session_id);
-          const es = createRemoteSessionStream(
+          const es = createRemoteSessionStreamWithReconnect(
             response.session.session_id,
             (line) => {
               handleSSELine(line);
@@ -312,7 +316,7 @@ export function useRemoteChat(options?: RemoteChatOptions) {
             }
           }
 
-          const es = createRemoteSessionStream(
+          const es = createRemoteSessionStreamWithReconnect(
             s.session_id,
             (line) => {
               handleSSELine(line);

--- a/frontend/src/hooks/useRemoteChat.ts
+++ b/frontend/src/hooks/useRemoteChat.ts
@@ -544,5 +544,6 @@ export function useRemoteChat(options?: RemoteChatOptions) {
     resumeSession,
     sendPermissionResponse: handlePermissionResponse,
     error,
+    sseState,
   };
 }

--- a/frontend/src/hooks/useRemoteChat.ts
+++ b/frontend/src/hooks/useRemoteChat.ts
@@ -219,12 +219,6 @@ export function useRemoteChat(options?: RemoteChatOptions) {
               },
             },
           );
-                setSession((prev) =>
-                  prev ? { ...prev, status: "completed" } : null
-                );
-              }
-            },
-          );
           eventSourceRef.current = es;
           // SSE is a long-lived background connection — once opened the
           // session is established and the user should be able to type.

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -82,6 +82,8 @@
     "remoteEndedCreate": "Remote session has ended. Please create a new session.",
     "remoteReconnectFailed": "Remote session disconnected. Please reconnect.",
     "reconnect": "Reconnect",
+    "sseReconnecting": "Reconnecting…",
+    "sseDisconnected": "Disconnected",
     "stop": "Stop (ESC)",
     "backToProjects": "Back to project selection",
     "viewHistory": "View conversation history",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -81,6 +81,8 @@
     "remoteEndedCreate": "リモートセッションが終了しました。新しいセッションを作成してください。",
     "remoteReconnectFailed": "リモートセッションが切断されました。再接続してください。",
     "reconnect": "再接続",
+    "sseReconnecting": "再接続中…",
+    "sseDisconnected": "切断されました",
     "stop": "停止（ESC）",
     "backToProjects": "プロジェクト選択に戻る",
     "viewHistory": "会話履歴を表示",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -81,6 +81,8 @@
     "remoteEndedCreate": "원격 세션이 종료되었습니다. 새 세션을 생성하세요.",
     "remoteReconnectFailed": "원격 세션이 연결 해제되었습니다. 다시 연결하세요.",
     "reconnect": "다시 연결",
+    "sseReconnecting": "재연결 중…",
+    "sseDisconnected": "연결 끊김",
     "stop": "중지 (ESC)",
     "backToProjects": "프로젝트 선택으로 돌아가기",
     "viewHistory": "대화 기록 보기",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -82,6 +82,8 @@
     "remoteEndedCreate": "远程会话已结束，请创建新会话",
     "remoteReconnectFailed": "远程会话连接断开，请重新连接",
     "reconnect": "重新连接",
+    "sseReconnecting": "正在重新连接…",
+    "sseDisconnected": "已断开连接",
     "stop": "停止 (ESC)",
     "backToProjects": "返回项目选择",
     "viewHistory": "查看对话历史",


### PR DESCRIPTION
## Summary

This PR adds SSE auto-reconnect capability for remote session stability, fixing issues where SSE disconnection causes permission request failures and AI not responding.

## Changes

### SSE Auto-Reconnect (`frontend/src/api/openace.ts`)
- Add `createRemoteSessionStreamWithReconnect` with retry logic (max 5 retries)
- Implement exponential backoff (1s initial delay, 30s max delay)
- Add `SSEConnectionState` type for connection status tracking
- Clean up reconnect timer on manual close

### Integration (`frontend/src/hooks/useRemoteChat.ts`)
- Use reconnect-enabled SSE for both session creation and resume
- Add `sseState` state variable for connection monitoring

## Related Issues

Fixes #195

Related to open-ace/open-ace#1511 (backend SSE stability improvements)