### PR TITLE
chore: bump version to 0.2.37

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qwen-code-webui",
-  "version": "0.2.36",
+  "version": "0.2.37",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qwen-code-webui",
-      "version": "0.2.36",
+      "version": "0.2.37",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.11",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qwen-code-webui",
-  "version": "0.2.36",
+  "version": "0.2.37",
   "type": "module",
   "description": "Web-based interface for the Qwen Code CLI with streaming chat interface",
   "keywords": [


### PR DESCRIPTION
Syncs the repo's `package.json`/`package-lock.json` to 0.2.37. The npm package was already published: https://www.npmjs.com/package/qwen-code-webui/v/0.2.37

Includes the dark-theme readability fix (#198) in the shipped frontend bundle.

Landed via PR because `main` is GH013-protected (direct pushes rejected).