### PR TITLE
fix(frontend): make `typecheck` actually type-check (tsc -b --noEmit)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,7 @@
     "lint": "eslint .",
     "format": "prettier --write src/ scripts/",
     "format:check": "prettier --check src/ scripts/",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc -b --noEmit",
     "preview": "vite preview",
     "test": "vitest",
     "test:run": "vitest run",


### PR DESCRIPTION
## Problem

The frontend `typecheck` script checks **nothing**. It's `tsc --noEmit`, but the root `tsconfig.json` has `"files": []` + project references and no `--build` flag — so `tsc` never compiles the referenced projects and exits 0 regardless of errors.

CI (`test.yml:47`) runs `npm run typecheck` as the type gate, so it stayed green while real TS errors landed on `main`. They only surfaced later when `npm run build` (`tsc -b && vite build`) ran during **/npm-publish** — which is exactly how 0.2.38 got blocked (see #203).

## Fix

```diff
- "typecheck": "tsc --noEmit"
+ "typecheck": "tsc -b --noEmit"
```

`--build` makes tsc compile the referenced projects (`tsconfig.app.json` / `tsconfig.node.json`); `--noEmit` keeps it type-check-only (TS 5.8 supports `--build --noEmit`; each project already sets `noEmit`, so nothing is emitted). This now matches the type-checking portion of `build`.

## Verification (empirical)

A deliberate type error (`const x: number = "not-a-number";`) was placed in a throwaway probe file:

| Command | Sees the error? | Exit |
|---|---|---|
| old `tsc --noEmit` | ❌ no | 0 |
| new `tsc -b --noEmit` | ✅ yes (`error TS2322`) | **2** |
| new `tsc -b --noEmit` on clean tree | — | 0 |

So CI's exit-code-based gate will now fail on real type errors.

## Self-validating

This PR is the first where CI's `npm run typecheck` step actually type-checks `src/`. If CI is green here, the fix works end-to end.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)