### PR TITLE
chore: bump version to 0.2.40

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qwen-code-webui",
-  "version": "0.2.39",
+  "version": "0.2.40",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qwen-code-webui",
-      "version": "0.2.39",
+      "version": "0.2.40",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.11",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qwen-code-webui",
-  "version": "0.2.39",
+  "version": "0.2.40",
   "type": "module",
   "description": "Web-based interface for the Qwen Code CLI with streaming chat interface",
   "keywords": [


### PR DESCRIPTION
Version bump after npm publish of qwen-code-webui@0.2.40.

- All tests passing
- Frontend built successfully
- Package published to npm: https://www.npmjs.com/package/qwen-code-webui/v/0.2.40

🤖 Generated with [Claude Code](https://claude.com/claude-code)