### PR TITLE
fix: 支持 v2 格式 token 验证（带 TTL）

### DIFF
--- a/backend/middleware/tokenAuth.ts
+++ b/backend/middleware/tokenAuth.ts
@@ -35,17 +35,79 @@ async function sha256Hex(data: string): Promise<string> {
 }
 
 /**
- * Validates a token against the expected signature
+ * Validates a v2 format token with TTL support
  *
- * @param token Token string to validate
+ * @param token Token string to validate (v2:{user_id}:{port}:{timestamp}:{random}:{signature})
  * @param secret Secret key for signature verification
  * @returns True if token is valid, false otherwise
  */
-async function validateToken(token: string, secret: string): Promise<boolean> {
+async function validateTokenV2(token: string, secret: string): Promise<boolean> {
+  try {
+    const parts = token.split(":");
+    if (parts.length !== 6) {
+      logger.app.warn("Invalid v2 token format: expected 6 parts");
+      return false;
+    }
+
+    const [version, userId, port, timestamp, randomPart, signature] = parts;
+
+    if (version !== "v2") {
+      logger.app.warn("Invalid v2 token: wrong version prefix");
+      return false;
+    }
+
+    // Check TTL (30 minutes = 1800 seconds)
+    const TTL_SECONDS = 1800;
+    const tokenTime = parseInt(timestamp, 10);
+    const currentTime = Math.floor(Date.now() / 1000);
+    const ageSeconds = currentTime - tokenTime;
+
+    if (ageSeconds > TTL_SECONDS) {
+      logger.app.warn("v2 token expired: age {age}s, TTL: {ttl}s", {
+        age: ageSeconds,
+        ttl: TTL_SECONDS,
+      });
+      return false;
+    }
+
+    if (ageSeconds < 0) {
+      logger.app.warn("v2 token timestamp is in the future");
+      return false;
+    }
+
+    // Verify signature
+    const payload = `v2:${userId}:${port}:${timestamp}:${randomPart}`;
+    const dataToSign = `${payload}:${secret}`;
+    const hexHash = await sha256Hex(dataToSign);
+    const expectedSignature = hexHash.slice(0, 16);
+
+    if (signature !== expectedSignature) {
+      logger.app.warn("v2 token signature mismatch");
+      return false;
+    }
+
+    logger.app.debug("v2 token validated successfully for user {userId}", {
+      userId,
+    });
+    return true;
+  } catch (error) {
+    logger.app.error("v2 token validation error: {error}", { error });
+    return false;
+  }
+}
+
+/**
+ * Validates a v1 format token (legacy, no TTL)
+ *
+ * @param token Token string to validate ({user_id}:{port}:{random}:{signature})
+ * @param secret Secret key for signature verification
+ * @returns True if token is valid, false otherwise
+ */
+async function validateTokenV1(token: string, secret: string): Promise<boolean> {
   try {
     const parts = token.split(":");
     if (parts.length !== 4) {
-      logger.app.warn("Invalid token format: expected 4 parts");
+      logger.app.warn("Invalid v1 token format: expected 4 parts");
       return false;
     }
 
@@ -57,18 +119,36 @@ async function validateToken(token: string, secret: string): Promise<boolean> {
     const expectedSignature = hexHash.slice(0, 16);
 
     if (signature !== expectedSignature) {
-      logger.app.warn("Token signature mismatch");
+      logger.app.warn("v1 token signature mismatch");
       return false;
     }
 
-    logger.app.debug("Token validated successfully for user {userId}", {
+    logger.app.debug("v1 token validated successfully for user {userId}", {
       userId,
     });
     return true;
   } catch (error) {
-    logger.app.error("Token validation error: {error}", { error });
+    logger.app.error("v1 token validation error: {error}", { error });
     return false;
   }
+}
+
+/**
+ * Validates a token against the expected signature
+ * Supports both v1 (legacy) and v2 (with TTL) formats
+ *
+ * @param token Token string to validate
+ * @param secret Secret key for signature verification
+ * @returns True if token is valid, false otherwise
+ */
+async function validateToken(token: string, secret: string): Promise<boolean> {
+  // v2 format: v2:{user_id}:{port}:{timestamp}:{random}:{signature}
+  if (token.startsWith("v2:")) {
+    return validateTokenV2(token, secret);
+  }
+
+  // v1 format: {user_id}:{port}:{random}:{signature}
+  return validateTokenV1(token, secret);
 }
 
 /**


### PR DESCRIPTION
## 问题描述

修复 open-ace/open-ace#2012

在 Open-ACE 工作区新建本地会话时，页面提示：
> 加载对话失败 Failed to load conversation: 401 Unauthorized

## 问题根因

**Open-ACE 和 qwen-code-webui 的 token 格式不匹配**：

1. **Open-ACE 在 Issue #1896 中升级了 token 格式到 v2**：
   - 格式：`v2:{user_id}:{port}:{timestamp}:{random}:{signature}`（6部分）
   - 包含 timestamp 用于 TTL（30分钟过期）

2. **但 qwen-code-webui 的 token 验证中间件只支持 v1 格式**：
   - 格式：`{user_id}:{port}:{random}:{signature}`（4部分）
   - 会拒绝 v2 格式 token，返回 401 Unauthorized

### 代码位置

- **Open-ACE 生成 v2 token**：
  ```python
  # app/services/webui_manager.py:444-466
  def generate_token(self, user_id: int, port: int) -> str:
      timestamp = int(time.time())
      random_part = secrets.token_hex(8)
      payload = f"v2:{user_id}:{port}:{timestamp}:{random_part}"
      signature = hashlib.sha256(f"{payload}:{self.config.token_secret}".encode()).hexdigest()[:16]
      return f"{payload}:{signature}"
  ```

- **qwen-code-webui 验证 token（仅支持 v1）**：
  ```typescript
  // backend/middleware/tokenAuth.ts:47-49
  const parts = token.split(":");
  if (parts.length !== 4) {  // ← 拒绝 v2 token（v2 有 6 部分）
    logger.app.warn("Invalid token format: expected 4 parts");
    return false;
  }
  ```

## 影响范围

所有在 Open-ACE 升级后（2026-07-23 之后）**新建本地会话**的用户都会遇到此问题。

## 解决方案

修改 `qwen-code-webui` 的 token 验证逻辑，使其同时支持 v1 和 v2 格式：

1. 新增 `validateTokenV2()` 函数：验证 v2 格式 token，包含 TTL 检查
2. 新增 `validateTokenV1()` 函数：验证 v1 格式 token（向后兼容）
3. 修改 `validateToken()` 函数：根据 token 前缀自动选择验证方法

## 测试

- v1 格式 token 验证通过
- v2 格式 token 验证通过
- v2 token TTL 过期检查正常

## 相关链接

- Open-ACE Issue: https://github.com/open-ace/open-ace/issues/2012
- qwen-code-webui 仓库：https://github.com/ivycomputing/qwen-code-webui