### PR TITLE
feat: add v2 token format support with TTL validation

### DIFF
--- a/backend/middleware/tokenAuth.test.ts
+++ b/backend/middleware/tokenAuth.test.ts
@@ -303,4 +303,29 @@ describe("createTokenAuthMiddleware", () => {
     expect(res.status).toBe(401);
     expect(await res.text()).toContain("Invalid token");
   });
+
+  it("should reject v2 token with future timestamp", async () => {
+    const secret = "test-secret-key";
+    const userId = 1;
+    const port = 3101;
+    // Timestamp 1 hour in the future
+    const timestamp = Math.floor(Date.now() / 1000) + 3600;
+    const randomPart = "abc123def456";
+
+    const futureToken = await generateTokenV2(
+      userId,
+      port,
+      timestamp,
+      randomPart,
+      secret
+    );
+
+    const app = new Hono();
+    app.use("*", createTokenAuthMiddleware(secret));
+    app.get("/test", (c) => c.text("OK"));
+
+    const res = await app.request(`/test?token=${futureToken}`);
+    expect(res.status).toBe(401);
+    expect(await res.text()).toContain("Invalid token");
+  });
 });

--- a/backend/middleware/tokenAuth.test.ts
+++ b/backend/middleware/tokenAuth.test.ts
@@ -6,9 +6,14 @@ import { describe, it, expect } from "vitest";
 import { Hono } from "hono";
 import { createTokenAuthMiddleware } from "./tokenAuth.ts";
 
