### PR TITLE
chore: bump version to 0.2.39

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qwen-code-webui",
-  "version": "0.2.38",
+  "version": "0.2.39",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qwen-code-webui",
-      "version": "0.2.38",
+      "version": "0.2.39",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.11",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qwen-code-webui",
-  "version": "0.2.38",
+  "version": "0.2.39",
   "type": "module",
   "description": "Web-based interface for the Qwen Code CLI with streaming chat interface",
   "keywords": [


### PR DESCRIPTION
Bumps qwen-code-webui to **0.2.39** (published to npm).

- Frontend rebuilt (`tsc -b` + `vite build`)
- Backend patch bump: 0.2.38 → 0.2.39
- `prepublishOnly` passed (92 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)