### PR TITLE
chore: bump version to 0.2.38

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qwen-code-webui",
-  "version": "0.2.37",
+  "version": "0.2.38",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qwen-code-webui",
-      "version": "0.2.37",
+      "version": "0.2.38",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.11",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qwen-code-webui",
-  "version": "0.2.37",
+  "version": "0.2.38",
   "type": "module",
   "description": "Web-based interface for the Qwen Code CLI with streaming chat interface",
   "keywords": [


### PR DESCRIPTION
Syncs the repo's `package.json` version to match `qwen-code-webui@0.2.38`, which is already published to npm.

Includes the `ws` security bump (8.20.1 → 8.21.0, #202) and the frontend build fix (#203) landed since 0.2.37.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)