-// Helper to generate token with same algorithm as Open-ACE (async for Node.js compatibility)
-async function generateToken(userId: number, port: number, randomPart: string, secret: string): Promise<string> {
-  // SHA256({userId}:{port}:{randomPart}:{secret}).hexdigest()[:16]
+// Helper to generate v1 token (legacy format)
+// SHA256({userId}:{port}:{randomPart}:{secret}).hexdigest()[:16]
+async function generateTokenV1(
+  userId: number,
+  port: number,
+  randomPart: string,
+  secret: string
+): Promise<string> {
   const dataToSign = `${userId}:${port}:${randomPart}:${secret}`;
   const encoder = new TextEncoder();
   const dataBuffer = encoder.encode(dataToSign);
@@ -19,6 +24,28 @@ async function generateToken(userId: number, port: number, randomPart: string, s
     .join("");
   const signature = hexHash.slice(0, 16);
   return `${userId}:${port}:${randomPart}:${signature}`;
+}
+
+// Helper to generate v2 token (with TTL)
+// SHA256(v2:{userId}:{port}:{timestamp}:{randomPart}:{secret}).hexdigest()[:16]
+async function generateTokenV2(
+  userId: number,
+  port: number,
+  timestamp: number,
+  randomPart: string,
+  secret: string
+): Promise<string> {
+  const payload = `v2:${userId}:${port}:${timestamp}:${randomPart}`;
+  const dataToSign = `${payload}:${secret}`;
+  const encoder = new TextEncoder();
+  const dataBuffer = encoder.encode(dataToSign);
+  const hashBuffer = await crypto.subtle.digest("SHA-256", dataBuffer);
+  const hashArray = new Uint8Array(hashBuffer);
+  const hexHash = Array.from(hashArray)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+  const signature = hexHash.slice(0, 16);
+  return `${payload}:${signature}`;
 }
 
 describe("createTokenAuthMiddleware", () => {
@@ -76,13 +103,13 @@ describe("createTokenAuthMiddleware", () => {
     expect(await res.text()).toContain("Invalid token");
   });
 
-  it("should accept request with valid token", async () => {
+  it("should accept request with valid v1 token", async () => {
     const secret = "test-secret-key";
     const userId = 1;
     const port = 3101;
     const randomPart = "abc123def456";
 
-    const validToken = await generateToken(userId, port, randomPart, secret);
+    const validToken = await generateTokenV1(userId, port, randomPart, secret);
 
     const app = new Hono();
     app.use("*", createTokenAuthMiddleware(secret));
@@ -93,13 +120,87 @@ describe("createTokenAuthMiddleware", () => {
     expect(await res.text()).toBe("OK");
   });
 
-  it("should accept request with valid token containing special characters", async () => {
+  it("should accept request with valid v2 token", async () => {
+    const secret = "test-secret-key";
+    const userId = 1;
+    const port = 3101;
+    const timestamp = Math.floor(Date.now() / 1000); // Current timestamp
+    const randomPart = "abc123def456";
+
+    const validToken = await generateTokenV2(
+      userId,
+      port,
+      timestamp,
+      randomPart,
+      secret
+    );
+
+    const app = new Hono();
+    app.use("*", createTokenAuthMiddleware(secret));
+    app.get("/test", (c) => c.text("OK"));
+
+    const res = await app.request(`/test?token=${validToken}`);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("OK");
+  });
+
+  it("should reject expired v2 token", async () => {
+    const secret = "test-secret-key";
+    const userId = 1;
+    const port = 3101;
+    // Timestamp 40 minutes ago (TTL is 30 minutes)
+    const timestamp = Math.floor(Date.now() / 1000) - 2400;
+    const randomPart = "abc123def456";
+
+    const expiredToken = await generateTokenV2(
+      userId,
+      port,
+      timestamp,
+      randomPart,
+      secret
+    );
+
+    const app = new Hono();
+    app.use("*", createTokenAuthMiddleware(secret));
+    app.get("/test", (c) => c.text("OK"));
+
+    const res = await app.request(`/test?token=${expiredToken}`);
+    expect(res.status).toBe(401);
+    expect(await res.text()).toContain("Invalid token");
+  });
+
+  it("should accept v2 token near expiry boundary", async () => {
+    const secret = "test-secret-key";
+    const userId = 1;
+    const port = 3101;
+    // Timestamp 29 minutes ago (within 30 minute TTL)
+    const timestamp = Math.floor(Date.now() / 1000) - 29 * 60;
+    const randomPart = "abc123def456";
+
+    const validToken = await generateTokenV2(
+      userId,
+      port,
+      timestamp,
+      randomPart,
+      secret
+    );
+
+    const app = new Hono();
+    app.use("*", createTokenAuthMiddleware(secret));
+    app.get("/test", (c) => c.text("OK"));
+
+    const res = await app.request(`/test?token=${validToken}`);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("OK");
+  });
+
+  it("should accept request with valid v1 token containing special characters", async () => {
     const secret = "test-secret-with-special!@#$";
     const userId = 42;
     const port = 9000;
     const randomPart = "a1b2c3d4e5f6";
 
-    const validToken = await generateToken(userId, port, randomPart, secret);
+    const validToken = await generateTokenV1(userId, port, randomPart, secret);
 
     const app = new Hono();
     app.use("*", createTokenAuthMiddleware(secret));
@@ -110,7 +211,31 @@ describe("createTokenAuthMiddleware", () => {
     expect(await res.text()).toBe("OK");
   });
 
-  it("should reject token generated with different secret", async () => {
+  it("should accept request with valid v2 token containing special characters", async () => {
+    const secret = "test-secret-with-special!@#$";
+    const userId = 42;
+    const port = 9000;
+    const timestamp = Math.floor(Date.now() / 1000);
+    const randomPart = "a1b2c3d4e5f6";
+
+    const validToken = await generateTokenV2(
+      userId,
+      port,
+      timestamp,
+      randomPart,
+      secret
+    );
+
+    const app = new Hono();
+    app.use("*", createTokenAuthMiddleware(secret));
+    app.get("/test", (c) => c.text("OK"));
+
+    const res = await app.request(`/test?token=${encodeURIComponent(validToken)}`);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("OK");
+  });
+
+  it("should reject v1 token generated with different secret", async () => {
     const correctSecret = "correct-secret";
     const wrongSecret = "wrong-secret";
     const userId = 1;
@@ -118,13 +243,63 @@ describe("createTokenAuthMiddleware", () => {
     const randomPart = "abc123";
 
     // Generate token with wrong secret
-    const invalidToken = await generateToken(userId, port, randomPart, wrongSecret);
+    const invalidToken = await generateTokenV1(userId, port, randomPart, wrongSecret);
 
     const app = new Hono();
     app.use("*", createTokenAuthMiddleware(correctSecret));
     app.get("/test", (c) => c.text("OK"));
 
     const res = await app.request(`/test?token=${invalidToken}`);
+    expect(res.status).toBe(401);
+    expect(await res.text()).toContain("Invalid token");
+  });
+
+  it("should reject v2 token generated with different secret", async () => {
+    const correctSecret = "correct-secret";
+    const wrongSecret = "wrong-secret";
+    const userId = 1;
+    const port = 3101;
+    const timestamp = Math.floor(Date.now() / 1000);
+    const randomPart = "abc123";
+
+    // Generate token with wrong secret
+    const invalidToken = await generateTokenV2(
+      userId,
+      port,
+      timestamp,
+      randomPart,
+      wrongSecret
+    );
+
+    const app = new Hono();
+    app.use("*", createTokenAuthMiddleware(correctSecret));
+    app.get("/test", (c) => c.text("OK"));
+
+    const res = await app.request(`/test?token=${invalidToken}`);
+    expect(res.status).toBe(401);
+    expect(await res.text()).toContain("Invalid token");
+  });
+
+  it("should reject v2 token with invalid format (wrong part count)", async () => {
+    const secret = "test-secret-key";
+    const app = new Hono();
+    app.use("*", createTokenAuthMiddleware(secret));
+    app.get("/test", (c) => c.text("OK"));
+
+    // v2 token with only 5 parts (should be 6)
+    const res = await app.request("/test?token=v2:1:3101:1234567890:abc123");
+    expect(res.status).toBe(401);
+    expect(await res.text()).toContain("Invalid token");
+  });
+
+  it("should reject v2 token with invalid timestamp", async () => {
+    const secret = "test-secret-key";
+    const app = new Hono();
+    app.use("*", createTokenAuthMiddleware(secret));
+    app.get("/test", (c) => c.text("OK"));
+
+    // v2 token with non-numeric timestamp
+    const res = await app.request("/test?token=v2:1:3101:notatimestamp:abc123:somesig");
     expect(res.status).toBe(401);
     expect(await res.text()).toContain("Invalid token");
   });

--- a/backend/middleware/tokenAuth.ts
+++ b/backend/middleware/tokenAuth.ts
@@ -78,9 +78,17 @@ async function validateTokenV2(
     return { valid: false };
   }
 
-  // Check TTL (token expiration)
+  // Check timestamp validity (TTL and future timestamp)
   const currentTimestamp = Math.floor(Date.now() / 1000);
   const tokenAge = currentTimestamp - timestampNum;
+
+  // Reject tokens with future timestamp (matching Open-ACE behavior)
+  if (tokenAge < 0) {
+    logger.app.warn("Token timestamp is in the future");
+    return { valid: false };
+  }
+
+  // Check TTL (token expiration)
   if (tokenAge > TOKEN_TTL_SECONDS) {
     logger.app.warn(
       "Token expired: age={age}s, max={ttl}s",

--- a/backend/middleware/tokenAuth.ts
+++ b/backend/middleware/tokenAuth.ts
@@ -4,8 +4,15 @@
  * When --token-secret is configured, this middleware validates tokens
  * from URL query parameters to ensure requests come from authorized Open-ACE users.
  *
- * Token format: {user_id}:{port}:{random}:{signature}
- * Signature: SHA256({user_id}:{port}:{random}:{secret}).hexdigest()[:16]
+ * Supports two token formats:
+ *
+ * v2 format (recommended): v2:{user_id}:{port}:{timestamp}:{random}:{signature}
+ *   - Includes timestamp for TTL validation (30 minutes default)
+ *   - Signature: SHA256(v2:{user_id}:{port}:{timestamp}:{random}:{secret})[:16]
+ *
+ * v1 format (legacy): {user_id}:{port}:{random}:{signature}
+ *   - No TTL support
+ *   - Signature: SHA256({user_id}:{port}:{random}:{secret})[:16]
  *
  * If --token-secret is not configured, the middleware skips validation,
  * allowing standalone usage without Open-ACE integration.
@@ -35,7 +42,110 @@ async function sha256Hex(data: string): Promise<string> {
 }
 
 /**
+ * Token TTL in seconds (30 minutes, matching Open-ACE default)
+ */
+const TOKEN_TTL_SECONDS = 1800;
+
+/**
+ * Validates a v2 format token with TTL support
+ *
+ * @param parts Token parts (already split by ":")
+ * @param secret Secret key for signature verification
+ * @returns True if token is valid, false otherwise
+ */
+async function validateTokenV2(
+  parts: string[],
+  secret: string
+): Promise<{ valid: boolean; userId?: string }> {
+  // v2 format: v2:{user_id}:{port}:{timestamp}:{random}:{signature}
+  if (parts.length !== 6) {
+    logger.app.warn("Invalid v2 token format: expected 6 parts");
+    return { valid: false };
+  }
+
+  const [version, userId, port, timestamp, randomPart, signature] = parts;
+
+  // Verify version prefix
+  if (version !== "v2") {
+    logger.app.warn("Invalid v2 token: missing v2 prefix");
+    return { valid: false };
+  }
+
+  // Validate timestamp is a number
+  const timestampNum = parseInt(timestamp, 10);
+  if (isNaN(timestampNum)) {
+    logger.app.warn("Invalid v2 token: invalid timestamp");
+    return { valid: false };
+  }
+
+  // Check TTL (token expiration)
+  const currentTimestamp = Math.floor(Date.now() / 1000);
+  const tokenAge = currentTimestamp - timestampNum;
+  if (tokenAge > TOKEN_TTL_SECONDS) {
+    logger.app.warn(
+      "Token expired: age={age}s, max={ttl}s",
+      { age: tokenAge, ttl: TOKEN_TTL_SECONDS }
+    );
+    return { valid: false };
+  }
+
+  // Compute expected signature using same algorithm as Open-ACE
+  // Signature: SHA256(v2:{user_id}:{port}:{timestamp}:{random}:{secret})[:16]
+  const payload = `v2:${userId}:${port}:${timestamp}:${randomPart}`;
+  const hexHash = await sha256Hex(`${payload}:${secret}`);
+  const expectedSignature = hexHash.slice(0, 16);
+
+  if (signature !== expectedSignature) {
+    logger.app.warn("v2 token signature mismatch");
+    return { valid: false };
+  }
+
+  logger.app.debug("v2 token validated successfully for user {userId}", {
+    userId,
+  });
+  return { valid: true, userId };
+}
+
+/**
+ * Validates a v1 format token (legacy, no TTL)
+ *
+ * @param parts Token parts (already split by ":")
+ * @param secret Secret key for signature verification
+ * @returns True if token is valid, false otherwise
+ */
+async function validateTokenV1(
+  parts: string[],
+  secret: string
+): Promise<{ valid: boolean; userId?: string }> {
+  // v1 format: {user_id}:{port}:{random}:{signature}
+  if (parts.length !== 4) {
+    logger.app.warn("Invalid v1 token format: expected 4 parts");
+    return { valid: false };
+  }
+
+  const [userId, port, randomPart, signature] = parts;
+
+  // Compute expected signature using same algorithm as Open-ACE
+  // Signature: SHA256({user_id}:{port}:{random}:{secret})[:16]
+  const dataToSign = `${userId}:${port}:${randomPart}:${secret}`;
+  const hexHash = await sha256Hex(dataToSign);
+  const expectedSignature = hexHash.slice(0, 16);
+
+  if (signature !== expectedSignature) {
+    logger.app.warn("v1 token signature mismatch");
+    return { valid: false };
+  }
+
+  logger.app.debug("v1 token validated successfully for user {userId}", {
+    userId,
+  });
+  return { valid: true, userId };
+}
+
+/**
  * Validates a token against the expected signature
+ *
+ * Supports both v2 (with TTL) and v1 (legacy) formats.
  *
  * @param token Token string to validate
  * @param secret Secret key for signature verification
@@ -44,27 +154,16 @@ async function sha256Hex(data: string): Promise<string> {
 async function validateToken(token: string, secret: string): Promise<boolean> {
   try {
     const parts = token.split(":");
-    if (parts.length !== 4) {
-      logger.app.warn("Invalid token format: expected 4 parts");
-      return false;
+
+    // v2 format: starts with "v2:" and has 6 parts
+    if (token.startsWith("v2:")) {
+      const result = await validateTokenV2(parts, secret);
+      return result.valid;
     }
 
-    const [userId, port, randomPart, signature] = parts;
-
-    // Compute expected signature using same algorithm as Open-ACE
-    const dataToSign = `${userId}:${port}:${randomPart}:${secret}`;
-    const hexHash = await sha256Hex(dataToSign);
-    const expectedSignature = hexHash.slice(0, 16);
-
-    if (signature !== expectedSignature) {
-      logger.app.warn("Token signature mismatch");
-      return false;
-    }
-
-    logger.app.debug("Token validated successfully for user {userId}", {
-      userId,
-    });
-    return true;
+    // v1 format: 4 parts (legacy, no TTL)
+    const result = await validateTokenV1(parts, secret);
+    return result.valid;
   } catch (error) {
     logger.app.error("Token validation error: {error}", { error });
     return false;


### PR DESCRIPTION
## Problem

When users create a new local session and send a message to AI through the WebUI iframe, they encounter the error:
```
JSON.parse: unexpected character at line 1 column 1 of the JSON data
```

This was caused by WebUI rejecting all requests due to token format mismatch:
- Open-ACE generates **v2 format tokens** (6 parts): `v2:{user_id}:{port}:{timestamp}:{random}:{signature}`
- WebUI expected **v1 format tokens** (4 parts): `{user_id}:{port}:{random}:{signature}`

## Solution

Modified `validateToken` function in `backend/middleware/tokenAuth.ts` to support both token formats:

### v2 format (new, recommended)
```
v2:{user_id}:{port}:{timestamp}:{random}:{signature}
```
- Includes timestamp for TTL validation (30 minutes default)
- Signature: `SHA256(v2:{user_id}:{port}:{timestamp}:{random}:{secret})[:16]`

### v1 format (legacy, backward compatible)
```
{user_id}:{port}:{random}:{signature}
```
- No TTL support
- Signature: `SHA256({user_id}:{port}:{random}:{secret})[:16]`

## Changes

1. **`backend/middleware/tokenAuth.ts`**:
   - Added `TOKEN_TTL_SECONDS` constant (1800 seconds = 30 minutes)
   - Added `validateTokenV2()` function for v2 format validation with TTL check
   - Added `validateTokenV1()` function for v1 format validation (backward compatible)
   - Updated `validateToken()` to route to appropriate validator based on `v2:` prefix

2. **`backend/middleware/tokenAuth.test.ts`**:
   - Added `generateTokenV1()` and `generateTokenV2()` helper functions
   - Added comprehensive test coverage for both formats:
     - Valid v1/v2 tokens
     - Expired v2 tokens
     - Token near expiry boundary
     - Invalid signatures
     - Invalid formats

## Testing

All 87 tests pass:
```
Test Files  9 passed (9)
Tests       87 passed (87)
```

## Verification

Deployed and verified on node237:
- WebUI iframe loads correctly
- Messages can be sent to AI
- No more `JSON.parse` errors
- No more `Invalid token format: expected 4 parts` logs

Fixes #209