### PR TITLE
fix: prevent white flash (FOUC) in dark theme iframe loading

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,24 +6,39 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no" />
     <title>Qwen Code Web UI</title>
     <script>
-      // Prevent flash of unstyled content by setting theme class early
+      // Prevent flash of unstyled content (FOUC) by setting theme class and
+      // background color before any rendering occurs.
       (function () {
         const storedTheme = localStorage.getItem("qwen-code-webui-theme");
         let theme = null;
         try {
           theme = storedTheme ? JSON.parse(storedTheme) : null;
         } catch {
-          // If parsing fails, fall back to null
           theme = null;
         }
-        
-        if (
+
+        // Check URL parameter for theme override (for iframe/embedded mode)
+        const urlParams = new URLSearchParams(window.location.search);
+        const themeParam = urlParams.get("theme");
+        if (themeParam === "dark" || themeParam === "light") {
+          theme = themeParam;
+        }
+
+        const isDark =
           theme === "dark" ||
-          (!theme && window.matchMedia("(prefers-color-scheme: dark)").matches)
-        ) {
-          document.documentElement.classList.add("dark");
+          (!theme && window.matchMedia("(prefers-color-scheme: dark)").matches);
+
+        const root = document.documentElement;
+        if (isDark) {
+          root.classList.add("dark");
+          // Set background color immediately to prevent white flash.
+          // This inline style will be overridden by Tailwind CSS once loaded.
+          root.style.backgroundColor = "#0f172a";
+          root.style.colorScheme = "dark";
         } else {
-          document.documentElement.classList.remove("dark");
+          root.classList.remove("dark");
+          root.style.backgroundColor = "#ffffff";
+          root.style.colorScheme = "light";
         }
       })();
     </script>


### PR DESCRIPTION
## Problem

In dark theme, when creating a new session via open-ace workspace (click +, select Local Workspace, click Create), the webui iframe shows a white flash before displaying the correct dark background. The same white flash occurs when refreshing the page.

## Root Cause

1. **`index.html` did not check URL parameter `theme`**: open-ace passes `?theme=dark` when creating iframe, but the inline script only checked localStorage
2. **`<html>` element had no background-color**: Before Tailwind CSS loaded, the page showed browser default white background

## Solution

1. Add URL parameter `theme` check in `index.html` inline script
2. Set `backgroundColor` inline style immediately to prevent white flash before CSS loads
3. Set `colorScheme` property for proper browser color scheme handling
4. Replace `bg-white` with `bg-slate-50` in Modal components to avoid conflicts with webui CSS `.bg-white` class

## Changes

- `frontend/index.html` - Add URL parameter handling + background color inline style
- `frontend/src/components/AddProjectModal.tsx` - `bg-white` → `bg-slate-50`
- `frontend/src/components/ConfirmModal.tsx` - `bg-white` → `bg-slate-50`
- `frontend/src/components/DirectoryBrowser.tsx` - `bg-white` → `bg-slate-50`
- `frontend/src/components/SettingsModal.tsx` - `bg-white` → `bg-slate-50`

Closes #199